### PR TITLE
feat(leftclickcast): Left-Click Cast plugin

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
@@ -34,6 +34,7 @@ public final class PluginConstants
     public static final String NATE = "<html>[<font color=orange>N</font>] ";
     public static final String SYN = "<html>[<font color=orange>Syn</font>] ";
     public static final String BIGL = "<html>[<font color=#b8f704>BL</font>] ";
+    public static final String PERT = "<html>[<font color=#FFFF00>P</font>] ";
 
     public static final boolean DEFAULT_ENABLED = false;
     public static final boolean IS_EXTERNAL = true; //test

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
@@ -118,11 +118,23 @@ public interface LeftClickCastConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "enabledToggleHotkey",
+		name = "Enable/Disable Hotkey",
+		description = "Hotkey that toggles the plugin on and off.",
+		section = hotkeysSection,
+		position = 0
+	)
+	default Keybind enabledToggleHotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
 		keyName = "slot1Hotkey",
 		name = "Slot 1 Hotkey",
 		description = "Hotkey that activates slot 1.",
 		section = hotkeysSection,
-		position = 0
+		position = 1
 	)
 	default Keybind slot1Hotkey()
 	{
@@ -134,7 +146,7 @@ public interface LeftClickCastConfig extends Config
 		name = "Slot 2 Hotkey",
 		description = "Hotkey that activates slot 2.",
 		section = hotkeysSection,
-		position = 1
+		position = 2
 	)
 	default Keybind slot2Hotkey()
 	{
@@ -146,7 +158,7 @@ public interface LeftClickCastConfig extends Config
 		name = "Slot 3 Hotkey",
 		description = "Hotkey that activates slot 3.",
 		section = hotkeysSection,
-		position = 2
+		position = 3
 	)
 	default Keybind slot3Hotkey()
 	{
@@ -158,7 +170,7 @@ public interface LeftClickCastConfig extends Config
 		name = "Slot 4 Hotkey",
 		description = "Hotkey that activates slot 4.",
 		section = hotkeysSection,
-		position = 3
+		position = 4
 	)
 	default Keybind slot4Hotkey()
 	{
@@ -170,7 +182,7 @@ public interface LeftClickCastConfig extends Config
 		name = "Slot 5 Hotkey",
 		description = "Hotkey that activates slot 5.",
 		section = hotkeysSection,
-		position = 4
+		position = 5
 	)
 	default Keybind slot5Hotkey()
 	{
@@ -178,13 +190,13 @@ public interface LeftClickCastConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "activeSlotChatMessage",
-		name = "Chat feedback on slot change",
-		description = "Post a game chat message when a hotkey switches the active slot.",
+		keyName = "chatFeedback",
+		name = "Chat feedback",
+		description = "Post a game chat message on plugin events (active slot change, enable/disable toggle).",
 		section = hotkeysSection,
-		position = 5
+		position = 6
 	)
-	default boolean activeSlotChatMessage()
+	default boolean chatFeedback()
 	{
 		return true;
 	}

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
@@ -3,6 +3,8 @@ package net.runelite.client.plugins.microbot.leftclickcast;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("leftclickcast")
 public interface LeftClickCastConfig extends Config
@@ -18,10 +20,11 @@ public interface LeftClickCastConfig extends Config
 		return true;
 	}
 
+	// Retained so existing stored config is not invalidated. Read once at startUp for migration into slot1Spell.
 	@ConfigItem(
 		keyName = "spell",
 		name = "Spell",
-		description = "The spell cast when left-clicking an attackable NPC",
+		description = "Legacy single-spell setting — migrated into Slot 1 on startup.",
 		position = 1
 	)
 	default PertTargetSpell spell()
@@ -36,6 +39,152 @@ public interface LeftClickCastConfig extends Config
 		position = 2
 	)
 	default boolean requireMagicWeapon()
