### PR TITLE
Herbiboar: Fix for catching stuck state (#105)

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarConfig.java
@@ -59,8 +59,7 @@ public interface HerbiboarConfig extends Config {
             name = "Reset if stuck?",
             description = "Fallback behavior to try getting unstuck if stuck for more than 1m in the same place.",
             section = OPTIONALS_SECTION,
-            position = 2,
-            hidden = true
+            position = 2
     )
     default boolean resetIfStuck() {
         return false;

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarPlugin.java
@@ -42,7 +42,7 @@ import java.util.Deque;
 )
 
 public class HerbiboarPlugin extends Plugin {
-    static final String version = "1.2.3";
+    static final String version = "1.2.4";
 
     @Getter
     @Setter

--- a/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/herbiboar/HerbiboarScript.java
@@ -454,7 +454,7 @@ public class HerbiboarScript extends Script {
                     setLastMove(Instant.now());
                     setLastLocation(null);
                     setState(HerbiboarState.RESET);
-                } else if (getLastMove() == null) {
+                } else if (getLastMove() == null || getLastLocation() == null) {
                     setLastMove(Instant.now());
                     setLastLocation(Rs2Player.getWorldLocation());
                 }


### PR DESCRIPTION
* fix: correct reset behavior for stuck state

- Remove hidden attribute from resetIfStuck option
- Update condition to check both lastMove and lastLocation

* chore: update version to 1.2.4

- Bump version number from 1.2.3 to 1.2.4