### PR TITLE
fix(nmz): migrate to new query API and fix potion shop logic

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/nmz/NmzOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/nmz/NmzOverlay.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.nmz;
 
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -40,7 +41,17 @@ public class NmzOverlay extends OverlayPanel {
                     .left("Will drink absorption at: " + NmzScript.minAbsorption)
                     .build());
 
-        } catch(Exception ex) {
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Overload (barrel):")
+                    .right(String.valueOf(Microbot.getVarbitValue(VarbitID.NZONE_POTION_3)))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Absorb (barrel):")
+                    .right(String.valueOf(Microbot.getVarbitValue(VarbitID.NZONE_POTION_4)))
+                    .build());
+
+} catch(Exception ex) {
             System.out.println(ex.getMessage());
         }
         return super.render(graphics);

--- a/src/main/java/net/runelite/client/plugins/microbot/nmz/NmzPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/nmz/NmzPlugin.java
@@ -31,7 +31,7 @@ import java.awt.*;
 )
 @Slf4j
 public class NmzPlugin extends Plugin {
-    final static String version = "2.3.1";
+    final static String version = "2.4.0";
     @Inject
     private NmzConfig config;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/nmz/NmzScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/nmz/NmzScript.java
@@ -2,15 +2,27 @@ package net.runelite.client.plugins.microbot.nmz;
 
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.api.*;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.api.npc.Rs2NpcCache;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.Rs2InventorySetup;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.antiban.enums.Activity;
+import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity;
+import net.runelite.client.plugins.microbot.util.antiban.enums.PlayStyle;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
-import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
@@ -18,16 +30,12 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
 import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
 import net.runelite.client.plugins.microbot.util.security.Encryption;
-import net.runelite.client.plugins.microbot.util.security.Login;
 import net.runelite.client.plugins.microbot.util.security.LoginManager;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import javax.inject.Inject;
 import java.util.concurrent.TimeUnit;
-
-import static net.runelite.api.ObjectID.OVERLOAD_POTION;
-import static net.runelite.api.Varbits.NMZ_ABSORPTION;
 
 public class NmzScript extends Script {
 
@@ -49,6 +57,11 @@ public class NmzScript extends Script {
     private boolean initialized = false;
     private long lastCombatTime = 0;
 
+    @Inject
+    private Rs2TileObjectCache tileObjectCache;
+    @Inject
+    private Rs2NpcCache npcCache;
+
     public boolean canStartNmz() {
         return Rs2Inventory.count("overload (4)") == config.overloadPotionAmount() ||
                 (Rs2Inventory.hasItem("prayer potion") && config.togglePrayerPotions());
@@ -64,32 +77,49 @@ public class NmzScript extends Script {
     public boolean run() {
         prayerPotionScript = new PrayerPotionScript();
         Microbot.getSpecialAttackConfigs().setSpecialAttack(true);
+        Rs2Antiban.resetAntibanSettings();
+        Rs2Antiban.setActivity(Activity.GENERAL_COMBAT);
+        Rs2Antiban.setActivityIntensity(ActivityIntensity.LOW);
+        Rs2Antiban.setPlayStyle(PlayStyle.MODERATE);
+        Rs2Antiban.activateAntiban();
+        Rs2AntibanSettings.moveMouseOffScreen = true;
+        Rs2AntibanSettings.simulateMistakes = true;
+        Rs2AntibanSettings.naturalMouse = true;
+        Rs2AntibanSettings.usePlayStyle = true;
+        Rs2AntibanSettings.behavioralVariability = true;
+        Rs2AntibanSettings.nonLinearIntervals = true;
+        Rs2AntibanSettings.actionCooldownChance = 0.00;
+        Rs2AntibanSettings.moveMouseOffScreenChance = 1.00;
+
+
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!Microbot.isLoggedIn()) return;
                 if (!initialized) {
                     initialized = true;
-                    if (config.inventorySetupon()) {
-                        if (config.inventorySetup() != null) {
-                            var inventorySetup = new Rs2InventorySetup(config.inventorySetup(), mainScheduledFuture);
-                            if (!inventorySetup.doesInventoryMatch() || !inventorySetup.doesEquipmentMatch()) {
-                                Rs2Walker.walkTo(Rs2Bank.getNearestBank().getWorldPoint(), 20);
-                                if (!inventorySetup.loadEquipment() || !inventorySetup.loadInventory()) {
-                                    Microbot.log("Failed to load inventory setup");
-                                    Microbot.stopPlugin(plugin);
-                                    return;
+                    // Skip inventory setup and lobby walk if already inside the NMZ instance
+                    boolean isInNmzInstance = Microbot.getClient().getLocalPlayer().getWorldLocation().getY() > 4500;
+                    if (!isInNmzInstance) {
+                        if (config.inventorySetupon()) {
+                            if (config.inventorySetup() != null) {
+                                var inventorySetup = new Rs2InventorySetup(config.inventorySetup(), mainScheduledFuture);
+                                if (!inventorySetup.doesInventoryMatch() || !inventorySetup.doesEquipmentMatch()) {
+                                    Rs2Walker.walkTo(Rs2Bank.getNearestBank().getWorldPoint(), 20);
+                                    if (!inventorySetup.loadEquipment() || !inventorySetup.loadInventory()) {
+                                        Microbot.log("Failed to load inventory setup");
+                                        Microbot.stopPlugin(plugin);
+                                        return;
+                                    }
+                                    Rs2Bank.closeBank();
                                 }
-                                Rs2Bank.closeBank();
                             }
                         }
+                        Rs2Walker.walkTo(new WorldPoint(2609, 3114, 0), 5);
                     }
-                    Rs2Walker.walkTo(new WorldPoint(2609, 3114, 0), 5);
                 }
                 if (!super.run()) return;
-                Rs2Combat.enableAutoRetialiate();
-                if (Rs2Random.between(1, 50) == 1 && config.randomMouseMovements()) {
-                    Microbot.getMouse().click(Rs2Random.between(0, Microbot.getClient().getCanvasWidth()), Rs2Random.between(0, Microbot.getClient().getCanvasHeight()), true);
-                }
+                if (Rs2AntibanSettings.actionCooldownActive) return;
+                Rs2Combat.setAutoRetaliate(true);
                 boolean isOutsideNmz = isOutside();
                 useOverload = Microbot.getClient().getBoostedSkillLevel(Skill.RANGED) == Microbot.getClient().getRealSkillLevel(Skill.RANGED) && config.overloadPotionAmount() > 0;
                 if (isOutsideNmz) {
@@ -108,6 +138,8 @@ public class NmzScript extends Script {
     @Override
     public void shutdown() {
         super.shutdown();
+        Rs2Antiban.deactivateAntiban();
+        Rs2Antiban.resetAntibanSettings();
         initialized = false;
     }
 
@@ -117,7 +149,7 @@ public class NmzScript extends Script {
     }
 
     public void handleOutsideNmz() {
-        boolean hasStartedDream = Microbot.getVarbitValue(3946) > 0;
+        boolean hasStartedDream = Microbot.getVarbitValue(VarbitID.NZONE_PURCHASEDDREAM) > 0;
         if (config.togglePrayerPotions())
             Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MELEE, false);
         if (!hasStartedDream) {
@@ -125,12 +157,12 @@ public class NmzScript extends Script {
         } else {
             final String overload = "Overload (4)";
             final String absorption = "Absorption (4)";
-            storePotions(OVERLOAD_POTION, "overload", config.overloadPotionAmount());
-            storePotions(ObjectID.ABSORPTION_POTION, "absorption", config.absorptionPotionAmount());
+            storePotions(ObjectID.NZONE_BARREL_3, "overload", config.overloadPotionAmount());
+            storePotions(ObjectID.NZONE_BARREL_4, "absorption", config.absorptionPotionAmount());
             handleStore();
-            fetchOverloadPotions(OVERLOAD_POTION, overload, config.overloadPotionAmount());
+            fetchOverloadPotions(ObjectID.NZONE_BARREL_3, overload, config.overloadPotionAmount());
             if (Rs2Inventory.hasItemAmount(overload, config.overloadPotionAmount())) {
-                fetchPotions(ObjectID.ABSORPTION_POTION, absorption, config.absorptionPotionAmount());
+                fetchPotions(ObjectID.NZONE_BARREL_4, absorption, config.absorptionPotionAmount());
             }
         }
         if (canStartNmz()) {
@@ -144,11 +176,13 @@ public class NmzScript extends Script {
         if (Rs2Player.isInCombat()) {
             lastCombatTime = System.currentTimeMillis();
         }
+        Rs2Antiban.takeMicroBreakByChance();
         if (!Rs2Player.isInCombat() && System.currentTimeMillis() - lastCombatTime > 20000) {
-            Rs2NpcModel closestNpc = Microbot.getRs2NpcCache().query().nearest();
-
+            Rs2NpcModel closestNpc = npcCache.query().nearest();
             if (closestNpc != null) {
-                closestNpc.click("Attack");
+                if (closestNpc.click("Attack")) {
+                    Rs2Antiban.actionCooldown();
+                }
             }
         }
         prayerPotionScript.run();
@@ -171,7 +205,8 @@ public class NmzScript extends Script {
     public void startNmzDream() {
         // Set new center so that it is random for every time joining the dream
         center = new WorldPoint(Rs2Random.between(2270, 2276), Rs2Random.between(4693, 4696), 0);
-        Microbot.getRs2NpcCache().query().withId(NpcID.DOMINIC_ONION).interact("Dream");
+        Rs2NpcModel dominic = npcCache.query().withName("Dominic Onion").nearest();
+        if (dominic != null) dominic.click("Dream");
         sleepUntil(() -> Rs2Widget.hasWidget("Which dream would you like to experience?"));
         Rs2Widget.clickWidget("Previous:");
         sleepUntil(() -> Rs2Widget.hasWidget("Click here to continue"));
@@ -186,28 +221,34 @@ public class NmzScript extends Script {
     public boolean useOrbs() {
         boolean orbHasSpawned = false;
         if (config.useZapper()) {
-            orbHasSpawned = interactWithObject(ObjectID.ZAPPER_26256);
+            orbHasSpawned = interactWithObject(ObjectID.NZONE_POWERUP_ZAPPER);
         }
         if (config.useReccurentDamage()) {
-            orbHasSpawned = interactWithObject(ObjectID.RECURRENT_DAMAGE);
+            orbHasSpawned = interactWithObject(ObjectID.NZONE_POWERUP_DAMAGEMULTIPLIER);
         }
 
         if (config.usePowerSurge()) {
-            orbHasSpawned = interactWithObject(ObjectID.POWER_SURGE);
+            orbHasSpawned = interactWithObject(ObjectID.NZONE_POWERUP_SPECIALATTACK);
         }
 
         return orbHasSpawned;
     }
 
     public boolean interactWithObject(int objectId) {
-        var rs2GameObject = Microbot.getRs2TileObjectCache().query().withId(objectId).nearest();
-        if (rs2GameObject != null) {
-            Rs2Walker.walkFastCanvas(rs2GameObject.getWorldLocation());
-            sleepUntil(() -> {
-                WorldPoint loc = Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation());
-                return loc != null && loc.distanceTo(rs2GameObject.getWorldLocation()) < 5;
-            });
-            rs2GameObject.click();
+        Rs2TileObjectModel obj = tileObjectCache.query().withId(objectId).nearest();
+        if (obj != null) {
+            sleep(1000, 15000);
+            WorldPoint playerLoc = Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation());
+            if (playerLoc != null && playerLoc.distanceTo(obj.getWorldLocation()) >= 15) {
+                Rs2Walker.walkFastLocal(obj.getLocalLocation());
+                sleepUntil(() -> {
+                    WorldPoint loc = Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation());
+                    return loc != null && loc.distanceTo(obj.getWorldLocation()) < 15;
+                }, 10000);
+            }
+            obj.click();
+            // Wait for the power-up to despawn to prevent repeated clicks on the same orb
+            sleepUntil(() -> tileObjectCache.query().withId(objectId).nearest() == null, 3000);
             return true;
         }
         return false;
@@ -220,13 +261,17 @@ public class NmzScript extends Script {
 
         int neededAmount = requiredAmount - currentAmount;
 
-        Microbot.getRs2TileObjectCache().query().withId(objectId).interact("Take");
+        Rs2TileObjectModel obj = tileObjectCache.query().withId(objectId).nearest();
+        if (obj == null) return;
+        obj.click("Take");
         String widgetText = "How many doses of ";
         sleepUntil(() -> Rs2Widget.hasWidget(widgetText));
 
         if (Rs2Widget.hasWidget(widgetText)) {
             // Each potion has 4 doses, so request the correct number of doses
+            sleep(Rs2Random.between(400, 900));
             Rs2Keyboard.typeString(Integer.toString(neededAmount * 4));
+            sleep(Rs2Random.between(200, 500));
             Rs2Keyboard.enter();
             sleepUntil(() -> Rs2Inventory.count(itemName) == requiredAmount);
         }
@@ -244,10 +289,12 @@ public class NmzScript extends Script {
                 && (!hasOverloadPotions || currentRangedLevel != realRangedLevel)) {
             maxHealth = 1;
 
-            if (Rs2Inventory.hasItem(ItemID.LOCATOR_ORB)) {
-                Rs2Inventory.interact(ItemID.LOCATOR_ORB, "feel");
-            } else if (Rs2Inventory.hasItem(ItemID.DWARVEN_ROCK_CAKE_7510)) {
-                Rs2Inventory.interact(ItemID.DWARVEN_ROCK_CAKE_7510, "guzzle");
+            if (Rs2Inventory.hasItem(ItemID.DS2_ORB)) {
+                Rs2Inventory.interact(ItemID.DS2_ORB, "feel");
+                Rs2Antiban.actionCooldown();
+            } else if (Rs2Inventory.hasItem(ItemID.HUNDRED_DWARF_COOL_ROCKCAKE)) {
+                Rs2Inventory.interact(ItemID.HUNDRED_DWARF_COOL_ROCKCAKE, "guzzle");
+                Rs2Antiban.actionCooldown();
             }
 
             if (currentHP == 1) {
@@ -276,7 +323,7 @@ public class NmzScript extends Script {
     }
 
     public void useAbsorptionPotion() {
-        if (Microbot.getVarbitValue(NMZ_ABSORPTION) < minAbsorption && Rs2Inventory.hasItem("absorption")) {
+        if (Microbot.getVarbitValue(VarbitID.NZONE_ABSORB_POTION_EFFECTS) < minAbsorption && Rs2Inventory.hasItem("absorption")) {
             for (int i = 0; i < Rs2Random.between(4, 8); i++) {
                 Rs2Inventory.interact(x -> x.getName().toLowerCase().contains("absorption"), "drink");
                 sleep(600, 1000);
@@ -289,11 +336,15 @@ public class NmzScript extends Script {
         if (Rs2Inventory.count(itemName) == requiredAmount) return;
         if (Rs2Inventory.get(itemName) == null) return;
 
-        Microbot.getRs2TileObjectCache().query().withId(objectId).interact("Store");
+        Rs2TileObjectModel obj = tileObjectCache.query().withId(objectId).nearest();
+        if (obj == null) return;
+        obj.click("Store");
         String storeWidgetText = "Store all your ";
         sleepUntil(() -> Rs2Widget.hasWidget(storeWidgetText));
         if (Rs2Widget.hasWidget(storeWidgetText)) {
+            sleep(Rs2Random.between(400, 900));
             Rs2Keyboard.typeString("1");
+            sleep(Rs2Random.between(200, 500));
             Rs2Keyboard.enter();
             sleepUntil(() -> !Rs2Inventory.hasItem(objectId));
             Rs2Inventory.dropAll(itemName);
@@ -303,53 +354,65 @@ public class NmzScript extends Script {
     private void fetchPotions(int objectId, String itemName, int requiredAmount) {
         if (Rs2Inventory.count(itemName) == requiredAmount) return;
 
-        Microbot.getRs2TileObjectCache().query().withId(objectId).interact("Take");
+        Rs2TileObjectModel obj = tileObjectCache.query().withId(objectId).nearest();
+        if (obj == null) return;
+        obj.click("Take");
         String widgetText = "How many doses of ";
         sleepUntil(() -> Rs2Widget.hasWidget(widgetText));
         if (Rs2Widget.hasWidget(widgetText)) {
+            sleep(Rs2Random.between(400, 900));
             Rs2Keyboard.typeString(Integer.toString(requiredAmount * 4));
+            sleep(Rs2Random.between(200, 500));
             Rs2Keyboard.enter();
             sleepUntil(() -> Rs2Inventory.count(itemName) == requiredAmount);
         }
     }
 
     public void consumeEmptyVial() {
-        final int EMPTY_VIAL = 26291;
         if (Microbot.getClientThread().runOnClientThreadOptional(() ->
                 Rs2Widget.getWidget(129, 6) == null || Rs2Widget.getWidget(129, 6).isHidden())
                 .orElse(false)) {
-            Microbot.getRs2TileObjectCache().query().withId(EMPTY_VIAL).interact("drink");
+            Rs2TileObjectModel vial = tileObjectCache.query().withId(ObjectID.NZONE_LOBBY_VIAL).nearest();
+            if (vial != null) vial.click("drink");
         }
-        sleep(2000,4000);
+        sleep(2000, 4000);
         Widget widget = Rs2Widget.getWidget(129, 6);
         if (!Microbot.getClientThread().runOnClientThreadOptional(widget::isHidden).orElse(false)) {
             Rs2Widget.clickWidget(widget.getId());
             sleep(300);
             Rs2Widget.clickWidget(widget.getId());
         }
-        sleep(2000,4000);
+        sleep(2000, 4000);
     }
 
     public void handleStore() {
         if (canStartNmz()) return;
-        int varbitOverload = 3953;
-        int varbitAbsorption = 3954;
-        int overloadAmt = Microbot.getVarbitValue(varbitOverload);
-        int absorptionAmt = Microbot.getVarbitValue(varbitAbsorption);
-        int nmzPoints = Microbot.getVarbitPlayerValue(VarPlayer.NMZ_REWARD_POINTS);
+        int overloadAmt = Microbot.getVarbitValue(VarbitID.NZONE_POTION_3);
+        int absorptionAmt = Microbot.getVarbitValue(VarbitID.NZONE_POTION_4);
 
-        if (absorptionAmt > config.absorptionPotionAmount() * 4 && overloadAmt > config.overloadPotionAmount() * 4)
+        // Varbits are in doses; config is in 4-dose potions
+        int overloadDosesNeeded = Math.max(0, config.overloadPotionAmount() * 4 - overloadAmt);
+        int absorptionDosesNeeded = Math.max(0, config.absorptionPotionAmount() * 4 - absorptionAmt);
+
+        if (overloadDosesNeeded == 0 && absorptionDosesNeeded == 0) return;
+
+        // Each shop purchase gives one 4-dose potion (ceiling division)
+        int overloadToBuy = (overloadDosesNeeded + 3) / 4;
+        int absorptionToBuy = (absorptionDosesNeeded + 3) / 4;
+
+        // NMZ reward shop costs: Overload 1,500 pts / Absorption 1,000 pts per 4-dose potion
+        int totalCost = overloadToBuy * 1500 + absorptionToBuy * 1000;
+        int nmzPoints = Microbot.getVarbitPlayerValue(VarPlayerID.NZONE_REWARDPOINTS);
+
+        if (nmzPoints < totalCost) {
+            Microbot.showMessage("BOT SHUTDOWN: Not enough points to buy potions (have " + nmzPoints + ", need " + totalCost + ")");
+            Microbot.stopPlugin(plugin);
             return;
-
-        if (!Rs2Inventory.isFull()) {
-            if ((absorptionAmt < (config.absorptionPotionAmount() * 4) || overloadAmt < config.overloadPotionAmount() * 4) && nmzPoints < 100000) {
-                Microbot.showMessage("BOT SHUTDOWN: Not enough points to buy potions");
-                Microbot.stopPlugin(plugin);
-                return;
-            }
         }
 
-        Microbot.getRs2TileObjectCache().query().withId(26273).interact();
+        Rs2TileObjectModel chest = tileObjectCache.query().withId(ObjectID.NZONE_LOBBY_CHEST).nearest();
+        if (chest == null) return;
+        chest.click();
         sleepUntil(() -> Rs2Widget.isWidgetVisible(13500418) || Rs2Bank.isBankPinWidgetVisible(), 10000);
         if (Rs2Bank.isBankPinWidgetVisible()) {
             try {
@@ -362,20 +425,26 @@ public class NmzScript extends Script {
 
         Widget benefitsBtn = Rs2Widget.getWidget(13500418);
         if (benefitsBtn == null) return;
-        boolean notSelected = benefitsBtn.getSpriteId() != 813;
-        if (notSelected) {
+        if (benefitsBtn.getSpriteId() != 813) {
             Rs2Widget.clickWidgetFast(benefitsBtn, 4, 4);
+            sleepUntil(() -> {
+                Widget btn = Rs2Widget.getWidget(13500418);
+                return btn != null && btn.getSpriteId() == 813;
+            }, 3000);
         }
-        int count = 0;
-        while (count < Rs2Random.between(3, 5)) {
+
+        for (int i = 0; i < overloadToBuy; i++) {
             Widget nmzRewardShop = Rs2Widget.getWidget(206, 6);
             if (nmzRewardShop == null) break;
-            Widget overload = nmzRewardShop.getChild(6);
-            Rs2Widget.clickWidgetFast(overload, 6, 4);
-            Widget absorption = nmzRewardShop.getChild(9);
-            Rs2Widget.clickWidgetFast(absorption, 9, 4);
-            sleep(600, 1200);
-            count++;
+            Rs2Widget.clickWidgetFast(nmzRewardShop.getChild(6), 6, 4);
+            sleep(600, 1000);
+        }
+
+        for (int i = 0; i < absorptionToBuy; i++) {
+            Widget nmzRewardShop = Rs2Widget.getWidget(206, 6);
+            if (nmzRewardShop == null) break;
+            Rs2Widget.clickWidgetFast(nmzRewardShop.getChild(9), 9, 4);
+            sleep(600, 1000);
         }
     }
 


### PR DESCRIPTION
## Summary
- Migrate `NmzScript` from deprecated static `Rs2GameObject`/`Rs2Npc` utils to injected `Rs2TileObjectCache`/`Rs2NpcCache` queryable API
- Replace deprecated `net.runelite.api.*` constants (`ObjectID`, `ItemID`, `Varbits`, `VarPlayer`) with `net.runelite.api.gameval.*` equivalents
- Fix potion shop logic: exact dose calculation, per-potion-type buying, sufficient-points check before opening shop
- Skip inventory setup + lobby walk when already inside NMZ instance
- Add random delays around keyboard input for widget interactions
- Add power-up despawn wait in `interactWithObject` to prevent repeated clicks