+	{
+		return true;
+	}
+
+	@ConfigSection(
+		name = "Spell Slots",
+		description = "Up to five spells that can be bound to hotkeys for mid-fight swapping.",
+		position = 10
+	)
+	String spellSlotsSection = "spellSlots";
+
+	@ConfigSection(
+		name = "Hotkeys",
+		description = "Hotkey bindings that switch the active spell slot.",
+		position = 11
+	)
+	String hotkeysSection = "hotkeys";
+
+	@ConfigItem(
+		keyName = "slot1Spell",
+		name = "Slot 1 Spell",
+		description = "Spell for slot 1 (the startup-active slot).",
+		section = spellSlotsSection,
+		position = 0
+	)
+	default PertTargetSpell slot1Spell()
+	{
+		return PertTargetSpell.FIRE_STRIKE;
+	}
+
+	@ConfigItem(
+		keyName = "slot2Spell",
+		name = "Slot 2 Spell",
+		description = "Spell for slot 2.",
+		section = spellSlotsSection,
+		position = 1
+	)
+	default PertTargetSpell slot2Spell()
+	{
+		return PertTargetSpell.FIRE_STRIKE;
+	}
+
+	@ConfigItem(
+		keyName = "slot3Spell",
+		name = "Slot 3 Spell",
+		description = "Spell for slot 3.",
+		section = spellSlotsSection,
+		position = 2
+	)
+	default PertTargetSpell slot3Spell()
+	{
+		return PertTargetSpell.FIRE_STRIKE;
+	}
+
+	@ConfigItem(
+		keyName = "slot4Spell",
+		name = "Slot 4 Spell",
+		description = "Spell for slot 4.",
+		section = spellSlotsSection,
+		position = 3
+	)
+	default PertTargetSpell slot4Spell()
+	{
+		return PertTargetSpell.FIRE_STRIKE;
+	}
+
+	@ConfigItem(
+		keyName = "slot5Spell",
+		name = "Slot 5 Spell",
+		description = "Spell for slot 5.",
+		section = spellSlotsSection,
+		position = 4
+	)
+	default PertTargetSpell slot5Spell()
+	{
+		return PertTargetSpell.FIRE_STRIKE;
+	}
+
+	@ConfigItem(
+		keyName = "slot1Hotkey",
+		name = "Slot 1 Hotkey",
+		description = "Hotkey that activates slot 1.",
+		section = hotkeysSection,
+		position = 0
+	)
+	default Keybind slot1Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+		keyName = "slot2Hotkey",
+		name = "Slot 2 Hotkey",
+		description = "Hotkey that activates slot 2.",
+		section = hotkeysSection,
+		position = 1
+	)
+	default Keybind slot2Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+		keyName = "slot3Hotkey",
+		name = "Slot 3 Hotkey",
+		description = "Hotkey that activates slot 3.",
+		section = hotkeysSection,
+		position = 2
+	)
+	default Keybind slot3Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+		keyName = "slot4Hotkey",
+		name = "Slot 4 Hotkey",
+		description = "Hotkey that activates slot 4.",
+		section = hotkeysSection,
+		position = 3
+	)
+	default Keybind slot4Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+		keyName = "slot5Hotkey",
+		name = "Slot 5 Hotkey",
+		description = "Hotkey that activates slot 5.",
+		section = hotkeysSection,
+		position = 4
+	)
+	default Keybind slot5Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+		keyName = "activeSlotChatMessage",
+		name = "Chat feedback on slot change",
+		description = "Post a game chat message when a hotkey switches the active slot.",
+		section = hotkeysSection,
+		position = 5
+	)
+	default boolean activeSlotChatMessage()
 	{
 		return true;
 	}

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.leftclickcast;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("leftclickcast")
+public interface LeftClickCastConfig extends Config
+{
+	@ConfigItem(
+		keyName = "enabled",
+		name = "Enabled",
+		description = "Replace the left-click Attack option on NPCs with Cast Spell",
+		position = 0
+	)
+	default boolean enabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "spell",
+		name = "Spell",
+		description = "The spell cast when left-clicking an attackable NPC",
+		position = 1
+	)
+	default PertTargetSpell spell()
+	{
+		return PertTargetSpell.FIRE_STRIKE;
+	}
+
+	@ConfigItem(
+		keyName = "requireMagicWeapon",
+		name = "Require magic weapon",
+		description = "When enabled, the Cast entry is only inserted while a staff, bladed staff, powered staff, or powered wand is equipped. Disable to cast regardless of equipped weapon.",
+		position = 2
+	)
+	default boolean requireMagicWeapon()
+	{
+		return true;
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -4,6 +4,7 @@ import com.google.inject.Provides;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
@@ -16,13 +17,18 @@ import net.runelite.api.Player;
 import net.runelite.api.StructComposition;
 import net.runelite.api.events.PostMenuSort;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.Keybind;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.PluginConstants;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.util.HotkeyListener;
 
 @PluginDescriptor(
 	name = PluginConstants.PERT + "Left-Click Cast",
@@ -36,7 +42,9 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 )
 public class LeftClickCastPlugin extends Plugin
 {
-	static final String version = "1.0.0";
+	static final String version = "1.1.0";
+
+	private static final int SLOT_COUNT = 5;
 
 	@Inject
 	private Client client;
@@ -44,10 +52,58 @@ public class LeftClickCastPlugin extends Plugin
 	@Inject
 	private LeftClickCastConfig config;
 
+	@Inject
+	private KeyManager keyManager;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	@Inject
+	private ConfigManager configManager;
+
+	private volatile int activeSlot = 0;
+
+	private final HotkeyListener[] hotkeyListeners = new HotkeyListener[SLOT_COUNT];
+
 	@Provides
 	LeftClickCastConfig provideConfig(ConfigManager configManager)
 	{
 		return configManager.getConfig(LeftClickCastConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		activeSlot = 0;
+		for (int i = 0; i < SLOT_COUNT; i++)
+		{
+			final int slotIndex = i;
+			HotkeyListener listener = new HotkeyListener(() -> slotHotkeyFor(slotIndex))
+			{
+				@Override
+				public void hotkeyPressed()
+				{
+					onSlotHotkey(slotIndex);
+				}
+			};
+			hotkeyListeners[i] = listener;
+			keyManager.registerKeyListener(listener);
+		}
+		migrateLegacySpellKey();
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		for (int i = 0; i < hotkeyListeners.length; i++)
+		{
+			HotkeyListener listener = hotkeyListeners[i];
+			if (listener != null)
+			{
+				keyManager.unregisterKeyListener(listener);
+				hotkeyListeners[i] = null;
+			}
+		}
 	}
 
 	@Subscribe
@@ -62,7 +118,7 @@ public class LeftClickCastPlugin extends Plugin
 		{
 			return;
 		}
-		PertTargetSpell spell = config.spell();
+		PertTargetSpell spell = slotSpellFor(activeSlot);
 		if (spell == null)
 		{
 			return;
@@ -108,11 +164,12 @@ public class LeftClickCastPlugin extends Plugin
 		final Actor dispatchTarget = targetActor instanceof NPC
 			? new Rs2NpcModel((NPC) targetActor)
 			: (Player) targetActor;
-		attack.setOption("Cast " + spell.getDisplayName());
+		final PertTargetSpell dispatchSpell = spell;
+		attack.setOption("Cast " + dispatchSpell.getDisplayName());
 		attack.setType(MenuAction.RUNELITE);
 		// Rs2Magic.castOn uses sleepUntil, which is a no-op on the client thread — dispatch off-thread.
 		attack.onClick(e -> CompletableFuture.runAsync(
-			() -> Rs2Magic.castOn(spell.getMagicAction(), dispatchTarget)));
+			() -> Rs2Magic.castOn(dispatchSpell.getMagicAction(), dispatchTarget)));
 
 		// Move to the tail of the array — that slot is the left-click action in RuneLite's menu model.
 		if (attackIdx != entries.length - 1)
@@ -120,6 +177,82 @@ public class LeftClickCastPlugin extends Plugin
 			entries[attackIdx] = entries[entries.length - 1];
 			entries[entries.length - 1] = attack;
 			menu.setMenuEntries(entries);
+		}
+	}
+
+	private Keybind slotHotkeyFor(int index)
+	{
+		switch (index)
+		{
+			case 0:
+				return config.slot1Hotkey();
+			case 1:
+				return config.slot2Hotkey();
+			case 2:
+				return config.slot3Hotkey();
+			case 3:
+				return config.slot4Hotkey();
+			case 4:
+				return config.slot5Hotkey();
+			default:
+				return Keybind.NOT_SET;
+		}
+	}
+
+	private PertTargetSpell slotSpellFor(int index)
+	{
+		switch (index)
+		{
+			case 0:
+				return config.slot1Spell();
+			case 1:
+				return config.slot2Spell();
+			case 2:
+				return config.slot3Spell();
+			case 3:
+				return config.slot4Spell();
+			case 4:
+				return config.slot5Spell();
+			default:
+				return config.slot1Spell();
+		}
+	}
+
+	private void onSlotHotkey(int index)
+	{
+		activeSlot = index;
+		if (config.activeSlotChatMessage())
+		{
+			PertTargetSpell spell = slotSpellFor(index);
+			String display = spell != null ? spell.getDisplayName() : "(no spell)";
+			chatMessageManager.queue(QueuedMessage.builder()
+				.type(ChatMessageType.GAMEMESSAGE)
+				.value("Left-Click Cast: now casting " + display)
+				.build());
+		}
+	}
+
+	// Best-effort: if the user had previously set the legacy `spell` key to a non-default value and
+	// slot1Spell is still at its default, copy the legacy value into slot1Spell so existing configs keep working.
+	private void migrateLegacySpellKey()
+	{
+		try
+		{
+			PertTargetSpell legacy = configManager.getConfiguration(
+				"leftclickcast", "spell", PertTargetSpell.class);
+			if (legacy == null || legacy == PertTargetSpell.FIRE_STRIKE)
+			{
+				return;
+			}
+			if (config.slot1Spell() != PertTargetSpell.FIRE_STRIKE)
+			{
+				return;
+			}
+			configManager.setConfiguration("leftclickcast", "slot1Spell", legacy);
+		}
+		catch (Exception ignored)
+		{
+			// Migration is best-effort; ignore any deserialization or storage errors.
 		}
 	}
 

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -1,15 +1,18 @@
 package net.runelite.client.plugins.microbot.leftclickcast;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.EnumComposition;
