### PR TITLE
fix(BarrowsPlugin): Add LockCondition Message to fix gradle build

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barrows/BarrowsPlugin.java
@@ -37,7 +37,7 @@ import java.awt.*;
 )
 @Slf4j
 public class BarrowsPlugin extends Plugin implements SchedulablePlugin {
-    public static final String version = "2.0.0";
+    public static final String version = "2.0.1";
 
     @Inject
     private BarrowsConfig config;
@@ -54,7 +54,7 @@ public class BarrowsPlugin extends Plugin implements SchedulablePlugin {
     @Inject
     BarrowsScript barrowsScript;
     LogicalCondition stopCondition = new AndCondition();
-    LockCondition lockCondition = new LockCondition();
+    LockCondition lockCondition = new LockCondition("Locked during the Barrows minigame");
 
 
     @Override


### PR DESCRIPTION
The lack of a string inside LockCondition was causing the gradle build to fail on the CI GH action.

## Github Copilot Summary

This pull request includes minor updates to the `BarrowsPlugin` for clarity and version tracking. The changes are straightforward and focus on improving maintainability and code readability.

Versioning:

* Updated the `version` field in `BarrowsPlugin` from "2.0.0" to "2.0.1" to reflect the new release.

Code clarity:

* Added a descriptive string to the `LockCondition` instantiation to clarify its purpose during the Barrows minigame.