### PR TITLE
feat(CannonballSmelter): Add furnace location config, fix double ammo mould logic

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/cannonballsmelter/CannonballSmelterConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cannonballsmelter/CannonballSmelterConfig.java
@@ -3,12 +3,23 @@ package net.runelite.client.plugins.microbot.cannonballsmelter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigInformation;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.plugins.microbot.cannonballsmelter.enums.Furnace;
 
 @ConfigGroup("CannonballSmelter")
 @ConfigInformation ("<div style='background-color:black;color:yellow;padding:20px;'>" +
                     "<center><h2>Instructions</h2>" +
-                    " <p>Start script in Edgeville bank <br /><br />" +
-                    " <b style='color:red;'>MUST</b> have Ammo mould in inventory <br />" +
-                    " and Steel bars in bank</center></div>")
+                    " <p>Start the script at the bank next to your selected Furnace <br /><br />" +
+                    " <b style='color:red;'>MUST</b> have Ammo mould or Double ammo mould <br />" +
+                    " and Steel bars in the bank</center></div>")
 public interface CannonballSmelterConfig extends Config {
+    @ConfigItem(
+            keyName = "furnace",
+            name = "Furnace",
+            description = "Which furnace location to smelt the cannonballs at",
+            position = 1
+    )
+    default Furnace getFurnace() {
+        return Furnace.EDGEVILLE;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/cannonballsmelter/CannonballSmelterPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cannonballsmelter/CannonballSmelterPlugin.java
@@ -14,7 +14,7 @@ import java.awt.*;
 @PluginDescriptor(
         name = PluginConstants.GIRDY + "Cannonball Smelter",
         description = "Makes cannonballs",
-        authors = { "Girdy" },
+        authors = { "Girdy", "Engin" },
         version = CannonballSmelterPlugin.version,
         minClientVersion = "1.9.9.1",
         tags = { "smithing", "girdy", "skilling" },
@@ -24,7 +24,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class CannonballSmelterPlugin extends Plugin {
-        public static final String version = "1.0.2";
+        public static final String version = "1.1.0";
 
         @Inject
         private CannonballSmelterConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/cannonballsmelter/enums/Furnace.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cannonballsmelter/enums/Furnace.java
@@ -1,0 +1,15 @@
+package net.runelite.client.plugins.microbot.cannonballsmelter.enums;
+
+import net.runelite.api.gameval.ObjectID;
+
+public enum Furnace {
+    EDGEVILLE(ObjectID.VARROCK_DIARY_FURNACE),
+    SHILO_VILLAGE(ObjectID.ZQFURNACE_LIT),
+    PRIFDDINAS(ObjectID.PRIF_FURNACE);
+
+    public final int furnaceID;
+
+    private Furnace(int furnaceID) {
+        this.furnaceID = furnaceID;
+    }
+}

--- a/src/main/resources/net/runelite/client/plugins/microbot/cannonballsmelter/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/cannonballsmelter/docs/README.md
@@ -8,20 +8,22 @@ The **Cannonball Smelter Plugin** provides an automated way to smelt cannonballs
 
 ## Feature Overview
 
-- X
+| Feature     | Description                                        |
+|-------------|----------------------------------------------------|
+| **Furnace** | Which furnace location to smelt the cannonballs at |
 
 ---
 
 ## Requirements
 - Microbot RuneLite client
-- Required Ingredients to smelt Cannonballs (Ammo mould, Steel bars)
+- Required Ingredients to smelt Cannonballs (Ammo mould or Double ammo mould and Steel bars)
 - Plugin enabled in the Microbot plugin list
 
 ---
 
 ## How It Works
-1. Make sure you have the Ingredients to smelt Cannonballs (Ammo mould, Steel bars).
-2. Go to the Edgeville Furnance.
+1. Make sure you have the Ingredients to smelt Cannonballs (Ammo mould or Double ammo mould and Steel bars) in your bank.
+2. Go to the bank next to your selected Furnance.
 3. Activate the plugin.
 4. Enjoy! :)
 


### PR DESCRIPTION
This PR adds different furnace locations to the Cannonball Smelter Plugin, resulting in configuration options that provide more efficient cannonball smelting:
- Edgeville (Default)
- Shilo Village
- Prifddinas

Relevant Information from the OSRS Wiki:

> Depending on which furnace the player chooses, one can produce between 2,160 and 2,400 cannonballs in an hour.

> [Edgeville](https://oldschool.runescape.wiki/w/Edgeville) [furnace](https://oldschool.runescape.wiki/w/Furnace) is the closest furnace to a [bank](https://oldschool.runescape.wiki/w/Bank) which has no requirements. The [Shilo Village](https://oldschool.runescape.wiki/w/Shilo_Village_(location)) furnace is the closest to a bank but players must pay 20 coins to use it, free with the [elite Karamja Diary](https://oldschool.runescape.wiki/w/Elite_Karamja_Diary). The [Prifddinas](https://oldschool.runescape.wiki/w/Prifddinas) [furnace](https://oldschool.runescape.wiki/w/Furnace) is the second closest to a bank but this requires the completion of [Song of the Elves](https://oldschool.runescape.wiki/w/Song_of_the_Elves).

It also fixes a small logic issue with the double ammo mould, which lead to the normal ammo mould being withdrawn instead of the double ammo mould, resulting in producing less cannonballs per hour.