+import net.runelite.api.EnumID;
+import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.Menu;
 import net.runelite.api.NPC;
-import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.ParamID;
+import net.runelite.api.StructComposition;
+import net.runelite.api.events.PostMenuSort;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -29,14 +32,9 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 	enabledByDefault = PluginConstants.DEFAULT_ENABLED,
 	isExternal = PluginConstants.IS_EXTERNAL
 )
-@Slf4j
 public class LeftClickCastPlugin extends Plugin
 {
 	static final String version = "1.0.0";
-
-	// Magic WeaponType ordinals against varbit 357 (EQUIPPED_WEAPON_TYPE).
-	// Sourced from the RuneLite core WeaponType enum: STAFF, BLADED_STAFF, POWERED_STAFF, POWERED_WAND.
-	private static final Set<Integer> MAGIC_WEAPON_TYPES = ImmutableSet.of(22, 23, 26, 27);
 
 	@Inject
 	private Client client;
@@ -51,47 +49,94 @@ public class LeftClickCastPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onMenuEntryAdded(MenuEntryAdded event)
+	public void onPostMenuSort(PostMenuSort event)
 	{
+		// Don't mutate while the right-click menu is open — entries are frozen at open-time.
+		if (client.isMenuOpen())
+		{
+			return;
+		}
 		if (!config.enabled())
 		{
 			return;
 		}
-
 		PertTargetSpell spell = config.spell();
 		if (spell == null)
 		{
 			return;
 		}
-
-		if (!"Attack".equals(event.getOption()))
-		{
-			return;
-		}
-
-		MenuEntry entry = event.getMenuEntry();
-		NPC npc = entry.getNpc();
-		if (npc == null)
-		{
-			return;
-		}
-
 		if (config.requireMagicWeapon() && !isMagicWeaponEquipped())
 		{
 			return;
 		}
 
-		client.getMenu().createMenuEntry(-1)
-			.setOption("Cast")
-			.setTarget("<col=00ff00>" + spell.getDisplayName() + "</col> " + event.getTarget())
-			.setType(net.runelite.api.MenuAction.RUNELITE)
-			// Rs2Magic.castOn uses sleepUntil, which is a no-op on the client thread — dispatch off-thread.
-			.onClick(e -> CompletableFuture.runAsync(
-				() -> Rs2Magic.castOn(spell.getMagicAction(), new Rs2NpcModel(npc))));
+		Menu menu = client.getMenu();
+		MenuEntry[] entries = menu.getMenuEntries();
+
+		// Find the top-most NPC Attack entry (the game's already-sorted left-click candidate).
+		int attackIdx = -1;
+		NPC npc = null;
+		for (int i = entries.length - 1; i >= 0; i--)
+		{
+			MenuEntry e = entries[i];
+			if ("Attack".equals(e.getOption()) && e.getNpc() != null)
+			{
+				attackIdx = i;
+				npc = e.getNpc();
+				break;
+			}
+		}
+		if (attackIdx < 0)
+		{
+			return;
+		}
+
+		MenuEntry attack = entries[attackIdx];
+		final NPC target = npc;
+		attack.setOption("Cast " + spell.getDisplayName());
+		attack.setType(MenuAction.RUNELITE);
+		// Rs2Magic.castOn uses sleepUntil, which is a no-op on the client thread — dispatch off-thread.
+		attack.onClick(e -> CompletableFuture.runAsync(
+			() -> Rs2Magic.castOn(spell.getMagicAction(), new Rs2NpcModel(target))));
+
+		// Move to the tail of the array — that slot is the left-click action in RuneLite's menu model.
+		if (attackIdx != entries.length - 1)
+		{
+			entries[attackIdx] = entries[entries.length - 1];
+			entries[entries.length - 1] = attack;
+			menu.setMenuEntries(entries);
+		}
 	}
 
+	// A weapon counts as "magic" when its style struct exposes Casting or Defensive Casting.
+	// Mirrors the core AttackStylesPlugin logic (EnumID.WEAPON_STYLES + ParamID.ATTACK_STYLE_NAME).
 	private boolean isMagicWeaponEquipped()
 	{
-		return MAGIC_WEAPON_TYPES.contains(client.getVarbitValue(VarbitID.COMBAT_WEAPON_CATEGORY));
+		int weaponType = client.getVarbitValue(VarbitID.COMBAT_WEAPON_CATEGORY);
+		EnumComposition weaponStyles = client.getEnum(EnumID.WEAPON_STYLES);
+		if (weaponStyles == null)
+		{
+			return false;
+		}
+		int styleEnumId = weaponStyles.getIntValue(weaponType);
+		if (styleEnumId == -1)
+		{
+			return false;
+		}
+		int[] styleStructs = client.getEnum(styleEnumId).getIntVals();
+		for (int structId : styleStructs)
+		{
+			StructComposition sc = client.getStructComposition(structId);
+			if (sc == null)
+			{
+				continue;
+			}
+			String name = sc.getStringValue(ParamID.ATTACK_STYLE_NAME);
+			if ("Casting".equalsIgnoreCase(name) || "Defensive Casting".equalsIgnoreCase(name))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -1,0 +1,97 @@
+package net.runelite.client.plugins.microbot.leftclickcast;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Provides;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.NPC;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+
+@PluginDescriptor(
+	name = PluginConstants.PERT + "Left-Click Cast",
+	description = "Replaces left-click Attack on NPCs with a preconfigured Cast Spell action.",
+	tags = {"magic", "combat", "spell", "left-click", "cast", "pvm", "pvp"},
+	authors = {"Pert"},
+	version = LeftClickCastPlugin.version,
+	minClientVersion = "2.0.13",
+	enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+	isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class LeftClickCastPlugin extends Plugin
+{
+	static final String version = "1.0.0";
+
+	// Magic WeaponType ordinals against varbit 357 (EQUIPPED_WEAPON_TYPE).
+	// Sourced from the RuneLite core WeaponType enum: STAFF, BLADED_STAFF, POWERED_STAFF, POWERED_WAND.
+	private static final Set<Integer> MAGIC_WEAPON_TYPES = ImmutableSet.of(22, 23, 26, 27);
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private LeftClickCastConfig config;
+
+	@Provides
+	LeftClickCastConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(LeftClickCastConfig.class);
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (!config.enabled())
+		{
+			return;
+		}
+
+		PertTargetSpell spell = config.spell();
+		if (spell == null)
+		{
+			return;
+		}
+
+		if (!"Attack".equals(event.getOption()))
+		{
+			return;
+		}
+
+		MenuEntry entry = event.getMenuEntry();
+		NPC npc = entry.getNpc();
+		if (npc == null)
+		{
+			return;
+		}
+
+		if (config.requireMagicWeapon() && !isMagicWeaponEquipped())
+		{
+			return;
+		}
+
+		client.getMenu().createMenuEntry(-1)
+			.setOption("Cast")
+			.setTarget("<col=00ff00>" + spell.getDisplayName() + "</col> " + event.getTarget())
+			.setType(net.runelite.api.MenuAction.RUNELITE)
+			// Rs2Magic.castOn uses sleepUntil, which is a no-op on the client thread — dispatch off-thread.
+			.onClick(e -> CompletableFuture.runAsync(
+				() -> Rs2Magic.castOn(spell.getMagicAction(), new Rs2NpcModel(npc))));
+	}
+
+	private boolean isMagicWeaponEquipped()
+	{
+		return MAGIC_WEAPON_TYPES.contains(client.getVarbitValue(Varbits.EQUIPPED_WEAPON_TYPE));
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.leftclickcast;
 import com.google.inject.Provides;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
@@ -11,6 +12,7 @@ import net.runelite.api.MenuEntry;
 import net.runelite.api.Menu;
 import net.runelite.api.NPC;
 import net.runelite.api.ParamID;
+import net.runelite.api.Player;
 import net.runelite.api.StructComposition;
 import net.runelite.api.events.PostMenuSort;
 import net.runelite.api.gameval.VarbitID;
@@ -73,16 +75,26 @@ public class LeftClickCastPlugin extends Plugin
 		Menu menu = client.getMenu();
 		MenuEntry[] entries = menu.getMenuEntries();
 
-		// Find the top-most NPC Attack entry (the game's already-sorted left-click candidate).
+		// Find the top-most NPC or Player Attack entry (the game's already-sorted left-click candidate).
 		int attackIdx = -1;
-		NPC npc = null;
+		Actor targetActor = null;
 		for (int i = entries.length - 1; i >= 0; i--)
 		{
 			MenuEntry e = entries[i];
-			if ("Attack".equals(e.getOption()) && e.getNpc() != null)
+			if (!"Attack".equals(e.getOption()))
+			{
+				continue;
+			}
+			if (e.getNpc() != null)
 			{
 				attackIdx = i;
-				npc = e.getNpc();
+				targetActor = e.getNpc();
+				break;
+			}
+			if (e.getPlayer() != null)
+			{
+				attackIdx = i;
+				targetActor = e.getPlayer();
 				break;
 			}
 		}
@@ -92,12 +104,15 @@ public class LeftClickCastPlugin extends Plugin
 		}
 
 		MenuEntry attack = entries[attackIdx];
-		final NPC target = npc;
+		// Rs2Magic.castOn requires Rs2NpcModel for NPCs but accepts raw Player (Rs2PlayerModel implements Player).
+		final Actor dispatchTarget = targetActor instanceof NPC
+			? new Rs2NpcModel((NPC) targetActor)
+			: (Player) targetActor;
 		attack.setOption("Cast " + spell.getDisplayName());
 		attack.setType(MenuAction.RUNELITE);
 		// Rs2Magic.castOn uses sleepUntil, which is a no-op on the client thread — dispatch off-thread.
 		attack.onClick(e -> CompletableFuture.runAsync(
-			() -> Rs2Magic.castOn(spell.getMagicAction(), new Rs2NpcModel(target))));
+			() -> Rs2Magic.castOn(spell.getMagicAction(), dispatchTarget)));
 
 		// Move to the tail of the array — that slot is the left-click action in RuneLite's menu model.
 		if (attackIdx != entries.length - 1)

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -25,9 +25,13 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.microbot.PluginConstants;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
+import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
+import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
 import net.runelite.client.util.HotkeyListener;
 
 @PluginDescriptor(
@@ -42,7 +46,7 @@ import net.runelite.client.util.HotkeyListener;
 )
 public class LeftClickCastPlugin extends Plugin
 {
-	static final String version = "1.1.0";
+	static final String version = "1.2.0";
 
 	private static final int SLOT_COUNT = 5;
 
@@ -160,16 +164,11 @@ public class LeftClickCastPlugin extends Plugin
 		}
 
 		MenuEntry attack = entries[attackIdx];
-		// Rs2Magic.castOn requires Rs2NpcModel for NPCs but accepts raw Player (Rs2PlayerModel implements Player).
-		final Actor dispatchTarget = targetActor instanceof NPC
-			? new Rs2NpcModel((NPC) targetActor)
-			: (Player) targetActor;
+		final Actor dispatchTarget = targetActor;
 		final PertTargetSpell dispatchSpell = spell;
 		attack.setOption("Cast " + dispatchSpell.getDisplayName());
 		attack.setType(MenuAction.RUNELITE);
-		// Rs2Magic.castOn uses sleepUntil, which is a no-op on the client thread — dispatch off-thread.
-		attack.onClick(e -> CompletableFuture.runAsync(
-			() -> Rs2Magic.castOn(dispatchSpell.getMagicAction(), dispatchTarget)));
+		attack.onClick(e -> castOnTargetFast(dispatchSpell, dispatchTarget));
 
 		// Move to the tail of the array — that slot is the left-click action in RuneLite's menu model.
 		if (attackIdx != entries.length - 1)
@@ -230,6 +229,54 @@ public class LeftClickCastPlugin extends Plugin
 				.value("Left-Click Cast: now casting " + display)
 				.build());
 		}
