### PR TITLE
Herbiboar - Configurable options for resolving stuck states and setting minimum interaction distances

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
@@ -53,6 +53,31 @@ public interface HerbiboarConfig extends Config {
     default boolean useMagicSecateurs() {
         return false;
     }
+
+    @ConfigItem(
+            keyName = "resetIfStuck",
+            name = "Reset if stuck?",
+            description = "Fallback behavior to try getting unstuck if stuck for more than 1m in the same place.",
+            section = OPTIONALS_SECTION,
+            position = 2
+    )
+    default boolean resetIfStuck() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "interactionDistance",
+            name = "Interaction distance",
+            description = "Minimum distance to start interacting with objects like tunnel, rock, etc. (lower = will move closer to object before clicking on it)",
+            section = OPTIONALS_SECTION,
+            position = 3
+    )
+    @Range (min = 1, max = 50)
+    default int interactionDistance() {
+        return 25;
+    }
+
+
     @ConfigSection(
         name = "Run energy management",
         description = "Run energy management",

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
@@ -42,7 +42,7 @@ import java.util.Deque;
 )
 
 public class HerbiboarPlugin extends Plugin {
-    static final String version = "1.2.1";
+    static final String version = "1.2.2";
 
     @Getter
     @Setter

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
@@ -21,12 +21,14 @@ import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.security.Login;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import org.slf4j.event.Level;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -42,7 +44,15 @@ public class HerbiboarScript extends Script {
     private boolean attackedTunnel;
     private static final WorldPoint BANK_LOCATION = new WorldPoint(3766, 3899, 0);
     private static final WorldPoint RETURN_LOCATION = new WorldPoint(3703, 3878, 0);
-    
+
+    @Getter
+    @Setter
+    private Instant lastMove = Instant.now();
+
+    @Getter
+    @Setter
+    private WorldPoint lastLocation = null;
+
     public static String version = HerbiboarPlugin.version;
 
     public void incrementHerbisCaught() {
@@ -430,7 +440,24 @@ public class HerbiboarScript extends Script {
                 if (!super.run()) return;
                 if (BreakHandlerScript.isMicroBreakActive()) return;
                 if (BreakHandlerScript.isBreakActive()) return;
-                
+
+
+                if (config.resetIfStuck() && state != HerbiboarState.RESET && state != HerbiboarState.INITIALIZING
+                        && state != HerbiboarState.CHECK_AUTO_RETALIATE && state != HerbiboarState.BANK) {
+                    // Keep checking for time of last movement, if more than 1 minute, set state to RESET
+                    if (getLastLocation() != null && !getLastLocation().equals(Rs2Player.getWorldLocation())) {
+                        setLastMove(Instant.now());
+                        setLastLocation(Rs2Player.getWorldLocation());
+                    } else if (getLastMove() != null && Instant.now().isAfter(getLastMove().plusSeconds(60))) {
+                        Microbot.log(Level.INFO,"Player has not moved for over 1 minute, resetting script state");
+                        setState(HerbiboarState.RESET);
+                        setLastMove(Instant.now());
+                    } else if (getLastMove() == null) {
+                        setLastMove(Instant.now());
+                        setLastLocation(Rs2Player.getWorldLocation());
+                    }
+                }
+
                 if (!Rs2Player.isMoving() && !Rs2Player.isInteracting()) {
                     Microbot.log(Level.INFO,"Checking inventory and run energy");
                     dropConfiguredItems(config);
@@ -454,6 +481,40 @@ public class HerbiboarScript extends Script {
                 }
                 
                 switch (state) {
+                    case RESET:
+                        /**
+                         * Here we reset the script state in case we get stuck somewhere for 1 minute.
+                         * This will walk us back to the starting rock and re-initialize the script.
+                         * If currently the warning for reset is not disabled, it will disable it.
+                         * After resetting, we check if there is a trail and then decide to go to START or TRAIL state.
+                         */
+                        Microbot.status = "Resetting...";
+                        Microbot.log(Level.INFO,"Resetting...");
+                        attackedTunnel = false;
+                        setLastMove(Instant.now());
+                        setLastLocation(null);
+                        WorldPoint resetRock = new WorldPoint(3704, 3810, 0);
+                        boolean reached = Rs2Walker.walkTo(resetRock);
+                        if (!reached) {
+                            Microbot.log(Level.INFO, "Failed to reach reset rock, stopping script");
+                            Rs2Player.logout();
+                            Microbot.showMessage("Failed to reach reset rock, stopping script");
+                            Microbot.stopPlugin(herbiboarPlugin.getClass());
+                            return;
+                        }
+                        if (Microbot.getVarbitValue(VarbitID.FOSSIL_HERBIBOAR_ALREADY_CAUGHT_IGNORE_WARNING) != 1) {
+                            Rs2GameObject.interact(resetRock, "Toggle warning");
+                            sleepUntil(() -> Microbot.getVarbitValue(VarbitID.FOSSIL_HERBIBOAR_ALREADY_CAUGHT_IGNORE_WARNING) == 1, 5000);
+                        }
+                        Rs2GameObject.interact(resetRock, "Inspect");
+                        Rs2Player.waitForAnimation();
+                        sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isInteracting() && !Rs2Player.isMoving(), 5000);
+                        if (herbiboarPlugin.getCurrentGroup() == null) {
+                            setState(HerbiboarState.START);
+                        } else {
+                            setState(HerbiboarState.TRAIL);
+                        }
+                        break;
                     case INITIALIZING:
                         Microbot.status = "Starting...";
                         Microbot.log(Level.INFO,"Initializing...");
@@ -482,7 +543,7 @@ public class HerbiboarScript extends Script {
                             if (start != null) {
                                 WorldPoint loc = start.getWorldLocation();
                                 LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), loc);
-                                if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(loc) >= 50) {
+                                if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(loc) >= config.interactionDistance()) {
                                     Rs2Walker.walkTo(loc);
                                 } else {
                                     Rs2Camera.turnTo(localPoint);
@@ -508,7 +569,7 @@ public class HerbiboarScript extends Script {
                             WorldPoint loc = path.get(path.size() - 1).getLocation();
                             LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), loc);
                             TileObject object = herbiboarPlugin.getTrailObjects().get(loc);
-                            if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(loc) >= 50){
+                            if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(loc) >= config.interactionDistance()){
                                 Rs2Walker.walkTo(loc);
                             } else {
                                 Rs2Camera.turnTo(localPoint);
@@ -528,7 +589,7 @@ public class HerbiboarScript extends Script {
                                 WorldPoint finishLoc = herbiboarPlugin.getEndLocations().get(finishId - 1);
                                 LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), finishLoc);
                                 TileObject tunnel = herbiboarPlugin.getTunnels().get(finishLoc);
-                                if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(finishLoc) >= 50) {
+                                if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(finishLoc) >= config.interactionDistance()) {
                                     Rs2Walker.walkTo(finishLoc);
                                 } else {
                                     Rs2Camera.turnTo(localPoint);
@@ -561,7 +622,7 @@ public class HerbiboarScript extends Script {
                                 if (start != null) {
                                     WorldPoint startLoc = start.getWorldLocation();
                                     LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), startLoc);
-                                    if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(startLoc) >= 50) {
+                                    if (localPoint == null || Rs2Player.getWorldLocation().distanceTo(startLoc) >= config.interactionDistance()) {
                                         Rs2Walker.walkTo(startLoc);
                                     } else {
                                         Rs2Camera.turnTo(localPoint);

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
@@ -442,20 +442,21 @@ public class HerbiboarScript extends Script {
                 if (BreakHandlerScript.isBreakActive()) return;
 
 
-                if (config.resetIfStuck() && state != HerbiboarState.RESET && state != HerbiboarState.INITIALIZING
+                // Keep checking for time of last movement, if more than 1 minute, set state to RESET
+                if (getLastLocation() != null && !getLastLocation().equals(Rs2Player.getWorldLocation())) {
+                    setLastMove(Instant.now());
+                    setLastLocation(Rs2Player.getWorldLocation());
+                } else if (config.resetIfStuck() && getLastMove() != null
+                        && Instant.now().isAfter(getLastMove().plusSeconds(60))
+                        && state != HerbiboarState.RESET && state != HerbiboarState.INITIALIZING
                         && state != HerbiboarState.CHECK_AUTO_RETALIATE && state != HerbiboarState.BANK) {
-                    // Keep checking for time of last movement, if more than 1 minute, set state to RESET
-                    if (getLastLocation() != null && !getLastLocation().equals(Rs2Player.getWorldLocation())) {
-                        setLastMove(Instant.now());
-                        setLastLocation(Rs2Player.getWorldLocation());
-                    } else if (getLastMove() != null && Instant.now().isAfter(getLastMove().plusSeconds(60))) {
-                        Microbot.log(Level.INFO,"Player has not moved for over 1 minute, resetting script state");
-                        setState(HerbiboarState.RESET);
-                        setLastMove(Instant.now());
-                    } else if (getLastMove() == null) {
-                        setLastMove(Instant.now());
-                        setLastLocation(Rs2Player.getWorldLocation());
-                    }
+                    Microbot.log(Level.INFO,"Player has not moved for over 1 minute, resetting script state");
+                    setLastMove(Instant.now());
+                    setLastLocation(null);
+                    setState(HerbiboarState.RESET);
+                } else if (getLastMove() == null) {
+                    setLastMove(Instant.now());
+                    setLastLocation(Rs2Player.getWorldLocation());
                 }
 
                 if (!Rs2Player.isMoving() && !Rs2Player.isInteracting()) {

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarState.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarState.java
@@ -8,7 +8,8 @@ public enum HerbiboarState {
     TUNNEL("Checking tunnel"),
     HARVEST("Harvesting"),
     BANK("Banking"),
-    RETURN_FROM_ISLAND("Returning from island");
+    RETURN_FROM_ISLAND("Returning from island"),
+    RESET("Resetting");
 
     private final String description;
 


### PR DESCRIPTION
According to user reports, the character tends to get stuck approximately once every hour for unknown reasons (due to improper bug reports). This PR introduces an optional state to reset the plugin's state and tracking activity. Additionally, a configuration setting has been added, allowing users to define the minimum distance from an object at which the character will attempt to interact with it.

## Github Copilot Summary

This pull request adds new configuration options and logic to improve the robustness of the Herbiboar script, specifically targeting scenarios where the player might get stuck. The main enhancements include a "reset if stuck" feature, a configurable interaction distance, and the associated logic to reset the script state and recover from being stuck.

**Stuck Detection and Recovery:**

* Added a new `resetIfStuck` config option in `HerbiboarConfig` to enable automatic script reset if the player hasn't moved for over 1 minute, along with supporting logic in `HerbiboarScript` to track player movement and trigger a reset when necessary. [[1]](diffhunk://#diff-06442776d6a0e1484572885a721b138a8c532736d2260d06ffac03d8716ae63cR56-R80) [[2]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cR48-R55) [[3]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cR444-R461) [[4]](diffhunk://#diff-b5deab71913498f38a6ac28ea8cc62d82ebb19a634c568b54420542aa6586031L11-R12)
* Implemented a new `RESET` state in `HerbiboarState` and corresponding state handling in `HerbiboarScript` to walk the player back to a safe location and reinitialize the script if stuck. [[1]](diffhunk://#diff-b5deab71913498f38a6ac28ea8cc62d82ebb19a634c568b54420542aa6586031L11-R12) [[2]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cR485-R518)

**Configurable Interaction Distance:**

* Added a new `interactionDistance` config option, allowing the minimum distance for interacting with objects to be customized. Updated all relevant distance checks in `HerbiboarScript` to use this value instead of a hardcoded distance. [[1]](diffhunk://#diff-06442776d6a0e1484572885a721b138a8c532736d2260d06ffac03d8716ae63cR56-R80) [[2]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cL485-R547) [[3]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cL511-R573) [[4]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cL531-R593) [[5]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cL564-R626)

**Minor Code Improvements:**

* Added missing imports and improved time tracking for player movement using `Instant`. [[1]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cR24-R31) [[2]](diffhunk://#diff-e271120054deba30fc088ff696cf8b3ec3dcaa3633741a6d81d122d5137b146cR48-R55)