### PR TITLE
[Giants Foundry] Calculation improvements

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryPlugin.java
@@ -28,7 +28,7 @@ import java.awt.*;
 @Slf4j
 public class GiantsFoundryPlugin extends Plugin {
 
-    public static final String version = "1.0.5";
+    public static final String version = "1.0.6";
 
     @Inject
     private GiantsFoundryConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryScript.java
@@ -263,7 +263,7 @@ public class GiantsFoundryScript extends Script {
                 if (!doAction && isAtLavaTile) return;
                 Rs2GameObject.interact(LAVA_POOL, "Heat-preform");
                 GiantsFoundryState.heatingCoolingState.stop();
-                GiantsFoundryState.heatingCoolingState.setup(7, 0, "heats");
+                GiantsFoundryState.heatingCoolingState.setup(false, true, "heats");
                 GiantsFoundryState.heatingCoolingState.start(GiantsFoundryState.getHeatAmount());
                 sleepUntil(() -> GiantsFoundryState.heatingCoolingState.getRemainingDuration() <= 1);
                 break;
@@ -272,7 +272,7 @@ public class GiantsFoundryScript extends Script {
                 if (!doAction && isAtWaterFallTile) return;
                 Rs2GameObject.interact(WATERFALL, "Cool-preform");
                 GiantsFoundryState.heatingCoolingState.stop();
-                GiantsFoundryState.heatingCoolingState.setup(-7, 0, "cools");
+                GiantsFoundryState.heatingCoolingState.setup(false, false, "cools");
                 GiantsFoundryState.heatingCoolingState.start(GiantsFoundryState.getHeatAmount());
                 sleepUntil(() -> GiantsFoundryState.heatingCoolingState.getRemainingDuration() <= 1);
                 break;

--- a/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryState.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/GiantsFoundryState.java
@@ -257,5 +257,11 @@ public class GiantsFoundryState {
 
         return actions;
     }
+
+    public static boolean isPlayerRunning()
+    {
+        return Microbot.getClient().getVarpValue(173) == 1;
+    }
+
     public static HeatActionStateMachine heatingCoolingState = new HeatActionStateMachine();
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/HeatActionSolver.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/HeatActionSolver.java
@@ -1,73 +1,301 @@
 package net.runelite.client.plugins.microbot.giantsfoundry;
 
-public class HeatActionSolver {
 
-    /**
-     * @param goal       the desired heat destination
-     * @param init_dx1   initial speed of heating/cooling. currently 7 for heat/cool, 27 for dunk/quench.
-     * @param dx2_offset bonus acceleration. currently, 0 for heat/cool, 2 for dunk/quench.
-     * @return Index here refers to tick. So an index of 10 means the goal can be reached in 10 ticks.
-     */
-    public static int findDx0Index(int goal, int init_dx1, int dx2_offset) {
+import lombok.Value;
+import net.runelite.client.plugins.microbot.giantsfoundry.enums.Stage;
+
+public class HeatActionSolver
+{
+
+    public static final int[] DX_1 = new int[]{
+            7,
+            8,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            24,
+            27, // -- dunk/quench starts here
+            30,
+            33,
+            37,
+            41,
+            45,
+            49,
+            53,
+            57,
+            62,
+            67,
+            72,
+            77,
+            83,
+            89,
+            95,
+            91, // last one will always overshoot 1000
+    };
+
+
+    // index is stage, ordinal order
+    public static final int[] TOOL_TICK_CYCLE = new int[] {
+            5,
+            2,
+            2
+    };
+
+    public static final int MAX_INDEX = DX_1.length;
+    public static final int FAST_INDEX = 10;
+
+    @Value(staticConstructor = "of")
+    public static class SolveResult
+    {
+        int index;
+        int dx0;
+        int dx1;
+        int dx2;
+    }
+
+    private static SolveResult heatingSolve(int start, int goal, boolean overshoot, int max, boolean isFast)
+    {
+        return relativeSolve(goal - start, overshoot, max - start, isFast, -1);
+    }
+
+    private static SolveResult coolingSolve(int start, int goal, boolean overshoot, int min, boolean isFast)
+    {
+        return relativeSolve(start - goal, overshoot, start - min, isFast, 1);
+    }
+
+    private static SolveResult relativeSolve(int goal, boolean overshoot, int max, boolean isFast, int decayValue)
+    {
+
+        int index = isFast ? FAST_INDEX : 0;
         int dx0 = 0;
-        int dx1 = init_dx1;
-        int count_index = 0;
-        for (int dx2 = 1; dx0 <= goal; dx2++) {  // Start from 1 up to the count inclusive
-            int repetitions;
-            if (dx2 == 1) {
-                repetitions = 2;  // The first number appears twice
-            } else if (dx2 % 2 == 0) {
-                repetitions = 6;  // Even numbers appear six times
-            } else {
-                repetitions = 4;  // Odd numbers (after 1) appear four times
+
+        boolean decay = false;
+
+        while (true) {
+
+            if (index > MAX_INDEX)
+            {
+                break;
             }
-            for (int j = 0; j < repetitions && dx0 <= goal; j++) {
-                dx0 += dx1;
-                dx1 += dx2 + dx2_offset;  // Sum the current number 'repetitions' times
-                count_index += 1;
+
+            if (!overshoot && dx0 + DX_1[index] > goal)
+            {
+                break;
             }
+            else if (overshoot && dx0 >= goal)
+            {
+                break;
+            }
+
+            if (dx0 + DX_1[index] >= max)
+            {
+                break;
+            }
+
+            if (decay)
+            {
+                dx0 -= decayValue;
+            }
+
+
+            dx0 += DX_1[index];
+            ++index;
+            decay = !decay;
         }
-        return count_index;
+
+        if (isFast)
+        {
+            index -= FAST_INDEX;
+        }
+
+        return SolveResult.of(index, dx0, DX_1[index], -1);
     }
 
 
-    /**
-     * We can use the pattern to get the dx2 at a specific index numerically
-     *
-     * @param index the index/tick we want to calculate dx2 at
-     * @return the acceleration of heating/cooling at index/tick
-     */
-    public static int getDx2AtIndex(int index) {
-        if (index <= 1) return 1;
-
-        index -= 2;
-        // 0 1 2 3 4 5 6 7 8 9
-        // e,e,e,e,e,e,o,o,o,o
-
-        int block = index / 10;
-        int block_idx = index % 10;
-        int number = block * 2;
-        if (block_idx <= 5) {
-            return number + 2;
-        } else {
-            return number + 3;
-        }
+    @Value(staticConstructor = "of")
+    public static class DurationResult
+    {
+        int duration;
+        boolean goalInRange;
+        boolean overshooting;
+        int predictedHeat;
     }
 
+    public static DurationResult solve(
+            Stage stage,
+            int[] range,
+            int actionLeftInStage,
+            int start,
+            boolean isFast,
+            boolean isActionHeating,
+            int paddingTicks,
+            boolean isRunning)
+    {
 
-    /**
-     * We can use the pattern to get the dx1 at a specific index numerically
-     *
-     * @param index    the index/tick we want to calculate the speed of heating/cooling
-     * @param constant the initial speed of heating/cooling.
-     * @return the speed of heating at index/tick
-     */
-    public static int getDx1AtIndex(int index, int constant) {
-        int _dx1 = constant;
-        for (int i = 0; i < index; ++i) {
-            _dx1 += getDx2AtIndex(i);
+        final boolean isStageHeating = stage.isHeating();
+        // adding tool cycle ticks because the first cycle at a tool is almost always nulled
+        // (unless manually reaching the tile, then clicking the tool)
+        final int toolDelay = TOOL_TICK_CYCLE[stage.ordinal()];
+        final int travelTicks = solveTravelTicks(isRunning, stage, isActionHeating) + toolDelay;
+        final int travelDecay = (int) Math.ceil((double) travelTicks / 2);
+
+        final int paddingDecay = (int) Math.ceil((double) paddingTicks / 2);
+
+        // adding 2.4s/8ticks worth of padding so preform doesn't decay out of range
+        // average distance from lava+waterfall around 8 ticks
+        // preform decays 1 heat every 2 ticks
+        final int min = Math.max(0, Math.min(1000, range[0] + paddingDecay + travelDecay));
+        final int max = Math.max(0, Math.min(1000, range[1] + paddingDecay + travelDecay));
+
+        final int actionsLeft_DeltaHeat = actionLeftInStage * stage.getHeatChange();
+
+        int estimatedDuration = 0;
+
+        final boolean goalInRange;
+        boolean overshoot = false;
+
+        SolveResult result = null;
+
+        // case actions are all cooling, heating is mirrored version
+
+        // goal: in-range // stage: heating
+        // overshoot goal
+        //  <----------|stop|<---------------- heat
+        // ------|min|----------goal-------|max|
+        //                      stage ---------------->
+
+        // goal: out-range // stage: heating
+        // undershoot min
+        // ...----------|stop|<--------------------- heat
+        // -goal---|min|---------------------|max|
+        //                      stage ----------------->
+
+        // goal: in-range // stage: cooling
+        // undershoot goal
+        //   <-------------------------|stop|<--------------- heat
+        // ------|min|----------goal-------|max|
+        //    <---------------- stage
+
+        // goal: out-range // stage: cooling
+        // overshoot max
+        //    <--------------------|stop|<--------------- heat
+        // --------|min|---------------------|max|----goal
+        //    <---------------- stage
+
+        if (isActionHeating)
+        {
+            int goal = min - actionsLeft_DeltaHeat;
+            goalInRange = goal >= min && goal <= max;
+
+            if (isStageHeating)
+            {
+
+                if (start <= max)
+                {
+                    overshoot = !goalInRange;
+
+                    if (!goalInRange)
+                    {
+                        goal = min;
+                    }
+
+                    result = heatingSolve(start, goal, overshoot, max, isFast);
+
+                    estimatedDuration = result.index;
+                }
+            }
+            else // cooling stage
+            {
+                // actionsLeft_DeltaHeat is negative here
+                if (start <= max)
+                {
+                    overshoot = goalInRange;
+
+                    if (!goalInRange)
+                    {
+                        goal = max;
+                    }
+
+                    result = heatingSolve(start, goal, overshoot, max, isFast);
+
+                    estimatedDuration = result.index;
+                }
+            }
+        }
+        else // cooling action
+        {
+            int goal = max - actionsLeft_DeltaHeat;
+            goalInRange = goal >= min && goal <= max;
+
+            if (isStageHeating)
+            {
+                if (start >= min)
+                {
+                    overshoot = goalInRange;
+
+                    if (!goalInRange)
+                    {
+                        goal = min;
+                    }
+
+                    result = coolingSolve(start, goal, overshoot, min, isFast);
+
+                    estimatedDuration = result.index;
+                }
+            }
+            else // cooling stage cooling action
+            {
+                if (start >= min)
+                {
+                    overshoot = !goalInRange;
+                    if (!goalInRange)
+                    {
+                        goal = max;
+                    }
+
+                    result = coolingSolve(start, goal, overshoot, min, isFast);
+
+                    estimatedDuration = result.index;
+                }
+            }
         }
 
-        return _dx1;
+        int dx0 = result == null ? 0 : result.dx0;
+        if (!isActionHeating)
+        {
+            dx0 *= -1;
+        }
+
+
+        return DurationResult.of(estimatedDuration, goalInRange, overshoot, start + dx0);
+    }
+
+    private static int solveTravelTicks(boolean isRunning, Stage stage, boolean isLava)
+    {
+        final int distance;
+        if (isLava)
+        {
+            distance = stage.getDistanceToLava();
+        }
+        else
+        {
+            distance = stage.getDistanceToWaterfall();
+        }
+
+        if (isRunning)
+        {
+            // for odd distances, like 7
+            // 7 / 2 = 3.5
+            // rounded to 4
+            return (int) Math.ceil((double) distance / 2);
+        }
+        else
+        {
+            return distance;
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/enums/Stage.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/giantsfoundry/enums/Stage.java
@@ -8,15 +8,17 @@ import net.runelite.api.coords.WorldPoint;
 @AllArgsConstructor
 public enum Stage
 {
-    TRIP_HAMMER("Hammer", Heat.HIGH, 20, -25, new WorldPoint(3367, 11497, 0)),
-    GRINDSTONE("Grind", Heat.MED, 10, 15, new WorldPoint(3364, 11492, 0)),
-    POLISHING_WHEEL("Polish", Heat.LOW, 10, -17, new WorldPoint(3365, 11485, 0));
+    TRIP_HAMMER("Hammer", Heat.HIGH, 20, -25, new WorldPoint(3367, 11497, 0), 4, 14),
+    GRINDSTONE("Grind", Heat.MED, 10, 15, new WorldPoint(3364, 11492, 0), 7, 19),
+    POLISHING_WHEEL("Polish", Heat.LOW, 10, -17, new WorldPoint(3365, 11485, 0), 12, 10);
 
     private final String name;
     private final Heat heat;
     private final int progressPerAction;
     private final int heatChange;
     private final WorldPoint location;
+    private final int distanceToLava;
+    private final int distanceToWaterfall;
 
     public boolean isHeating()
     {


### PR DESCRIPTION
Issue:
The plugin sometimes overshoots cooling/heating when doing longer actions

Fix:
 Updated the logic to use the newest Easy Giants Foundry -plugins calculations. These are much more accurate and should prevent situations where the plugin overshoots heating or cooling to the point where it needs to do the opposite action for a fix.

Todo/Issues:

Calculations for when to stop actions could use some improvement. It's a tick too late in some cases, but for general use this should be now perfect!

Sometimes when setting up a mould the interface bugs out and resets, which causes a nullpointer exception, the Discord has some discussion about the issue. To remedy this some null checking and retrying should be done around the mould setting. Maybe will take a look at some point, but probably wont have the time.

Plugin version to be corrected if the other PR gets merged first