+	}
+
+	// Fast-path cast: fire two synchronous client.menuAction packets back-to-back so the server processes
+	// the spell selection and the spell-on-target dispatch on the same game tick. Falls back to
+	// Rs2Magic.castOn (tab switch + sleeps + clicks) if the spellbook widget isn't loaded yet or the
+	// spell isn't on the current spellbook.
+	private void castOnTargetFast(PertTargetSpell spell, Actor target)
+	{
+		if (target == null)
+		{
+			return;
+		}
+		MagicAction magic = spell.getMagicAction();
+		Widget magicRoot = client.getWidget(218, 0);
+		boolean widgetReady = magicRoot != null && magicRoot.getStaticChildren() != null;
+		if (widgetReady)
+		{
+			try
+			{
+				int spellWidgetId = magic.getWidgetId();
+				// Packet 1: select the spell client-side (WIDGET_TARGET on the spell widget).
+				client.menuAction(-1, spellWidgetId, MenuAction.WIDGET_TARGET, 1, -1, "Cast", magic.getName());
+				// Packet 2: dispatch the selected spell on the target, same tick.
+				if (target instanceof NPC)
+				{
+					NPC npc = (NPC) target;
+					client.menuAction(0, 0, MenuAction.WIDGET_TARGET_ON_NPC, npc.getIndex(), -1, "Use", npc.getName());
+				}
+				else if (target instanceof Player)
+				{
+					Player p = (Player) target;
+					client.menuAction(0, 0, MenuAction.WIDGET_TARGET_ON_PLAYER, p.getId(), -1, "Use", p.getName());
+				}
+				return;
+			}
+			catch (Exception ignored)
+			{
+				// Spell not on the active spellbook (e.g., modern while on ancients) — fall through.
+			}
+		}
+		else
+		{
+			// Spellbook widget not yet loaded this session; nudge it open so the next click is fast.
+			Rs2Tab.switchTo(InterfaceTab.MAGIC);
+		}
+		// Slow fallback path. Rs2Magic.castOn uses sleepUntil which is a no-op on the client thread, so dispatch async.
+		final Actor dispatch = target instanceof NPC ? new Rs2NpcModel((NPC) target) : target;
+		CompletableFuture.runAsync(() -> Rs2Magic.castOn(magic, dispatch));
 	}
 
 	// Best-effort: if the user had previously set the legacy `spell` key to a non-default value and

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -9,8 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
-import net.runelite.api.Varbits;
 import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -92,6 +92,6 @@ public class LeftClickCastPlugin extends Plugin
 
 	private boolean isMagicWeaponEquipped()
 	{
-		return MAGIC_WEAPON_TYPES.contains(client.getVarbitValue(Varbits.EQUIPPED_WEAPON_TYPE));
+		return MAGIC_WEAPON_TYPES.contains(client.getVarbitValue(VarbitID.COMBAT_WEAPON_CATEGORY));
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -21,7 +21,10 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.ExternalPluginsChanged;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -46,7 +49,7 @@ import net.runelite.client.util.HotkeyListener;
 )
 public class LeftClickCastPlugin extends Plugin
 {
-	static final String version = "1.2.0";
+	static final String version = "1.3.0";
 
 	private static final int SLOT_COUNT = 5;
 
@@ -65,9 +68,14 @@ public class LeftClickCastPlugin extends Plugin
 	@Inject
 	private ConfigManager configManager;
 
+	@Inject
+	private EventBus eventBus;
+
 	private volatile int activeSlot = 0;
 
 	private final HotkeyListener[] hotkeyListeners = new HotkeyListener[SLOT_COUNT];
+
+	private HotkeyListener enabledToggleListener;
 
 	@Provides
 	LeftClickCastConfig provideConfig(ConfigManager configManager)
@@ -78,6 +86,9 @@ public class LeftClickCastPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
+		// MicrobotConfigPanel renders boolean checkboxes from raw stored values; missing keys read as false
+		// even when the @ConfigItem default is true. Materialize defaults so the UI and the proxy agree.
+		configManager.setDefaultConfiguration(config, false);
 		activeSlot = 0;
 		for (int i = 0; i < SLOT_COUNT; i++)
 		{
@@ -93,6 +104,15 @@ public class LeftClickCastPlugin extends Plugin
 			hotkeyListeners[i] = listener;
 			keyManager.registerKeyListener(listener);
 		}
+		enabledToggleListener = new HotkeyListener(() -> config.enabledToggleHotkey())
+		{
+			@Override
+			public void hotkeyPressed()
+			{
+				onEnabledToggleHotkey();
+			}
+		};
+		keyManager.registerKeyListener(enabledToggleListener);
 		migrateLegacySpellKey();
 	}
 
