### PR TITLE
Enforce JDK 11 using Gradle Task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'application'
+    id 'java'
     id 'io.freefair.lombok' version '8.6'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'maven-publish'
@@ -11,6 +12,28 @@ import groovy.json.JsonOutput
 
 apply from: 'gradle/project-config.gradle'
 apply from: 'gradle/plugin-utils.gradle'
+
+// Java toolchain configuration
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(project.ext.TARGET_JDK_VERSION)
+        vendor = JvmVendorSpec."${project.ext.JDK_VENDOR}"
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release = project.ext.TARGET_JDK_VERSION
+    options.compilerArgs.addAll([
+        '-parameters',
+        '-Xlint:none',
+        '-g:none'
+    ])
+
+
+    options.fork = true
+    options.forkOptions.jvmArgs = ['-Dfile.encoding=UTF-8']
+}
 
 configurations {
     microbotRuntime {
@@ -220,4 +243,31 @@ tasks.register("generatePluginsJson") {
 tasks.named("build") {
     finalizedBy("generatePluginsJson")
     finalizedBy("copyPluginDocs")
+}
+
+tasks.register('validateJdkVersion') {
+    group = 'verification'
+    description = 'Validates that the correct JDK version is being used'
+
+    doLast {
+        def currentJdkVersion = System.getProperty('java.version')
+        def expectedVersion = project.ext.TARGET_JDK_VERSION
+
+        // Extract major version from full version string (e.g., "11.0.28" -> 11)
+        def majorVersion = currentJdkVersion.split('\\.')[0] as Integer
+
+        if (majorVersion != expectedVersion) {
+            throw new GradleException(
+                "❌ JDK version mismatch!\n" +
+                "Expected: JDK ${expectedVersion}\n" +
+                "Current:  JDK ${majorVersion} (${currentJdkVersion})\n"
+            )
+        } else {
+            logger.lifecycle("✅ JDK version validated: ${currentJdkVersion}")
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    dependsOn 'validateJdkVersion'
 }

--- a/gradle/plugin-utils.gradle
+++ b/gradle/plugin-utils.gradle
@@ -70,8 +70,6 @@ ext {
                 if (dep.trim()) {
                     logger.info("Adding dependency: ${dep.trim()}")
                     dependencies.add(pluginConfigName, dep.trim())
-                } else {
-                    logger.info("Skipping empty line")
                 }
             }
         }
@@ -82,16 +80,28 @@ ext {
     // Common JAR exclusions
     getCommonJarExclusions = {
         return [
-            'module-info.class',
-            'META-INF/versions/**',
-            'META-INF/INDEX.LIST',
-            'META-INF/*.SF',
-            'META-INF/*.DSA',
-            'META-INF/*.RSA',
-            '**/module-info.class',
-            '**/plugins.json',
-            '**/docs/**',
-            '**/dependencies.txt'
+                'module-info.class',
+                'META-INF/versions/**',
+                'META-INF/INDEX.LIST',
+                'META-INF/*.SF',
+                'META-INF/*.DSA',
+                'META-INF/*.RSA',
+                'META-INF/DEPENDENCIES',
+                'META-INF/LICENSE*',
+                'META-INF/NOTICE*',
+                'META-INF/MANIFEST.MF',
+                'META-INF/native-image/**',
+                'META-INF/services/java.**',
+                'META-INF/services/javax.**',
+                'META-INF/services/sun.**',
+                'META-INF/services/com.sun.**',
+                '**/.gitkeep',
+                '**/.DS_Store',
+                '**/Thumbs.db',
+                '**/module-info.class',
+                '**/plugins.json',
+                '**/docs/**',
+                '**/dependencies.txt',
         ]
     }
 
@@ -212,6 +222,22 @@ ext {
             // Centralized reproducible build settings
             preserveFileTimestamps = false
             reproducibleFileOrder = true
+
+            // Override manifest attributes
+            manifest {
+                attributes(
+                        'Implementation-Title': plugin.name,
+                        'Implementation-Version': version,
+                        'Built-By': 'microbot-build',
+                        'Created-By': 'Gradle Shadow Plugin'
+                )
+
+                attributes.remove('Build-Jdk-Spec')
+                attributes.remove('Built-Jdk')
+                attributes.remove('Build-Jdk')
+                attributes.remove('Build-Date')
+                attributes.remove('Build-Time')
+            }
 
             eachFile { fileCopyDetails ->
                 fileCopyDetails.mode = 0644 // rw-r--r--

--- a/gradle/project-config.gradle
+++ b/gradle/project-config.gradle
@@ -1,6 +1,10 @@
 // gradle/project-config.gradle
 // Centralized configuration for the microbot hub project
 
+// JDK version configuration
+project.ext.TARGET_JDK_VERSION = 11
+project.ext.JDK_VENDOR = 'ADOPTIUM'
+
 // Common project paths
 project.ext.PLUGINS_SOURCE_PATH = 'src/main/java/net/runelite/client/plugins/microbot'
 project.ext.PLUGINS_RESOURCE_PATH = 'src/main/resources/net/runelite/client/plugins/microbot'

--- a/public/docs/plugins.json
+++ b/public/docs/plugins.json
@@ -14,7 +14,7 @@
         "author": "Bolado",
         "supportUrl": "https://github.com/chsami/microbot",
         "iconUrl": "https://oldschool.runescape.wiki/images/Rogue_mask_chathead.png?0b359",
-        "sha256": "af095746fc3ddca04ea27d4297d555a5e702513c9239ac98af893bf9ae757f7a",
+        "sha256": "f4b373dd23935efb7adfa412e7bba2f18efcb211c2251b5ec9141260abea06c8",
         "url": "https://nexus.microbot.cloud/repository/microbot-plugins/net/runelite/client/plugins/microbot/anonymousplugin/1.0.1/anonymousplugin-1.0.1.jar"
     },
     {
@@ -35,7 +35,7 @@
         "author": "Hal",
         "supportUrl": "https://github.com/chsami/microbot",
         "iconUrl": "https://oldschool.runescape.wiki/images/Jug_of_wine.png",
-        "sha256": "d7569f334e0b0551452cd5b2e35e04c39fa87f8cdaf52c2c57510cfa8fea8187",
+        "sha256": "17298af44b02911b40e0ea4a16c8ce775807df51effd4c222f4f57412a941158",
         "url": "https://nexus.microbot.cloud/repository/microbot-plugins/net/runelite/client/plugins/microbot/blessedwineplugin/1.0.1/blessedwineplugin-1.0.1.jar"
     },
     {
@@ -53,7 +53,7 @@
         "author": "g-mason0",
         "supportUrl": "https://github.com/chsami/microbot",
         "iconUrl": "",
-        "sha256": "c85b1eab9766ff625f085a2f4fd15b809f73464a58d3bd3903ff52dc857d8e46",
+        "sha256": "e021222c0e10e1c65bf1e33f4a96a50a3d8553bb1482dc351e9b3933011c73ea",
         "url": "https://nexus.microbot.cloud/repository/microbot-plugins/net/runelite/client/plugins/microbot/ouraniaplugin/1.4.1/ouraniaplugin-1.4.1.jar"
     },
     {
@@ -70,7 +70,7 @@
         "author": "Mocrosoft",
         "supportUrl": "https://github.com/chsami/microbot",
         "iconUrl": "https://oldschool.runescape.wiki/images/Pest_Control.png?ed7bb",
-        "sha256": "8682b055582fa58010e316264cb1618842dd672e6e4becbf9dc4693c04b60f21",
+        "sha256": "9816a98eca006515dbf62826cb777e1ef0e252ff73804320c94cc1df768248cd",
         "url": "https://nexus.microbot.cloud/repository/microbot-plugins/net/runelite/client/plugins/microbot/pestcontrolplugin/2.2.5/pestcontrolplugin-2.2.5.jar"
     },
     {
@@ -88,7 +88,7 @@
         "author": "g-mason0",
         "supportUrl": "https://github.com/chsami/microbot",
         "iconUrl": "",
-        "sha256": "8334554b8997cd8ae586a4ae25710e8feaba6225302374279f2581ba971353a6",
+        "sha256": "1d7672daa94f68acf42dd5aeef21a2e7f681245cff7dc90d83083e526947b69b",
         "url": "https://nexus.microbot.cloud/repository/microbot-plugins/net/runelite/client/plugins/microbot/shootingstarplugin/1.4.1/shootingstarplugin-1.4.1.jar"
     }
 ]


### PR DESCRIPTION
I have found that when compiling against different JDK versions (11 vs 17) this causes the SHA256 of the jar file to be different.

This is presumed to be byte code differences between JDK versions.

This also removes several generic manifest properties I have found that should further generalize jar files so hashes can match.