### PR TITLE
fix(FarmTreeRun): use Yanillian hops for Mahogany tree protection

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunPlugin.java
@@ -30,7 +30,7 @@ import java.awt.*;
 )
 @Slf4j
 public class FarmTreeRunPlugin extends Plugin {
-    public static final String version = "1.1.1";
+    public static final String version = "1.1.2";
     @Inject
     private FarmTreeRunConfig config;
     @Provides

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/HardTreeEnums.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/HardTreeEnums.java
@@ -10,7 +10,7 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 @RequiredArgsConstructor
 public enum HardTreeEnums {
     TEAK("Teak sapling", ItemID.PLANTPOT_TEAK_SAPLING, ItemID.LIMPWURT_ROOT, 15,75),
-    MAHOGANY("Mahogany sapling", ItemID.PLANTPOT_MAHOGANY_SAPLING, ItemID.LIMPWURT_ROOT, 15,75);
+    MAHOGANY("Mahogany sapling", ItemID.PLANTPOT_MAHOGANY_SAPLING, ItemID.YANILLIAN_HOPS, 25,75);
 
 
     private final String name;


### PR DESCRIPTION
## Summary
Mahogany tree protection was a copy-paste of Teak's Limpwurt root payment. The correct payment for protecting a Mahogany tree is **25 Yanillian hops** — this PR updates the `MAHOGANY` entry in `HardTreeEnums` accordingly.

Bumps plugin version to 1.1.3 (sequenced to merge after #386).

Supersedes #385 (that PR targeted `main` from `mdp18:main`, so the diff showed unrelated commits).

## Test plan
- [ ] With Mahogany selected and "Protect Hard trees" enabled, verify the script withdraws 25 Yanillian hops per planted Mahogany patch rather than limpwurt roots.