@@ -107,6 +127,11 @@ public class LeftClickCastPlugin extends Plugin
 				keyManager.unregisterKeyListener(listener);
 				hotkeyListeners[i] = null;
 			}
+		}
+		if (enabledToggleListener != null)
+		{
+			keyManager.unregisterKeyListener(enabledToggleListener);
+			enabledToggleListener = null;
 		}
 	}
 
@@ -220,7 +245,7 @@ public class LeftClickCastPlugin extends Plugin
 	private void onSlotHotkey(int index)
 	{
 		activeSlot = index;
-		if (config.activeSlotChatMessage())
+		if (config.chatFeedback())
 		{
 			PertTargetSpell spell = slotSpellFor(index);
 			String display = spell != null ? spell.getDisplayName() : "(no spell)";
@@ -229,6 +254,35 @@ public class LeftClickCastPlugin extends Plugin
 				.value("Left-Click Cast: now casting " + display)
 				.build());
 		}
+	}
+
+	private void onEnabledToggleHotkey()
+	{
+		boolean newValue = !config.enabled();
+		configManager.setConfiguration("leftclickcast", "enabled", newValue);
+		// MicrobotConfigPanel doesn't subscribe to ConfigChanged for individual checkbox refresh, but it does
+		// rebuild on ExternalPluginsChanged. Posting that here makes the open config panel re-read this and
+		// every other config item, so the "Enabled" checkbox visually flips to match the keybind toggle.
+		eventBus.post(new ExternalPluginsChanged());
+		// Chat feedback is emitted by onConfigChanged so checkbox clicks and hotkey presses share one path.
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!"leftclickcast".equals(event.getGroup()) || !"enabled".equals(event.getKey()))
+		{
+			return;
+		}
+		if (!config.chatFeedback())
+		{
+			return;
+		}
+		boolean enabled = "true".equals(event.getNewValue());
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.GAMEMESSAGE)
+			.value("Left-Click Cast: " + (enabled ? "enabled" : "disabled"))
+			.build());
 	}
 
 	// Fast-path cast: fire two synchronous client.menuAction packets back-to-back so the server processes

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/PertTargetSpell.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/PertTargetSpell.java
@@ -1,0 +1,96 @@
+package net.runelite.client.plugins.microbot.leftclickcast;
+
+import lombok.Getter;
+import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
+
+@Getter
+public enum PertTargetSpell
+{
+	// Modern autocastable combat lines (Strike -> Surge)
+	WIND_STRIKE("Wind Strike", MagicAction.WIND_STRIKE),
+	WATER_STRIKE("Water Strike", MagicAction.WATER_STRIKE),
+	EARTH_STRIKE("Earth Strike", MagicAction.EARTH_STRIKE),
+	FIRE_STRIKE("Fire Strike", MagicAction.FIRE_STRIKE),
+	WIND_BOLT("Wind Bolt", MagicAction.WIND_BOLT),
+	WATER_BOLT("Water Bolt", MagicAction.WATER_BOLT),
+	EARTH_BOLT("Earth Bolt", MagicAction.EARTH_BOLT),
+	FIRE_BOLT("Fire Bolt", MagicAction.FIRE_BOLT),
+	WIND_BLAST("Wind Blast", MagicAction.WIND_BLAST),
+	WATER_BLAST("Water Blast", MagicAction.WATER_BLAST),
+	EARTH_BLAST("Earth Blast", MagicAction.EARTH_BLAST),
+	FIRE_BLAST("Fire Blast", MagicAction.FIRE_BLAST),
+	WIND_WAVE("Wind Wave", MagicAction.WIND_WAVE),
+	WATER_WAVE("Water Wave", MagicAction.WATER_WAVE),
+	EARTH_WAVE("Earth Wave", MagicAction.EARTH_WAVE),
+	FIRE_WAVE("Fire Wave", MagicAction.FIRE_WAVE),
+	WIND_SURGE("Wind Surge", MagicAction.WIND_SURGE),
+	WATER_SURGE("Water Surge", MagicAction.WATER_SURGE),
+	EARTH_SURGE("Earth Surge", MagicAction.EARTH_SURGE),
+	FIRE_SURGE("Fire Surge", MagicAction.FIRE_SURGE),
+
+	// Ancient autocastable combat lines (Rush/Burst/Blitz/Barrage for each element)
+	SMOKE_RUSH("Smoke Rush", MagicAction.SMOKE_RUSH),
+	SHADOW_RUSH("Shadow Rush", MagicAction.SHADOW_RUSH),
+	BLOOD_RUSH("Blood Rush", MagicAction.BLOOD_RUSH),
+	ICE_RUSH("Ice Rush", MagicAction.ICE_RUSH),
+	SMOKE_BURST("Smoke Burst", MagicAction.SMOKE_BURST),
+	SHADOW_BURST("Shadow Burst", MagicAction.SHADOW_BURST),
+	BLOOD_BURST("Blood Burst", MagicAction.BLOOD_BURST),
+	ICE_BURST("Ice Burst", MagicAction.ICE_BURST),
+	SMOKE_BLITZ("Smoke Blitz", MagicAction.SMOKE_BLITZ),
+	SHADOW_BLITZ("Shadow Blitz", MagicAction.SHADOW_BLITZ),
+	BLOOD_BLITZ("Blood Blitz", MagicAction.BLOOD_BLITZ),
+	ICE_BLITZ("Ice Blitz", MagicAction.ICE_BLITZ),
+	SMOKE_BARRAGE("Smoke Barrage", MagicAction.SMOKE_BARRAGE),
+	SHADOW_BARRAGE("Shadow Barrage", MagicAction.SHADOW_BARRAGE),
+	BLOOD_BARRAGE("Blood Barrage", MagicAction.BLOOD_BARRAGE),
+	ICE_BARRAGE("Ice Barrage", MagicAction.ICE_BARRAGE),
+
+	// Non-autocastable combat spells
+	CRUMBLE_UNDEAD("Crumble Undead", MagicAction.CRUMBLE_UNDEAD),
+	IBAN_BLAST("Iban Blast", MagicAction.IBAN_BLAST),
+	MAGIC_DART("Magic Dart", MagicAction.MAGIC_DART),
+	SARADOMIN_STRIKE("Saradomin Strike", MagicAction.SARADOMIN_STRIKE),
+	CLAWS_OF_GUTHIX("Claws of Guthix", MagicAction.CLAWS_OF_GUTHIX),
+	FLAMES_OF_ZAMORAK("Flames of Zamorak", MagicAction.FLAMES_OF_ZAMORAK),
+
+	// Arceuus offensive target spells
+	GHOSTLY_GRASP("Ghostly Grasp", MagicAction.GHOSTLY_GRASP),
+	SKELETAL_GRASP("Skeletal Grasp", MagicAction.SKELETAL_GRASP),
+	UNDEAD_GRASP("Undead Grasp", MagicAction.UNDEAD_GRASP),
+	INFERIOR_DEMONBANE("Inferior Demonbane", MagicAction.INFERIOR_DEMONBANE),
+	SUPERIOR_DEMONBANE("Superior Demonbane", MagicAction.SUPERIOR_DEMONBANE),
+	DARK_DEMONBANE("Dark Demonbane", MagicAction.DARK_DEMONBANE),
+	LESSER_CORRUPTION("Lesser Corruption", MagicAction.LESSER_CORRUPTION),
+	GREATER_CORRUPTION("Greater Corruption", MagicAction.GREATER_CORRUPTION),
+
+	// Utility target spells
+	CONFUSE("Confuse", MagicAction.CONFUSE),
+	WEAKEN("Weaken", MagicAction.WEAKEN),
+	CURSE("Curse", MagicAction.CURSE),
+	BIND("Bind", MagicAction.BIND),
+	SNARE("Snare", MagicAction.SNARE),
+	ENTANGLE("Entangle", MagicAction.ENTANGLE),
+	VULNERABILITY("Vulnerability", MagicAction.VULNERABILITY),
+	ENFEEBLE("Enfeeble", MagicAction.ENFEEBLE),
+	STUN("Stun", MagicAction.STUN),
+	TELE_BLOCK("Tele Block", MagicAction.TELE_BLOCK),
+	TELEOTHER_LUMBRIDGE("Tele Other Lumbridge", MagicAction.TELEOTHER_LUMBRIDGE),
+	TELEOTHER_FALADOR("Tele Other Falador", MagicAction.TELEOTHER_FALADOR),
+	TELEOTHER_CAMELOT("Tele Other Camelot", MagicAction.TELEOTHER_CAMELOT);
+
+	private final String displayName;
+	private final MagicAction magicAction;
+
+	PertTargetSpell(String displayName, MagicAction magicAction)
+	{
+		this.displayName = displayName;
+		this.magicAction = magicAction;
+	}
+
+	@Override
+	public String toString()
+	{
+		return displayName;
+	}
+}

