### PR TITLE
Disable reset if stuck option in Herbiboar config

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
@@ -59,10 +59,11 @@ public interface HerbiboarConfig extends Config {
             name = "Reset if stuck?",
             description = "Fallback behavior to try getting unstuck if stuck for more than 1m in the same place.",
             section = OPTIONALS_SECTION,
-            position = 2
+            position = 2,
+            hidden = true
     )
     default boolean resetIfStuck() {
-        return true;
+        return false;
     }
 
     @ConfigItem(

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
@@ -42,7 +42,7 @@ import java.util.Deque;
 )
 
 public class HerbiboarPlugin extends Plugin {
-    static final String version = "1.2.2";
+    static final String version = "1.2.3";
 
     @Getter
     @Setter


### PR DESCRIPTION
User reported the helper not helping, so we disable by default now and set it to hidden till more debugging can be done.

## Github Copilot Summary

This pull request makes a small update to the herbiboar plugin, mainly hiding the "Reset if stuck?" configuration option from the UI and changing its default value. The plugin version is also incremented to reflect these changes.

- Configuration changes:
  * The `resetIfStuck` option in `HerbiboarConfig.java` is now hidden from the configuration UI and its default value is set to `false` instead of `true`.

- Version update:
  * The plugin version in `HerbiboarPlugin.java` is incremented from "1.2.2" to "1.2.3".