### PR TITLE
Remove unnecessary references

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/autobankstander/AutoBankStanderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autobankstander/AutoBankStanderPlugin.java
@@ -20,10 +20,10 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 
 @PluginDescriptor(
-    name = PluginConstants.BGA + "Auto Bankstander",
+    name = PluginConstants.DEFAULT_PREFIX + "Bank Stander",
     description = "AIO bank standing plugin for various processing activities",
     tags = {"magic", "skilling", "processing"},
-    authors = {"bga"},
+    authors = {"Unknown"},
     version = AutoBankStanderPlugin.version,
     minClientVersion = "1.9.8",
     iconUrl = "https://chsami.github.io/Microbot-Hub/AutoBankStanderPlugin/assets/icon.png",
@@ -33,7 +33,7 @@ import java.awt.image.BufferedImage;
 )
 @Slf4j
 public class AutoBankStanderPlugin extends Plugin {
-    static final String version = "1.0.0";
+    static final String version = "1.0.1";
     
     @Inject
     private AutoBankStanderConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/autochompykiller/AutoChompyKillerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autochompykiller/AutoChompyKillerPlugin.java
@@ -16,10 +16,10 @@ import javax.inject.Inject;
 import java.awt.*;
 
 @PluginDescriptor(
-        name = PluginConstants.BGA + "Auto Chompy Killer",
+        name = PluginConstants.DEFAULT_PREFIX + "Chompy Killer",
         description = "Automated chompy bird hunting plugin...",
         tags = {"chompy", "combat"},
-        authors = {"bga"},
+        authors = {"Unknown"},
         version = AutoChompyKillerPlugin.version,
         minClientVersion = "1.9.8",
         iconUrl = "https://chsami.github.io/Microbot-Hub/AutoChompyKillerPlugin/assets/icon.png",
@@ -29,7 +29,7 @@ import java.awt.*;
 )
 @Slf4j
 public class AutoChompyKillerPlugin extends Plugin {
-    static final String version = "1.0.0";
+    static final String version = "1.0.1";
     @Inject
     private AutoChompyKillerConfig config;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/autoessencemining/AutoEssenceMiningPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoessencemining/AutoEssenceMiningPlugin.java
@@ -12,10 +12,10 @@ import javax.inject.Inject;
 import java.awt.*;
 
 @PluginDescriptor(
-        name = PluginConstants.BGA + "Auto Essence Mining",
+        name = PluginConstants.DEFAULT_PREFIX + "Essence Mining",
         description = "Mines Rune/Pure Essence...",
         tags = {"mining", "essence", "skilling"},
-        authors = {"bga"},
+        authors = {"Unknown"},
         version = AutoEssenceMiningPlugin.version,
         minClientVersion = "1.9.8",
         iconUrl = "https://chsami.github.io/Microbot-Hub/AutoEssenceMiningPlugin/assets/icon.png",
@@ -25,7 +25,7 @@ import java.awt.*;
 )
 @Slf4j
 public class AutoEssenceMiningPlugin extends Plugin {
-    static final String version = "1.0.0";
+    static final String version = "1.0.1";
     @Inject
     private AutoEssenceMiningConfig config;
     

--- a/src/main/java/net/runelite/client/plugins/microbot/autofishing/AutoFishingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autofishing/AutoFishingPlugin.java
@@ -17,10 +17,10 @@ import javax.inject.Inject;
 import java.awt.*;
 
 @PluginDescriptor(
-        name = PluginConstants.BGA + "Auto Fishing",
+        name = PluginConstants.DEFAULT_PREFIX + "Fishing",
         description = "Automated fishing plugin with banking support",
         tags = {"fishing", "skilling"},
-        authors = {"bga"},
+        authors = {"Unknown"},
         version = AutoFishingPlugin.version,
         minClientVersion = "1.9.8",
         iconUrl = "https://chsami.github.io/Microbot-Hub/AutoFishingPlugin/assets/icon.png",
@@ -30,7 +30,7 @@ import java.awt.*;
 )
 @Slf4j
 public class AutoFishingPlugin extends Plugin {
-    static final String version = "1.0.0";
+    static final String version = "1.0.1";
     @Inject
     private AutoFishingConfig config;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/autoherbiboar/AutoHerbiboarPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoherbiboar/AutoHerbiboarPlugin.java
@@ -25,10 +25,10 @@ import java.awt.*;
 import java.util.Set;
 
 @PluginDescriptor(
-        name = PluginConstants.BGA + "Auto Herbiboar",
+        name = PluginConstants.DEFAULT_PREFIX + "Herbiboar",
         description = "Automaticalli hunts herbiboars with trail tracking and banking support",
         tags = {"skilling", "hunter"},
-        authors = {"bga"},
+        authors = {"Unknown"},
         version = AutoHerbiboarPlugin.version,
         minClientVersion = "1.9.8",
         iconUrl = "https://chsami.github.io/Microbot-Hub/AutoHerbiboarPlugin/assets/icon.png",
@@ -38,7 +38,7 @@ import java.util.Set;
 )
 @Slf4j
 public class AutoHerbiboarPlugin extends Plugin {
-    static final String version = "1.1.0";
+    static final String version = "1.1.1";
     
     private static final Set<Integer> START_OBJECT_IDS = ImmutableSet.of(
         ObjectID.HUNTING_TRAIL_SPAWN_FOSSIL1,


### PR DESCRIPTION
Due hub sorting plugins alphabetically at this current date, it can be used by some as a way of getting exposure before executing exit scam practices, this can be avoided by sorting by last update date, number of downloads, etc, but as of this PR goes, it was made so we remove the type of thing which (hopefully) are not welcome on Microbot project in general.

## Github Copilot Summary

This pull request updates several microbot plugins to standardize their naming conventions, update author information, and increment their version numbers. The changes help improve consistency and clarity across the plugins.

**Naming and author updates:**

* Changed the `name` field in the `@PluginDescriptor` annotation of each plugin to use `PluginConstants.DEFAULT_PREFIX` instead of `PluginConstants.BGA`, and updated the displayed plugin name accordingly [[1]](diffhunk://#diff-d533dcd1bd56c1526da1dcbe6ae53dc4c9e2a04054c8a59702ed2e949c916bd1L23-R26) [[2]](diffhunk://#diff-5c31712d3b8af2b6574eb13044bff47ee675f44fb2037486e0e406e7ff12390cL19-R22) [[3]](diffhunk://#diff-c4dabbab48d36102662c859cb9f48c4b2d27e805c5382d28cbbbd37a16a409d1L15-R18) [[4]](diffhunk://#diff-502ebb9e4a7942a9375bbbbf0f02ed2574fc56878fd07460dd2a1a9d3c217e7bL20-R23) [[5]](diffhunk://#diff-e5216799d0d7139be8b44a23ef0210c2fd81238e9af841ea8f447fcb08efadacL28-R31).
* Changed the `authors` field in each plugin's `@PluginDescriptor` annotation from `{"bga"}` to `{"Unknown"}` [[1]](diffhunk://#diff-d533dcd1bd56c1526da1dcbe6ae53dc4c9e2a04054c8a59702ed2e949c916bd1L23-R26) [[2]](diffhunk://#diff-5c31712d3b8af2b6574eb13044bff47ee675f44fb2037486e0e406e7ff12390cL19-R22) [[3]](diffhunk://#diff-c4dabbab48d36102662c859cb9f48c4b2d27e805c5382d28cbbbd37a16a409d1L15-R18) [[4]](diffhunk://#diff-502ebb9e4a7942a9375bbbbf0f02ed2574fc56878fd07460dd2a1a9d3c217e7bL20-R23) [[5]](diffhunk://#diff-e5216799d0d7139be8b44a23ef0210c2fd81238e9af841ea8f447fcb08efadacL28-R31).

**Version bumps:**

* Incremented the `version` field in each plugin class to the next patch version (e.g., `1.0.0` to `1.0.1`, or `1.1.0` to `1.1.1`) to reflect these updates [[1]](diffhunk://#diff-d533dcd1bd56c1526da1dcbe6ae53dc4c9e2a04054c8a59702ed2e949c916bd1L36-R36) [[2]](diffhunk://#diff-5c31712d3b8af2b6574eb13044bff47ee675f44fb2037486e0e406e7ff12390cL32-R32) [[3]](diffhunk://#diff-c4dabbab48d36102662c859cb9f48c4b2d27e805c5382d28cbbbd37a16a409d1L28-R28) [[4]](diffhunk://#diff-502ebb9e4a7942a9375bbbbf0f02ed2574fc56878fd07460dd2a1a9d3c217e7bL33-R33) [[5]](diffhunk://#diff-e5216799d0d7139be8b44a23ef0210c2fd81238e9af841ea8f447fcb08efadacL41-R41).