--- a/src/main/resources/net/runelite/client/plugins/microbot/leftclickcast/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/leftclickcast/docs/README.md
@@ -1,6 +1,6 @@
 # Left-Click Cast
 
-Replaces the left-click **Attack** option on attackable NPCs with a preconfigured **Cast Spell** action. The plugin stays invisible when you swap to a melee or ranged weapon, so leaving it enabled is safe.
+Replaces the left-click **Attack** option on attackable NPCs and on players (wilderness / PvP) with a preconfigured **Cast Spell** action. The plugin stays invisible when you swap to a melee or ranged weapon, so leaving it enabled is safe.
 
 ## How it works
 
@@ -22,7 +22,6 @@ All casting is dispatched through the Microbot client's existing `Rs2Magic.castO
 - **No auto-spellbook switching.** If the selected spell is not on your current spellbook, the cast fails silently. Switch spellbooks manually.
 - **The dropdown is the source of truth.** Spells not listed in the dropdown are not supported by this plugin.
 - **Staff-only default.** With `Require magic weapon` enabled (default), non-magic weapon types produce normal Attack behavior. Disable the toggle if you want to cast from melee/ranged weapons as well.
-- **PvP out of scope.** Left-click cast on players is not implemented; OSRS's native autocast already handles staves in PvP.
 - **Cooperative menu composition.** If another plugin inserts menu entries after this one on the same tick, its entry becomes the top entry instead — a known limitation of RuneLite's menu model.
 
 ## Supported spells

