### PR TITLE
Herbiboar: Fix for catching stuck state

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
@@ -59,8 +59,7 @@ public interface HerbiboarConfig extends Config {
             name = "Reset if stuck?",
             description = "Fallback behavior to try getting unstuck if stuck for more than 1m in the same place.",
             section = OPTIONALS_SECTION,
-            position = 2,
-            hidden = true
+            position = 2
     )
     default boolean resetIfStuck() {
         return false;

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
@@ -42,7 +42,7 @@ import java.util.Deque;
 )
 
 public class HerbiboarPlugin extends Plugin {
-    static final String version = "1.2.3";
+    static final String version = "1.2.4";
 
     @Getter
     @Setter

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
@@ -454,7 +454,7 @@ public class HerbiboarScript extends Script {
                     setLastMove(Instant.now());
                     setLastLocation(null);
                     setState(HerbiboarState.RESET);
-                } else if (getLastMove() == null) {
+                } else if (getLastMove() == null || getLastLocation() == null) {
                     setLastMove(Instant.now());
                     setLastLocation(Rs2Player.getWorldLocation());
                 }


### PR DESCRIPTION
Credits for HelloHello1 for debugging and finding the fix:

The initial goal of the last if block was to check if lastLocation was null and not lastMove time.

## Github Copilot Summary

This pull request makes two targeted improvements to the herbiboar plugin's stuck detection and configuration. It updates the fallback behavior for handling stuck states and refines the configuration UI by adjusting property visibility.

Improvements to stuck detection logic:
* Updated the stuck detection logic in `HerbiboarScript.java` to also reset the last move and location if either is null, making the script more robust against edge cases where location data might be missing.

Configuration UI adjustments:
* Modified the `resetIfStuck` configuration option in `HerbiboarConfig.java` to remove the `hidden = true` property, ensuring this option is now visible in the plugin configuration UI.- Remove hidden attribute from resetIfStuck option
- Update condition to check both lastMove and lastLocation