### PR TITLE
Playermonitor import fixes

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/FlashOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/FlashOverlay.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.plugins.PlayerMonitor;
+package net.runelite.client.plugins.microbot.PlayerMonitor;
 
 import java.awt.*;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/MouseListener.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/MouseListener.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.plugins.PlayerMonitor;
+package net.runelite.client.plugins.microbot.PlayerMonitor;
 
 import net.runelite.api.Client;
 import net.runelite.api.GameState;

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/MouseOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/MouseOverlay.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.plugins.PlayerMonitor;
+package net.runelite.client.plugins.microbot.PlayerMonitor;
 
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.components.LineComponent;

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorConfig.java
@@ -1,8 +1,8 @@
-package net.runelite.client.plugins.microbot.plugins.PlayerMonitor;
+package net.runelite.client.plugins.microbot.PlayerMonitor;
 
 import net.runelite.client.config.*;
-import net.runelite.client.plugins.microbot.storm.plugins.PlayerMonitor.enums.SoundEffectID;
-import net.runelite.client.plugins.microbot.storm.plugins.PlayerMonitor.enums.emergencyOptions;
+import net.runelite.client.plugins.microbot.PlayerMonitor.enums.SoundEffectID;
+import net.runelite.client.plugins.microbot.PlayerMonitor.enums.emergencyOptions;
 
 import java.awt.*;
  

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorPlugin.java
@@ -21,7 +21,6 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.PluginConstants;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.player.Rs2PlayerModel;
-import net.runelite.client.plugins.microbot.wildernessagility.WildernessAgilityPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorPlugin.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.plugins.PlayerMonitor;
+package net.runelite.client.plugins.microbot.PlayerMonitor;
 
 import com.google.inject.Provides;
 import lombok.Getter;

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/PlayerMonitorScript.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.plugins.PlayerMonitor;
+package net.runelite.client.plugins.microbot.PlayerMonitor;
 
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/enums/SoundEffectID.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/enums/SoundEffectID.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.storm.plugins.PlayerMonitor.enums;
+package net.runelite.client.plugins.microbot.PlayerMonitor.enums;
 
 public enum SoundEffectID {
     UI_BOOP(2266),

--- a/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/enums/emergencyOptions.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PlayerMonitor/enums/emergencyOptions.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.microbot.storm.plugins.PlayerMonitor.enums;
+package net.runelite.client.plugins.microbot.PlayerMonitor.enums;
 
 public enum emergencyOptions {
     LOGOUT("logout"),


### PR DESCRIPTION
Removed unnecessary Wilderness Agility import. 

Fixed imports to actually match Plugin Hub's directories.

Sorry didn't check completely.