--- a/src/main/resources/net/runelite/client/plugins/microbot/leftclickcast/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/leftclickcast/docs/README.md
@@ -13,8 +13,25 @@ All casting is dispatched through the Microbot client's existing `Rs2Magic.castO
 | Option | Default | Description |
 | --- | --- | --- |
 | **Enabled** | `true` | Master switch. When off, no menu entries are inserted. |
-| **Spell** | `Fire Strike` | The spell cast on left-click. Only spells in the dropdown are supported. |
+| **Spell** | `Fire Strike` | Legacy single-spell setting. On startup the plugin migrates this into **Slot 1 Spell** if Slot 1 is still at its default — keeps existing configs working without any manual action. |
 | **Require magic weapon** | `true` | When on, the Cast entry only shows while a staff, bladed staff, powered staff, or powered wand is equipped (detected via varbit `EQUIPPED_WEAPON_TYPE`). Disable to cast regardless of weapon. |
+
+### Spell slots and hotkeys
+
+The plugin exposes five independently configurable spell slots, grouped under two sections in the config panel:
+
+| Section | Options |
+| --- | --- |
+| **Spell Slots** | `Slot 1 Spell` … `Slot 5 Spell` — each picks any spell from the full supported-spells dropdown. All five default to `Fire Strike`. |
+| **Hotkeys** | `Slot 1 Hotkey` … `Slot 5 Hotkey` — RuneLite-standard hotkey pickers, all unbound by default. `Chat feedback on slot change` — toggles the chat message posted when a hotkey switches slots (default on). |
+
+**How slot switching works:**
+
+- **Slot 1 is always active at startup.** Enabling the plugin (or restarting the client) resets the active slot to Slot 1. The active slot is runtime-only — it is never written to config.
+- **Press a bound slot hotkey** (while the game window is focused and no text field is active) to make that slot the active slot. The next menu-sort uses the new slot's spell.
+- **Unbound hotkeys are inert.** A slot whose hotkey is `Not set` cannot be activated by keypress. RuneLite's hotkey plumbing suppresses hotkeys while you're typing in a chat or search widget, so hotkey letters won't accidentally swap slots during text entry.
+- **Slot 1 needs no hotkey.** Because it's the startup default, leave its hotkey unbound unless you want to explicitly return to it from another slot.
+- **Chat feedback** (when enabled) prints `Left-Click Cast: now casting <SpellName>` on every slot change. Toggle it off if it's noisy during combat rotations.
 
 ## Limitations
 

