### PR TITLE
Fix mahogany tree payment requirement in FarmTreeRunScript

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/HardTreeEnums.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/HardTreeEnums.java
@@ -10,7 +10,7 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 @RequiredArgsConstructor
 public enum HardTreeEnums {
     TEAK("Teak sapling", ItemID.PLANTPOT_TEAK_SAPLING, ItemID.LIMPWURT_ROOT, 15,75),
-    MAHOGANY("Mahogany sapling", ItemID.PLANTPOT_MAHOGANY_SAPLING, ItemID.LIMPWURT_ROOT, 15,75);
+    MAHOGANY("Mahogany sapling", ItemID.PLANTPOT_MAHOGANY_SAPLING, ItemID.YANILLIAN_HOPS, 25,75);
 
 
     private final String name;


### PR DESCRIPTION
## Description
Fixes incorrect payment item and amount required for protecting mahogany trees in the Farm Tree Run plugin.

## Changes
- Updated `HardTreeEnums.java` mahogany enum to use Yanillian Hops (25) instead of Limpwurt Root (15) for tree protection payment

## Details
Mahogany trees in OSRS require 25 Yanillian Hops to protect, not 15 Limpwurt Roots. This fix corrects the payment requirement to match the actual in-game requirements.

**Before:**
```java
MAHOGANY("Mahogany sapling", ItemID.PLANTPOT_MAHOGANY_SAPLING, ItemID.LIMPWURT_ROOT, 15, 75)
```
**After:**
```java
MAHOGANY("Mahogany sapling", ItemID.PLANTPOT_MAHOGANY_SAPLING, ItemID.YANILLIAN_HOPS, 25, 75)
```

See Wiki: https://oldschool.runescape.wiki/w/Yew_sapling