### PR TITLE
fix(agility-pyramid): fix second level Gap obstacle area

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/agility/courses/PyramidObstacleData.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/agility/courses/PyramidObstacleData.java
@@ -74,7 +74,7 @@ public class PyramidObstacleData {
         area(3364, 2849, 3365, 2850, 2, 10865, 3370, 2833, "Low wall (floor 2) approach"),
         area(3366, 2849, 3373, 2851, 2, 10865, 3370, 2833, "Low wall (floor 2) east"),
         // End of floor 2
-        area(3369, 2834, 3370, 2834, 2, 10859, 3365, 2833, "Gap jump (floor 2 end)"),
+        area(3369, 2833, 3370, 2834, 2, 10859, 3365, 2833, "Gap jump (floor 2 end)"),
         area(3363, 2834, 3365, 2834, 2, 10857, 3358, 2833, "Stairs (floor 2 up)"),
         area(3358, 2833, 3362, 2834, 2, 10857, 3358, 2833, "Stairs (floor 2 up)"),
         


### PR DESCRIPTION
## Summary

Fixes an issue where the Agility Pyramid bot fails to detect the player's position at coordinate (3369, 2833, 2) on floor 2 after crossing the low wall obstacle and gets stuck in a loop.

## Problem

The obstacle area for the "Gap jump (floor 2 end)" was only detecting Y coordinate 2834, missing players positioned at Y coordinate 2833. This caused the bot to not recognize when it needed to interact with the gap jump obstacle from that position.

## Solution

Extended the obstacle detection area from:
- `area(3369, 2834, 3370, 2834, 2, 10859, ...)`

To:
- `area(3369, 2833, 3370, 2834, 2, 10859, ...)`

This now properly includes both Y coordinates 2833 and 2834, ensuring the bot detects the player at either position.