--- a/src/main/resources/net/runelite/client/plugins/microbot/leftclickcast/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/leftclickcast/docs/README.md
@@ -1,0 +1,38 @@
+# Left-Click Cast
+
+Replaces the left-click **Attack** option on attackable NPCs with a preconfigured **Cast Spell** action. The plugin stays invisible when you swap to a melee or ranged weapon, so leaving it enabled is safe.
+
+## How it works
+
+When an "Attack" menu entry is added for an NPC, the plugin inserts a new menu entry for the selected spell and places it above Attack, making the spell the left-click action.
+
+All casting is dispatched through the Microbot client's existing `Rs2Magic.castOn(MagicAction, Actor)` — the plugin does not re-implement rune checks, spellbook switching, or targeting.
+
+## Configuration
+
+| Option | Default | Description |
+| --- | --- | --- |
+| **Enabled** | `true` | Master switch. When off, no menu entries are inserted. |
+| **Spell** | `Fire Strike` | The spell cast on left-click. Only spells in the dropdown are supported. |
+| **Require magic weapon** | `true` | When on, the Cast entry only shows while a staff, bladed staff, powered staff, or powered wand is equipped (detected via varbit `EQUIPPED_WEAPON_TYPE`). Disable to cast regardless of weapon. |
+
+## Limitations
+
+- **No rune auto-management.** If you run out of runes, the cast fails cleanly and you see the normal "You do not have enough ..." chat message.
+- **No auto-spellbook switching.** If the selected spell is not on your current spellbook, the cast fails silently. Switch spellbooks manually.
+- **The dropdown is the source of truth.** Spells not listed in the dropdown are not supported by this plugin.
+- **Staff-only default.** With `Require magic weapon` enabled (default), non-magic weapon types produce normal Attack behavior. Disable the toggle if you want to cast from melee/ranged weapons as well.
+- **PvP out of scope.** Left-click cast on players is not implemented; OSRS's native autocast already handles staves in PvP.
+- **Cooperative menu composition.** If another plugin inserts menu entries after this one on the same tick, its entry becomes the top entry instead — a known limitation of RuneLite's menu model.
+
+## Supported spells
+
+**Modern combat (Strike → Surge):** Wind Strike, Water Strike, Earth Strike, Fire Strike, Wind Bolt, Water Bolt, Earth Bolt, Fire Bolt, Wind Blast, Water Blast, Earth Blast, Fire Blast, Wind Wave, Water Wave, Earth Wave, Fire Wave, Wind Surge, Water Surge, Earth Surge, Fire Surge.
+
+**Ancient combat:** Smoke / Shadow / Blood / Ice — Rush, Burst, Blitz, Barrage.
+
+**Non-autocastable combat:** Crumble Undead, Iban Blast, Magic Dart, Saradomin Strike, Claws of Guthix, Flames of Zamorak.
+
+**Arceuus offensive:** Ghostly Grasp, Skeletal Grasp, Undead Grasp, Inferior Demonbane, Superior Demonbane, Dark Demonbane, Lesser Corruption, Greater Corruption.
+
+**Utility target spells:** Confuse, Weaken, Curse, Bind, Snare, Entangle, Vulnerability, Enfeeble, Stun, Tele Block, Tele Other (Lumbridge / Falador / Camelot).

--- a/src/test/java/net/runelite/client/Microbot.java
+++ b/src/test/java/net/runelite/client/Microbot.java
@@ -10,6 +10,7 @@ import net.runelite.client.plugins.microbot.aiofighter.AIOFighterPlugin;
 import net.runelite.client.plugins.microbot.astralrc.AstralRunesPlugin;
 import net.runelite.client.plugins.microbot.autofishing.AutoFishingPlugin;
 import net.runelite.client.plugins.microbot.example.ExamplePlugin;
+import net.runelite.client.plugins.microbot.leftclickcast.LeftClickCastPlugin;
 import net.runelite.client.plugins.microbot.sailing.MSailingPlugin;
 import net.runelite.client.plugins.microbot.thieving.ThievingPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
@@ -20,7 +21,8 @@ public class Microbot
 
 	private static final Class<?>[] debugPlugins = {
 		AIOFighterPlugin.class,
-		AgentServerPlugin.class
+		AgentServerPlugin.class,
+		LeftClickCastPlugin.class
 	};
 
     public static void main(String[] args) throws Exception


### PR DESCRIPTION
## Summary

Adds the **Left-Click Cast** plugin (`PluginConstants.PERT`). It replaces the left-click *Attack* option on attackable NPCs and Players (wilderness / PvP) with a preconfigured *Cast Spell* action, dispatched via two same-tick `menuAction` packets for a zero-delay feel (fallback to `Rs2Magic.castOn` if the spellbook widget isn't loaded yet).

- Five independently configurable spell slots with hotkey-driven active-slot switching (Slot 1 active at startup, runtime-only — never persisted).
- Dedicated hotkey for the master enable/disable toggle, kept in sync with the config panel checkbox via `ExternalPluginsChanged`.
- Unified "Chat feedback" toggle gates all in-game chat messages (slot change + enable/disable toggle).
- "Require magic weapon" option (default on) uses `EnumID.WEAPON_STYLES` + `ParamID.ATTACK_STYLE_NAME` to detect casting-capable weapons, mirroring core `AttackStylesPlugin` logic.
- Broad spell coverage: modern Strike→Surge, Ancients (Rush/Burst/Blitz/Barrage × 4 elements), Arceuus offensive, non-autocastables (Magic Dart, Saradomin Strike, etc.), and utility target spells (Bind/Snare/Entangle/Tele Block/Tele Other).

Also adds the `PERT` author prefix to `PluginConstants`.

Plugin version: `1.3.0`, `minClientVersion: 2.0.13`.

## Test plan

- [x] `./gradlew -PpluginList=LeftClickCastPlugin build` succeeds (produces `LeftClickCastPlugin-1.3.0.jar`).
- [x] Unit / integration tests pass (`./gradlew test`).
- [x] Manually tested via `./gradlew runDebug` — left-click cast fires as a single motion on NPCs and Players; slot hotkeys swap the active spell mid-fight; enable-toggle hotkey flips the config panel checkbox; chat feedback toggle gates both event types.
- [x] Legacy `spell` config key migrates into `slot1Spell` on startup when a non-default value is present.