### PR TITLE
Dismiss Npc Event 

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/DismissNpcEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/DismissNpcEvent.java
@@ -36,7 +36,7 @@ public class DismissNpcEvent implements BlockingEvent {
             Rs2Dialogue.clickContinue();
             return true;
         }
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Changed to return true, or it would re quene within the block manager system. As a result would encounter null on subsequent retries.