### PR TITLE
[Plugin] Add Auto World Hopper Plugin

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperConfig.java
@@ -1,0 +1,242 @@
+package net.runelite.client.plugins.microbot.autoworldhopper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+import net.runelite.client.plugins.microbot.autoworldhopper.enums.WorldMembershipFilter;
+
+@ConfigGroup(AutoWorldHopperConfig.GROUP)
+public interface AutoWorldHopperConfig extends Config {
+    String GROUP = "autoworldhopper";
+
+    @ConfigSection(
+            name = "World Settings",
+            description = "Configure world selection preferences",
+            position = 0,
+            closedByDefault = false
+    )
+    String worldSection = "worldSection";
+
+    @ConfigSection(
+            name = "Hop Triggers",
+            description = "Configure when to hop worlds",
+            position = 1,
+            closedByDefault = false
+    )
+    String triggersSection = "triggersSection";
+
+    @ConfigSection(
+            name = "Advanced",
+            description = "Advanced settings",
+            position = 2,
+            closedByDefault = true
+    )
+    String advancedSection = "advancedSection";
+
+    // =========================================
+    // ========== WORLD SETTINGS ==============
+    // =========================================
+
+    @ConfigItem(
+            keyName = "enabled",
+            name = "Enable Auto World Hopper",
+            description = "Enable or disable the auto world hopper",
+            position = 0,
+            section = worldSection
+    )
+    default boolean enabled() {
+        return false;
+    }
+
+    @Range(min = 0, max = 300)
+    @ConfigItem(
+            keyName = "startupDelay",
+            name = "Startup Delay (seconds)",
+            description = "Delay in seconds before triggers become active (allows time for walking/setup)",
+            position = 1,
+            section = worldSection
+    )
+    default int startupDelay() {
+        return 30;
+    }
+
+    @ConfigItem(
+            keyName = "membershipFilter",
+            name = "World Type",
+            description = "Choose between member worlds, free worlds, or both",
+            position = 1,
+            section = worldSection
+    )
+    default WorldMembershipFilter membershipFilter() {
+        return WorldMembershipFilter.BOTH;
+    }
+
+    @ConfigItem(
+            keyName = "avoidPvpWorlds",
+            name = "Avoid PvP Worlds",
+            description = "Skip PvP and high-risk worlds when hopping",
+            position = 2,
+            section = worldSection
+    )
+    default boolean avoidPvpWorlds() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "avoidSkillTotalWorlds",
+            name = "Avoid Skill Total Worlds",
+            description = "Skip worlds with skill total requirements",
+            position = 3,
+            section = worldSection
+    )
+    default boolean avoidSkillTotalWorlds() {
+        return true;
+    }
+
+    // =========================================
+    // ========== HOP TRIGGERS ================
+    // =========================================
+
+    @ConfigItem(
+            keyName = "enablePlayerDetection",
+            name = "Enable Player Detection",
+            description = "Hop worlds when too many players are detected nearby",
+            position = 0,
+            section = triggersSection
+    )
+    default boolean enablePlayerDetection() {
+        return true;
+    }
+
+    @Range(min = 0, max = 20)
+    @ConfigItem(
+            keyName = "maxPlayers",
+            name = "Max Players Nearby",
+            description = "Maximum number of other players allowed nearby (0 = zero tolerance, hop if ANY players detected)",
+            position = 1,
+            section = triggersSection
+    )
+    default int maxPlayers() {
+        return 3;
+    }
+
+    @Range(min = 0, max = 50)
+    @ConfigItem(
+            keyName = "detectionRadius",
+            name = "Detection Radius",
+            description = "Radius in tiles to check for other players (0 = same tile only)",
+            position = 2,
+            section = triggersSection
+    )
+    default int detectionRadius() {
+        return 10;
+    }
+
+    @ConfigItem(
+            keyName = "showPlayerRadius",
+            name = "Show Player Detection Radius",
+            description = "Visually display the player detection radius on the game canvas",
+            position = 3,
+            section = triggersSection
+    )
+    default boolean showPlayerRadius() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "enableTimeHopping",
+            name = "Enable Time-based Hopping",
+            description = "Hop worlds after a set amount of time",
+            position = 3,
+            section = triggersSection
+    )
+    default boolean enableTimeHopping() {
+        return false;
+    }
+
+    @Range(min = 1, max = 60)
+    @ConfigItem(
+            keyName = "hopIntervalMinutes",
+            name = "Hop Interval (minutes)",
+            description = "Time in minutes before automatically hopping worlds",
+            position = 4,
+            section = triggersSection
+    )
+    default int hopIntervalMinutes() {
+        return 10;
+    }
+
+    @ConfigItem(
+            keyName = "enableChatDetection",
+            name = "Enable Chat Detection",
+            description = "Hop worlds when someone else speaks in public chat",
+            position = 5,
+            section = triggersSection
+    )
+    default boolean enableChatDetection() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "ignoreFriends",
+            name = "Ignore Friends Chat",
+            description = "Don't hop when friends speak in public chat",
+            position = 6,
+            section = triggersSection
+    )
+    default boolean ignoreFriends() {
+        return true;
+    }
+
+    // =========================================
+    // =========== ADVANCED SECTION ===========
+    // =========================================
+
+    @Range(min = 1, max = 10)
+    @ConfigItem(
+            keyName = "hopCooldown",
+            name = "Hop Cooldown (seconds)",
+            description = "Minimum time between world hops to avoid spam",
+            position = 0,
+            section = advancedSection
+    )
+    default int hopCooldown() {
+        return 5;
+    }
+
+    @Range(min = 0, max = 30)
+    @ConfigItem(
+            keyName = "randomDelay",
+            name = "Random Delay (seconds)",
+            description = "Add random delay before hopping (0 = no delay)",
+            position = 1,
+            section = advancedSection
+    )
+    default int randomDelay() {
+        return 3;
+    }
+
+    @ConfigItem(
+            keyName = "showNotifications",
+            name = "Show Notifications",
+            description = "Show chat notifications when hopping worlds",
+            position = 2,
+            section = advancedSection
+    )
+    default boolean showNotifications() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "debugMode",
+            name = "Debug Mode",
+            description = "Show debug information in overlay",
+            position = 3,
+            section = advancedSection
+    )
+    default boolean debugMode() {
+        return false;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperInfoOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperInfoOverlay.java
@@ -1,0 +1,134 @@
+package net.runelite.client.plugins.microbot.autoworldhopper;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.autoworldhopper.scripts.WorldHopScript;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class AutoWorldHopperInfoOverlay extends OverlayPanel {
+    private final AutoWorldHopperConfig config;
+    private final AutoWorldHopperPlugin plugin;
+
+    @Inject
+    AutoWorldHopperInfoOverlay(AutoWorldHopperPlugin plugin, AutoWorldHopperConfig config) {
+        super(plugin);
+        this.config = config;
+        this.plugin = plugin;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            if (!config.enabled()) {
+                return null;
+            }
+
+            WorldHopScript script = plugin.getWorldHopScript();
+            if (script == null) {
+                return null;
+            }
+
+            panelComponent.setPreferredSize(new Dimension(200, 120));
+            
+            // Title
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Auto World Hopper v" + AutoWorldHopperPlugin.version)
+                    .color(Color.CYAN)
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
+            // Status
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status:")
+                    .right(script.isRunning() ? (script.isPaused() ? "Paused" : "Running") : "Stopped")
+                    .rightColor(script.isRunning() ? (script.isPaused() ? Color.YELLOW : Color.GREEN) : Color.RED)
+                    .build());
+
+            // Startup delay status
+            if (script.isRunning() && !script.isPaused()) {
+                int remainingDelay = script.getRemainingStartupDelay();
+                if (remainingDelay > 0) {
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Startup Delay:")
+                            .right(remainingDelay + "s remaining")
+                            .rightColor(Color.ORANGE)
+                            .build());
+                }
+            }
+
+            // Current world
+            if (Microbot.getClient().getLocalPlayer() != null) {
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Current World:")
+                        .right(String.valueOf(Microbot.getClient().getWorld()))
+                        .build());
+            }
+
+            // Time until next hop (if time-based hopping is enabled)
+            if (config.enableTimeHopping() && script.isRunning() && !script.isPaused()) {
+                long nextHopTime = script.getNextTimeHop();
+                if (nextHopTime > 0) {
+                    long timeLeft = Math.max(0, nextHopTime - System.currentTimeMillis());
+                    long minutes = TimeUnit.MILLISECONDS.toMinutes(timeLeft);
+                    long seconds = TimeUnit.MILLISECONDS.toSeconds(timeLeft) % 60;
+                    
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Next time hop:")
+                            .right(String.format("%d:%02d", minutes, seconds))
+                            .build());
+                }
+            }
+
+            // Players nearby (if player detection is enabled)
+            if (config.enablePlayerDetection()) {
+                int playersNearby = script.getPlayersNearby();
+                int max = config.maxPlayers();
+                Color playerColor = (max == 0 ? playersNearby > 0 : playersNearby >= max)
+                        ? Color.RED : Color.WHITE;
+                
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Players nearby:")
+                        .right(playersNearby + "/" + max)
+                        .rightColor(playerColor)
+                        .build());
+            }
+
+            // Debug information
+            if (config.debugMode()) {
+                panelComponent.getChildren().add(LineComponent.builder().build());
+                
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Last hop reason:")
+                        .right(script.getLastHopReason())
+                        .build());
+
+                long lastHopTime = script.getLastHopTime();
+                if (lastHopTime > 0) {
+                    long timeSinceHop = System.currentTimeMillis() - lastHopTime;
+                    long secondsAgo = TimeUnit.MILLISECONDS.toSeconds(timeSinceHop);
+                    
+                    panelComponent.getChildren().add(LineComponent.builder()
+                            .left("Last hop:")
+                            .right(secondsAgo + "s ago")
+                            .build());
+                }
+            }
+
+        } catch (Exception ex) {
+            log.error("Error rendering overlay", ex);
+        }
+
+        return super.render(graphics);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperOverlay.java
@@ -1,0 +1,174 @@
+package net.runelite.client.plugins.microbot.autoworldhopper;
+
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.autoworldhopper.scripts.WorldHopScript;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.List;
+
+import static net.runelite.client.ui.overlay.OverlayUtil.renderPolygon;
+
+public class AutoWorldHopperOverlay extends OverlayPanel {
+    
+    private static final Color PLAYER_DETECTION_RADIUS = new Color(255, 165, 0, 50); // Orange translucent
+    private static final Color DETECTED_PLAYER_OUTLINE = new Color(255, 69, 0); // Red-orange for detected players
+    private static final Color FRIEND_PLAYER_OUTLINE = new Color(0, 255, 0); // Green for friends
+    
+    private final AutoWorldHopperConfig config;
+    private final ModelOutlineRenderer modelOutlineRenderer;
+
+    @Inject
+    private AutoWorldHopperOverlay(AutoWorldHopperConfig config, ModelOutlineRenderer modelOutlineRenderer) {
+        this.config = config;
+        this.modelOutlineRenderer = modelOutlineRenderer;
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+        setPriority(OverlayPriority.HIGH);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (!config.enabled()) {
+            return null;
+        }
+
+        if (Microbot.getClient().getGameState() != net.runelite.api.GameState.LOGGED_IN) {
+            return null;
+        }
+
+        Player localPlayer = Microbot.getClient().getLocalPlayer();
+        if (localPlayer == null) {
+            return null;
+        }
+
+        renderPlayerDetectionRadius(graphics, localPlayer);
+        renderDetectedPlayers(graphics);
+
+        return super.render(graphics);
+    }
+
+    private void renderPlayerDetectionRadius(Graphics2D graphics, Player localPlayer) {
+        if (!config.enablePlayerDetection() || !config.showPlayerRadius()) {
+            return; // Don't show radius if player detection is disabled or radius display is off
+        }
+
+        LocalPoint playerLocation = localPlayer.getLocalLocation();
+        if (playerLocation == null) {
+            return;
+        }
+
+        // Render the detection radius circle
+        int radiusTiles = config.detectionRadius();
+        int sizeTiles = Math.max(1, radiusTiles * 2 + 1); // 0 -> 1x1, R -> (2R+1)x(2R+1)
+        Polygon radiusPolygon = Perspective.getCanvasTileAreaPoly(
+            Microbot.getClient(),
+            playerLocation,
+            sizeTiles
+        );
+
+        if (radiusPolygon != null) {
+            renderPolygon(graphics, radiusPolygon, PLAYER_DETECTION_RADIUS);
+            
+            // Draw radius border
+            graphics.setColor(new Color(255, 165, 0, 200));
+            graphics.setStroke(new BasicStroke(2));
+            graphics.draw(radiusPolygon);
+        }
+    }
+
+    private void renderDetectedPlayers(Graphics2D graphics) {
+        // Only render if plugin is enabled and player detection is active
+        if (!config.enabled() || !config.enablePlayerDetection()) {
+            return;
+        }
+
+        Player localPlayer = Microbot.getClient().getLocalPlayer();
+        if (localPlayer == null) {
+            return;
+        }
+
+        List<Player> nearbyPlayers = Microbot.getClient().getPlayers();
+        if (nearbyPlayers == null) {
+            return;
+        }
+
+        int detectionRadius = config.detectionRadius();
+        
+        for (Player player : nearbyPlayers) {
+            if (player == null || player == localPlayer) {
+                continue;
+            }
+
+            // Check if player is within detection radius
+            double distance = localPlayer.getWorldLocation().distanceTo(player.getWorldLocation());
+            boolean withinRadius = (detectionRadius == 0) ? (distance == 0) : (distance <= detectionRadius);
+            
+            if (withinRadius) {
+                renderDetectedPlayer(graphics, player);
+            }
+        }
+    }
+
+    private void renderDetectedPlayer(Graphics2D graphics, Player player) {
+        try {
+            // Determine color based on whether player is a friend
+            boolean isFriend = Microbot.getClient().isFriended(player.getName(), false);
+            Color outlineColor = isFriend ? FRIEND_PLAYER_OUTLINE : DETECTED_PLAYER_OUTLINE;
+            
+            // Render player outline
+            modelOutlineRenderer.drawOutline(player, 2, outlineColor, 3);
+            
+            // Get player's canvas polygon for additional rendering
+            Polygon playerPoly = Perspective.getCanvasTilePoly(Microbot.getClient(), player.getLocalLocation());
+            if (playerPoly != null) {
+                graphics.setColor(outlineColor);
+                graphics.setStroke(new BasicStroke(2));
+                graphics.draw(playerPoly);
+                
+                // Draw player name above the polygon
+                Point textPoint = new Point(
+                    (int) playerPoly.getBounds().getCenterX(),
+                    (int) playerPoly.getBounds().getMinY() - 5
+                );
+                
+                graphics.setColor(Color.WHITE);
+                graphics.setFont(new Font("Arial", Font.BOLD, 11));
+                String displayName = player.getName();
+                if (displayName != null) {
+                    FontMetrics fm = graphics.getFontMetrics();
+                    int textWidth = fm.stringWidth(displayName);
+                    graphics.drawString(
+                        displayName, 
+                        textPoint.getX() - textWidth / 2, 
+                        textPoint.getY()
+                    );
+                }
+            }
+            
+        } catch (Exception ex) {
+            // Safely handle any rendering exceptions
+            Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+        }
+    }
+
+    public static void renderMinimapRect(Client client, Graphics2D graphics, Point center, int width, int height, Color color) {
+        double angle = client.getCameraYawTarget() * Math.PI / 1024.0d;
+
+        graphics.setColor(color);
+        graphics.rotate(angle, center.getX(), center.getY());
+        graphics.fillRect(center.getX() - width / 2, center.getY() - height / 2, width, height);
+        graphics.rotate(-angle, center.getX(), center.getY());
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/AutoWorldHopperPlugin.java
@@ -1,0 +1,172 @@
+package net.runelite.client.plugins.microbot.autoworldhopper;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.game.WorldService;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.autoworldhopper.scripts.WorldHopScript;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.Text;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Mocrosoft + "Auto World Hopper",
+        description = "Automatically hops worlds based on player count, time, or chat activity",
+        tags = {"world", "hopper", "auto", "microbot"},
+        authors = {"Matheus Gois"},
+        version = AutoWorldHopperPlugin.version,
+        minClientVersion = "2.0.7",
+        enabledByDefault = false
+)
+@Slf4j
+public class AutoWorldHopperPlugin extends Plugin {
+    public static final String version = "1.0.0";
+
+    @Inject
+    private Client client;
+
+    @Inject
+    private AutoWorldHopperConfig config;
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private AutoWorldHopperInfoOverlay infoOverlay;
+
+    @Inject
+    private AutoWorldHopperOverlay visualOverlay;
+
+    @Inject
+    private WorldService worldService;
+
+    @Inject
+    private net.runelite.client.chat.ChatMessageManager chatMessageManager;
+
+    private final WorldHopScript worldHopScript = new WorldHopScript();
+    private long lastChatTime = 0;
+
+    @Provides
+    AutoWorldHopperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(AutoWorldHopperConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        Microbot.pauseAllScripts.compareAndSet(true, false);
+        
+        if (overlayManager != null) {
+            overlayManager.add(infoOverlay);
+            overlayManager.add(visualOverlay);
+        }
+        
+        if (config.enabled()) {
+            worldHopScript.run(config, worldService, chatMessageManager);
+            log.info("Auto World Hopper started");
+        }
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        worldHopScript.shutdown();
+        
+        if (overlayManager != null) {
+            overlayManager.remove(infoOverlay);
+            overlayManager.remove(visualOverlay);
+        }
+        
+        log.info("Auto World Hopper stopped");
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        if (!event.getGroup().equals(AutoWorldHopperConfig.GROUP)) {
+            return;
+        }
+
+        if (event.getKey().equals("enabled")) {
+            if (config.enabled()) {
+                worldHopScript.run(config, worldService, chatMessageManager);
+                log.info("Auto World Hopper enabled via config");
+            } else {
+                worldHopScript.shutdown();
+                log.info("Auto World Hopper disabled via config");
+            }
+        }
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {
+        if (gameStateChanged.getGameState() == GameState.LOGGED_IN) {
+            // Reset timers when logging in
+            worldHopScript.resetTimers();
+        } else if (gameStateChanged.getGameState() == GameState.LOGIN_SCREEN) {
+            // Stop script when logged out
+            worldHopScript.pause();
+        }
+    }
+
+    @Subscribe
+    public void onGameTick(GameTick gameTick) {
+        if (!config.enabled() || !Microbot.isLoggedIn()) {
+            return;
+        }
+
+        // Update the script with current game tick
+        worldHopScript.onGameTick();
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage chatMessage) {
+        if (!config.enabled() || !config.enableChatDetection()) {
+            return;
+        }
+
+        // Only react to public chat messages
+        if (chatMessage.getType() != ChatMessageType.PUBLICCHAT) {
+            return;
+        }
+
+        String playerName = Text.removeTags(chatMessage.getName());
+        String localPlayerName = client.getLocalPlayer().getName();
+
+        // Ignore our own messages
+        if (playerName.equals(localPlayerName)) {
+            return;
+        }
+
+        // Ignore friends if configured
+        if (config.ignoreFriends() && client.getFriendContainer() != null 
+            && client.getFriendContainer().findByName(playerName) != null) {
+            return;
+        }
+
+        // Trigger world hop due to chat activity
+        lastChatTime = System.currentTimeMillis();
+        worldHopScript.triggerChatHop(playerName, chatMessage.getMessage());
+        
+        if (config.showNotifications()) {
+            Microbot.showMessage("Chat detected from " + playerName + ", hopping worlds...");
+        }
+    }
+
+    public long getLastChatTime() {
+        return lastChatTime;
+    }
+
+    public WorldHopScript getWorldHopScript() {
+        return worldHopScript;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/enums/WorldMembershipFilter.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/enums/WorldMembershipFilter.java
@@ -1,0 +1,19 @@
+package net.runelite.client.plugins.microbot.autoworldhopper.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WorldMembershipFilter {
+    FREE("Free Worlds Only"),
+    MEMBERS("Members Worlds Only"),
+    BOTH("Both Free and Members");
+
+    private final String description;
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/scripts/WorldHopScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/autoworldhopper/scripts/WorldHopScript.java
@@ -1,0 +1,404 @@
+package net.runelite.client.plugins.microbot.autoworldhopper.scripts;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.GameState;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.client.game.WorldService;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.autoworldhopper.AutoWorldHopperConfig;
+import net.runelite.client.plugins.microbot.autoworldhopper.enums.WorldMembershipFilter;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.http.api.worlds.World;
+import net.runelite.http.api.worlds.WorldResult;
+import net.runelite.http.api.worlds.WorldType;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class WorldHopScript extends Script {
+
+    private ChatMessageManager chatMessageManager;
+    
+    private AutoWorldHopperConfig config;
+    private WorldService worldService;
+    
+    @Getter
+    private long lastHopTime = 0;
+    @Getter
+    private long nextTimeHop = 0;
+    @Getter
+    private String lastHopReason = "None";
+    @Getter
+    private int playersNearby = 0;
+    @Getter
+    private boolean paused = false;
+    @Getter
+    private long scriptStartTime = 0;
+    
+    private boolean chatTriggered = false;
+    private long chatTriggerTime = 0;
+    
+    /**
+     * Check if the startup delay has elapsed
+     */
+    public boolean isStartupDelayComplete() {
+        if (config.startupDelay() == 0) {
+            return true; // No delay configured
+        }
+        
+        long elapsedSeconds = (System.currentTimeMillis() - scriptStartTime) / 1000;
+        return elapsedSeconds >= config.startupDelay();
+    }
+    
+    /**
+     * Get remaining startup delay in seconds
+     */
+    public int getRemainingStartupDelay() {
+        if (config.startupDelay() == 0) {
+            return 0;
+        }
+        
+        long elapsedSeconds = (System.currentTimeMillis() - scriptStartTime) / 1000;
+        return Math.max(0, config.startupDelay() - (int)elapsedSeconds);
+    }
+    
+    public boolean run(AutoWorldHopperConfig config, WorldService worldService, ChatMessageManager chatMessageManager) {
+        this.config = config;
+        this.worldService = worldService;
+        this.chatMessageManager = chatMessageManager;
+        
+        if (!config.enabled()) {
+            return false;
+        }
+        
+        resetTimers();
+        paused = false;
+        scriptStartTime = System.currentTimeMillis();
+        
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn() || Microbot.getClient().getGameState() != GameState.LOGGED_IN) {
+                    return;
+                }
+                
+                if (!super.run() || paused) {
+                    return;
+                }
+                
+                // Update player count
+                updatePlayersNearby();
+                
+                // Check if we should hop
+                String hopReason = shouldHop();
+                if (hopReason != null) {
+                    performWorldHop(hopReason);
+                }
+                
+            } catch (Exception ex) {
+                log.error("Error in WorldHopScript", ex);
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS); // Check every second
+        
+        return true;
+    }
+    
+    public void onGameTick() {
+        // Update on each game tick for more precise timing
+        updatePlayersNearby();
+    }
+    
+    public void resetTimers() {
+        if (config != null && config.enableTimeHopping()) {
+            nextTimeHop = System.currentTimeMillis() + (config.hopIntervalMinutes() * 60 * 1000);
+        } else {
+            nextTimeHop = 0;
+        }
+        chatTriggered = false;
+        chatTriggerTime = 0;
+        lastHopReason = "None";
+    }
+    
+    public void pause() {
+        paused = true;
+    }
+    
+    public void resume() {
+        paused = false;
+        resetTimers();
+    }
+    
+    public void triggerChatHop(String playerName, String message) {
+        if (!config.enableChatDetection()) {
+            return;
+        }
+        
+        chatTriggered = true;
+        chatTriggerTime = System.currentTimeMillis();
+        log.info("Chat trigger activated by player: {} - Message: {}", playerName, message);
+    }
+    
+    private void updatePlayersNearby() {
+        if (!config.enablePlayerDetection()) {
+            playersNearby = 0;
+            return;
+        }
+        
+        Player localPlayer = Microbot.getClient().getLocalPlayer();
+        if (localPlayer == null) {
+            playersNearby = 0;
+            return;
+        }
+        
+        WorldPoint localPlayerLocation = localPlayer.getWorldLocation();
+        int radius = config.detectionRadius();
+        int count = 0;
+        
+        for (Player player : Microbot.getClient().getPlayers()) {
+            if (player == localPlayer) {
+                continue; // Skip ourselves
+            }
+            
+            double distance = player.getWorldLocation().distanceTo(localPlayerLocation);
+            boolean withinRadius = (radius == 0) ? (distance == 0) : (distance <= radius);
+            
+            if (withinRadius) {
+                count++;
+            }
+        }
+        
+        playersNearby = count;
+    }
+    
+    private String shouldHop() {
+        long currentTime = System.currentTimeMillis();
+        
+        // Check startup delay first
+        if (!isStartupDelayComplete()) {
+            return null; // Still in startup delay period
+        }
+        
+        // Check cooldown
+        if (currentTime - lastHopTime < (config.hopCooldown() * 1000)) {
+            return null; // Still in cooldown
+        }
+        
+        // Check chat trigger
+        if (chatTriggered && config.enableChatDetection()) {
+            return "Chat detected";
+        }
+        
+        // Check player count
+        if (config.enablePlayerDetection()) {
+            if (config.maxPlayers() == 0) {
+                // Zero tolerance mode - hop if ANY players detected
+                if (playersNearby > 0) {
+                    return "Zero tolerance - " + playersNearby + " player(s) detected";
+                }
+            } else {
+                // Normal mode - hop if too many players
+                if (playersNearby >= config.maxPlayers()) {
+                    return "Too many players (" + playersNearby + "/" + config.maxPlayers() + ")";
+                }
+            }
+        }
+        
+        // Check time-based hopping
+        if (config.enableTimeHopping() && nextTimeHop > 0) {
+            if (currentTime >= nextTimeHop) {
+                return "Time interval reached";
+            }
+        }
+        
+        return null; // No reason to hop
+    }
+    
+    private void performWorldHop(String reason) {
+        try {
+            // Add random delay if configured
+            if (config.randomDelay() > 0) {
+                int delay = Rs2Random.between(0, config.randomDelay() * 1000);
+                Thread.sleep(delay);
+            }
+            
+            World targetWorld = findSuitableWorld();
+            if (targetWorld == null) {
+                log.warn("No suitable world found for hopping");
+                return;
+            }
+            
+            log.info("Hopping to world {} - Reason: {}", targetWorld.getId(), reason);
+            
+            // Perform the world hop
+            if (hopToWorld(targetWorld)) {
+                lastHopTime = System.currentTimeMillis();
+                lastHopReason = reason;
+                
+                // Reset triggers and timers
+                chatTriggered = false;
+                chatTriggerTime = 0;
+                if (config.enableTimeHopping()) {
+                    nextTimeHop = System.currentTimeMillis() + (config.hopIntervalMinutes() * 60 * 1000);
+                }
+                
+                // Show notification
+                if (config.showNotifications()) {
+                    sendChatMessage("Hopped to world " + targetWorld.getId() + " - " + reason);
+                }
+            }
+            
+        } catch (Exception ex) {
+            log.error("Error performing world hop", ex);
+        }
+    }
+    
+    private World findSuitableWorld() {
+        WorldResult worldResult = worldService.getWorlds();
+        if (worldResult == null) {
+            return null;
+        }
+        
+        int currentWorld = Microbot.getClient().getWorld();
+        List<World> suitableWorlds = new ArrayList<>();
+        
+        for (World world : worldResult.getWorlds()) {
+            if (world.getId() == currentWorld) {
+                continue; // Skip current world
+            }
+            
+            if (!isWorldSuitable(world)) {
+                continue;
+            }
+            
+            suitableWorlds.add(world);
+        }
+        
+        if (suitableWorlds.isEmpty()) {
+            return null;
+        }
+        
+        // Return random suitable world
+        return suitableWorlds.get(Rs2Random.between(0, suitableWorlds.size() - 1));
+    }
+    
+    private boolean isWorldSuitable(World world) {
+        EnumSet<WorldType> types = world.getTypes();
+        
+        // Check membership filter
+        switch (config.membershipFilter()) {
+            case FREE:
+                if (types.contains(WorldType.MEMBERS)) {
+                    return false;
+                }
+                break;
+            case MEMBERS:
+                if (!types.contains(WorldType.MEMBERS)) {
+                    return false;
+                }
+                break;
+            case BOTH:
+                // Allow both
+                break;
+        }
+        
+        // Check PvP worlds
+        if (config.avoidPvpWorlds()) {
+            if (types.contains(WorldType.PVP) || types.contains(WorldType.HIGH_RISK) || 
+                types.contains(WorldType.DEADMAN)) {
+                return false;
+            }
+        }
+        
+        // Check skill total worlds
+        if (config.avoidSkillTotalWorlds()) {
+            if (types.contains(WorldType.SKILL_TOTAL)) {
+                return false;
+            }
+        }
+        
+        // Check if world is offline
+        if (world.getPlayers() < 0) {
+            return false;
+        }
+        
+        // Avoid very full worlds (near max capacity)
+        if (world.getPlayers() >= 1900) {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    private boolean hopToWorld(World world) {
+        try {
+            // Use the existing world hopping functionality
+            net.runelite.api.World rsWorld = Microbot.getClient().createWorld();
+            rsWorld.setActivity(world.getActivity());
+            rsWorld.setAddress(world.getAddress());
+            rsWorld.setId(world.getId());
+            rsWorld.setPlayerCount(world.getPlayers());
+            rsWorld.setLocation(world.getLocation());
+            rsWorld.setTypes(net.runelite.client.util.WorldUtil.toWorldTypes(world.getTypes()));
+            
+            // If on login screen, just change world
+            if (Microbot.getClient().getGameState() == GameState.LOGIN_SCREEN) {
+                Microbot.getClient().changeWorld(rsWorld);
+                return true;
+            }
+            
+            // If logged in, use the world hopper
+            Microbot.getClient().openWorldHopper();
+            sleep(1000); // Wait for interface to open
+            
+            if (Microbot.getClient().getWidget(InterfaceID.Worldswitcher.BUTTONS) != null) {
+                Microbot.getClient().hopToWorld(rsWorld);
+                return true;
+            }
+            
+            return false;
+            
+        } catch (Exception ex) {
+            log.error("Error hopping to world {}", world.getId(), ex);
+            return false;
+        }
+    }
+    
+    private void sendChatMessage(String message) {
+        if (chatMessageManager == null) {
+            return;
+        }
+        
+        String chatMessage = new ChatMessageBuilder()
+                .append(ChatColorType.HIGHLIGHT)
+                .append("[Auto World Hopper] ")
+                .append(ChatColorType.NORMAL)
+                .append(message)
+                .build();
+        
+        chatMessageManager.queue(QueuedMessage.builder()
+                .type(ChatMessageType.CONSOLE)
+                .runeLiteFormattedMessage(chatMessage)
+                .build());
+    }
+    
+    @Override
+    public void shutdown() {
+        paused = true;
+        super.shutdown();
+        log.info("WorldHopScript shutdown");
+    }
+}


### PR DESCRIPTION
<img width="300"  alt="Screenshot 2025-09-14 at 20 47 58" src="https://github.com/user-attachments/assets/ff6fbe4e-18b5-40c1-9f1a-99fa723653f8" />
<img width="300"  alt="Screenshot 2025-09-14 at 20 42 29" src="https://github.com/user-attachments/assets/c0aaa4fb-9212-4488-8f24-5218421c5690" />

<img width="250" height="716" alt="Screenshot 2025-09-14 at 20 42 06" src="https://github.com/user-attachments/assets/ef484ab9-e7b4-4021-805f-bbc09df99db2" />


# Add Auto World Hopper Plugin

## Overview
Adds a new automated world hopping plugin that switches worlds based on configurable triggers.

## Changes Added
- **7 new files, 1,237 lines of code**
- Complete plugin implementation with configuration, overlays, and core logic

## Features
### Hop Triggers
- **Player Detection**: Hop when too many players nearby (configurable radius 5-50 tiles)
- **Time-based**: Automatic hopping at set intervals (1-60 minutes)  
- **Chat Detection**: Hop when public chat is detected (with friend ignore option)

### World Filtering
- Filter by membership (Free/Members/Both)
- Avoid PvP and high-risk worlds
- Avoid skill total requirement worlds

### Safety & Configuration
- Hop cooldown system (1-10 seconds)
- Random delays (0-30 seconds)
- Startup delay option
- Zero tolerance mode (hop on any player detection)
- Debug mode with detailed information

### UI/UX
- Info overlay showing status, timers, and player counts
- Visual overlay with player detection radius and outlines  
- Chat notifications for hop events
- Real-time configuration updates

## Technical Implementation
- Plugin follows RuneLite plugin architecture
- Uses scheduled executor for timing logic
- Integrates with WorldService for world selection
- Respects world capacity limits and hopping restrictions
- Event-driven chat and game state handling
