### PR TITLE
Disable Attack Healers option on config and set default to false

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/jad/JadConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/jad/JadConfig.java
@@ -6,7 +6,7 @@ import net.runelite.client.config.ConfigInformation;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(JadConfig.configGroup)
-@ConfigInformation("This plugin will pray switch jad attacks and attack healers. Supports up to 3 jads")
+@ConfigInformation("This plugin will pray switch jad attacks. Supports up to 3 jads")
 public interface JadConfig extends Config {
     String configGroup = "micro-jadhelper";
     String shouldAttackHealers = "shouldAttackHealers";
@@ -15,9 +15,10 @@ public interface JadConfig extends Config {
             keyName = shouldAttackHealers,
             name = "Attack Healers",
             description = "Enable this setting to handle jad healers",
-            position = 0
+            position = 0,
+            hidden = true
     )
     default boolean shouldAttackHealers() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/jad/JadPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/jad/JadPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
 )
 @Slf4j
 public class JadPlugin extends Plugin {
-    static final String version = "1.0.6";
+    static final String version = "1.0.7";
 
     @Inject
     private JadConfig config;


### PR DESCRIPTION
User would only be able to know that the feature was broken if testing on speedrun worlds or failing on fight cave, so it's better to hide the option and set the default value to false to avoid unnecessary frustration 😄.

## Github Copilot Summary

This pull request updates the Jad plugin to disable the "Attack Healers" feature by default and hides the related configuration option from the UI. It also updates the plugin version to reflect these changes. The main focus is on simplifying the plugin's configuration and clarifying its description.

**Configuration and Feature Changes:**

* The "Attack Healers" configuration option in `JadConfig` is now hidden from the user interface and its default value is set to `false` instead of `true`.
* The configuration description has been updated to remove mention of attacking healers, clarifying that the plugin only pray switches Jad attacks.

**Versioning:**

* The plugin version has been incremented from `1.0.6` to `1.0.7` in `JadPlugin.java`.