### PR TITLE
fix(BirdHunter): trap ownership, safer drops, placement & click reliability

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterConfig.java
@@ -18,16 +18,6 @@ public interface BirdHunterConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "keepItemNames",
-            name = "Keep Item Names",
-            description = "Comma-separated list of item names that should not be dropped",
-            position = 3
-    )
-    default String keepItemNames() {
-        return "Bird snare";
-    }
-
-    @ConfigItem(
             keyName = "huntingRadiusValue",
             name = "Hunting radius",
             description = "The radius in which the player will set traps and hunt birds. Indicated by yellow borders. " +

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterPlugin.java
@@ -1,16 +1,32 @@
 package net.runelite.client.plugins.microbot.birdhunter;
 
 import com.google.inject.Provides;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.Player;
+import net.runelite.api.Tile;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.gameval.ObjectID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.hunter.HunterTrap;
+import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.PluginConstants;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 @PluginDescriptor(
         name = PluginDescriptor.zerozero + "Bird Hunter",
@@ -26,7 +42,10 @@ import javax.inject.Inject;
 @Slf4j
 public class BirdHunterPlugin extends Plugin {
 
-    public final static String version = "1.0.1";
+    public final static String version = "1.0.2";
+
+    @Inject
+    private Client client;
 
     @Inject
     private BirdHunterConfig config;
@@ -40,6 +59,10 @@ public class BirdHunterPlugin extends Plugin {
     @Inject
     private OverlayManager overlayManager;
 
+    @Getter
+    private final Map<WorldPoint, HunterTrap> traps = new HashMap<>();
+    private WorldPoint lastTickLocalPlayerLocation;
+
     @Provides
     BirdHunterConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(BirdHunterConfig.class);
@@ -47,8 +70,20 @@ public class BirdHunterPlugin extends Plugin {
 
     @Override
     protected void startUp() {
+        // Seed lastTickLocalPlayerLocation on the client thread before the
+        // script loop can fire a layBirdSnare — otherwise the first snare's
+        // GameObjectSpawned event sees a null baseline, the trap is never
+        // recorded as owned, and the filter/setTrap path puts the bot in an
+        // infinite movePlayerOffObject loop on its own untracked trap.
+        // startUp runs on the AWT EDT; reading player location from there
+        // throws "must be called on client thread".
+        lastTickLocalPlayerLocation = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            Player lp = client.getLocalPlayer();
+            return lp != null ? lp.getWorldLocation() : null;
+        }).orElse(null);
+
         if (config.startScript()) {
-            birdHunterScript.run(config);
+            birdHunterScript.run(config, this);
             this.overlayManager.add(this.birdHunterOverlay);
         }
     }
@@ -57,13 +92,14 @@ public class BirdHunterPlugin extends Plugin {
     protected void shutDown() {
         this.overlayManager.remove(this.birdHunterOverlay);
         birdHunterScript.shutdown();
+        traps.clear();
     }
 
     @Subscribe
     public void onConfigChanged(ConfigChanged event) {
         if (event.getGroup().equals("birdhunter") && event.getKey().equals("startScript")) {
             if (config.startScript()) {
-                birdHunterScript.run(config);
+                birdHunterScript.run(config, this);
             } else {
                 birdHunterScript.shutdown();
             }
@@ -71,5 +107,83 @@ public class BirdHunterPlugin extends Plugin {
         if (event.getKey().equals("huntingRadiusValue")) {
             birdHunterScript.updateHuntingArea(config);
         }
+    }
+
+    @Subscribe
+    public void onGameObjectSpawned(GameObjectSpawned event) {
+        final GameObject go = event.getGameObject();
+        final WorldPoint trapLocation = go.getWorldLocation();
+        final HunterTrap myTrap = traps.get(trapLocation);
+
+        switch (go.getId()) {
+            // Empty placed snare — ownership decision point. Player location is
+            // updated before this event fires, so we compare the spawn tile to
+            // the PREVIOUS tick's player location. distance == 0 means the snare
+            // spawned on the exact tile the player stood on last tick, i.e. ours.
+            case ObjectID.HUNTING_OJIBWAY_TRAP:
+                if (lastTickLocalPlayerLocation != null
+                        && trapLocation.distanceTo(lastTickLocalPlayerLocation) == 0) {
+                    traps.put(trapLocation, new HunterTrap(go));
+                }
+                break;
+
+            case ObjectID.HUNTING_OJIBWAY_TRAP_FULL_JUNGLE:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_FULL_POLAR:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_FULL_DESERT:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_FULL_WOODLAND:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_FULL_COLOURED:
+                if (myTrap != null) {
+                    myTrap.setState(HunterTrap.State.FULL);
+                    myTrap.resetTimer();
+                }
+                break;
+
+            case ObjectID.HUNTING_OJIBWAY_TRAP_BROKEN:
+                if (myTrap != null) {
+                    myTrap.setState(HunterTrap.State.EMPTY);
+                    myTrap.resetTimer();
+                }
+                break;
+
+            case ObjectID.HUNTING_OJIBWAY_TRAP_FAILING:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_TRAPPING_JUNGLE:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_TRAPPING_COLOURED:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_TRAPPING_DESERT:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_TRAPPING_WOODLAND:
+            case ObjectID.HUNTING_OJIBWAY_TRAP_TRAPPING_POLAR:
+                if (myTrap != null) {
+                    myTrap.setState(HunterTrap.State.TRANSITION);
+                }
+                break;
+        }
+    }
+
+    @Subscribe
+    public void onGameTick(GameTick event) {
+        Iterator<Map.Entry<WorldPoint, HunterTrap>> it = traps.entrySet().iterator();
+        Tile[][][] tiles = client.getScene().getTiles();
+        Instant expire = Instant.now().minus(HunterTrap.TRAP_TIME.multipliedBy(2));
+
+        while (it.hasNext()) {
+            Map.Entry<WorldPoint, HunterTrap> entry = it.next();
+            HunterTrap trap = entry.getValue();
+            WorldPoint world = entry.getKey();
+            LocalPoint local = LocalPoint.fromWorld(client, world);
+
+            if (local == null) {
+                if (trap.getPlacedOn().isBefore(expire)) it.remove();
+                continue;
+            }
+
+            GameObject[] objects = tiles[world.getPlane()][local.getSceneX()][local.getSceneY()].getGameObjects();
+            boolean anyObject = false;
+            for (GameObject o : objects) {
+                if (o != null) { anyObject = true; break; }
+            }
+            if (!anyObject) it.remove();
+        }
+
+        Player lp = client.getLocalPlayer();
+        if (lp != null) lastTickLocalPlayerLocation = lp.getWorldLocation();
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterScript.java
@@ -23,8 +23,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class BirdHunterScript extends Script {
 
@@ -41,7 +43,10 @@ public class BirdHunterScript extends Script {
     private final Pair<Integer, Integer> boneThresholdRange = Pair.of(3, 10);
     private final Pair<Integer, Integer> HandleInventoryThresholdRange = Pair.of(18, 25);
 
-    public boolean run(BirdHunterConfig config) {
+    private BirdHunterPlugin plugin;
+
+    public boolean run(BirdHunterConfig config, BirdHunterPlugin plugin) {
+        this.plugin = plugin;
         Microbot.log("Bird Hunter script started.");
 
         if (!hasRequiredSnares()) {
@@ -93,10 +98,11 @@ public class BirdHunterScript extends Script {
 
     public void updateHuntingArea(BirdHunterConfig config) {
         huntingRadius = config.huntingRadiusValue();
+        int side = (2 * huntingRadius) + 1;
         dynamicHuntingArea = new WorldArea(
                 initialStartTile.getX() - huntingRadius,
                 initialStartTile.getY() - huntingRadius,
-                (huntingRadius * huntingRadius) + 1, (huntingRadius * huntingRadius) + 1,
+                side, side,
                 initialStartTile.getPlane()
         );
     }
@@ -107,7 +113,7 @@ public class BirdHunterScript extends Script {
     }
 
     private void walkBackToArea() {
-        WorldPoint walkableTile = getSafeWalkableTile(dynamicHuntingArea);
+        WorldPoint walkableTile = getNearestSafeWalkableTileInArea(dynamicHuntingArea);
 
         if (walkableTile != null) {
             Rs2Walker.walkFastCanvas(walkableTile);
@@ -115,6 +121,28 @@ public class BirdHunterScript extends Script {
         } else {
             Microbot.log("No safe walkable tile found inside the hunting area.");
         }
+    }
+
+    private WorldPoint getNearestSafeWalkableTileInArea(WorldArea huntingArea) {
+        WorldPoint from = Rs2Player.getWorldLocation();
+        WorldPoint nearest = null;
+        int bestDist = Integer.MAX_VALUE;
+
+        for (int x = initialStartTile.getX() - huntingRadius; x <= initialStartTile.getX() + huntingRadius; x++) {
+            for (int y = initialStartTile.getY() - huntingRadius; y <= initialStartTile.getY() + huntingRadius; y++) {
+                WorldPoint candidate = new WorldPoint(x, y, huntingArea.getPlane());
+                LocalPoint localPoint = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), candidate);
+                if (localPoint == null || !huntingArea.contains(candidate)) continue;
+                if (!Rs2Tile.isWalkable(localPoint) || isGameObjectAt(candidate)) continue;
+
+                int dist = from.distanceTo(candidate);
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    nearest = candidate;
+                }
+            }
+        }
+        return nearest;
     }
 
     private void handleTraps(BirdHunterConfig config) {
@@ -134,9 +162,19 @@ public class BirdHunterScript extends Script {
         catchingTraps.addAll(Microbot.getRs2TileObjectCache().query().withId(ObjectID.HUNTING_OJIBWAY_TRAP_TRAPPING_POLAR).toList());
         catchingTraps.addAll(Microbot.getRs2TileObjectCache().query().withId(ObjectID.HUNTING_OJIBWAY_TRAP_FULL_JUNGLE).toList());
 
-        List<Rs2TileObjectModel> failedTraps = Microbot.getRs2TileObjectCache().query().withId(ObjectID.HUNTING_OJIBWAY_TRAP_BROKEN).toList();
+        List<Rs2TileObjectModel> failedTraps = new ArrayList<>(Microbot.getRs2TileObjectCache().query().withId(ObjectID.HUNTING_OJIBWAY_TRAP_BROKEN).toList());
         List<Rs2TileObjectModel> idleTraps = new ArrayList<>(Microbot.getRs2TileObjectCache().query().withId(ObjectID.HUNTING_OJIBWAY_TRAP).toList());
         idleTraps.addAll(Microbot.getRs2TileObjectCache().query().withId(ObjectID.HUNTING_OJIBWAY_TRAP_FAILING).toList());
+
+        // Ownership filter: the plugin records a trap's WorldPoint when it spawns
+        // on the player's previous-tick tile. Skip everything else — other players'
+        // snares should not be clicked, and they must not inflate totalTraps below.
+        Set<WorldPoint> owned = plugin.getTraps().keySet();
+        Predicate<Rs2TileObjectModel> mine = t -> owned.contains(t.getWorldLocation());
+        successfulTraps.removeIf(mine.negate());
+        catchingTraps.removeIf(mine.negate());
+        failedTraps.removeIf(mine.negate());
+        idleTraps.removeIf(mine.negate());
 
         int availableTraps = getAvailableTraps(Rs2Player.getRealSkillLevel(Skill.HUNTER));
         int totalTraps = successfulTraps.size() + failedTraps.size() + idleTraps.size() + catchingTraps.size();
@@ -245,6 +283,7 @@ public class BirdHunterScript extends Script {
 
 
     private boolean interactWithTrap(Rs2TileObjectModel birdSnare) {
+        if (!plugin.getTraps().containsKey(birdSnare.getWorldLocation())) return false;
         sleep(Rs2Random.randomGaussian(2000, 1250));
         birdSnare.click();
         sleepUntil(() -> Rs2Inventory.waitForInventoryChanges(7000));
@@ -274,11 +313,9 @@ public class BirdHunterScript extends Script {
     }
 
     private void handleInventory(BirdHunterConfig config) {
-        if (config.buryBones() && Rs2Inventory.count("Bones") > randomBoneThreshold) {
+        if (config.buryBones()) {
             buryBones(config);
-
         }
-        buryBones(config);
         dropItems(config);
     }
 
@@ -294,14 +331,16 @@ public class BirdHunterScript extends Script {
         }
     }
 
+    // Strict drop whitelist. Replaces an earlier dropAllExcept(keepList) that would
+    // nuke the entire inventory if the keep list was misconfigured. Bird snaring
+    // only produces Raw bird meat, Bones, and feathers — feathers stack so we let
+    // them ride; bones are buried when the config is enabled, dropped otherwise.
     private void dropItems(BirdHunterConfig config) {
-        String keepItemsConfig = config.keepItemNames();
-        List<String> keepItemNames = List.of(keepItemsConfig.split("\\s*,\\s*"));
-
-        if (!keepItemNames.contains("Bird snare")) {
-            keepItemNames.add("Bird snare");
+        if (config.buryBones()) {
+            Rs2Inventory.dropAll("Raw bird meat");
+        } else {
+            Rs2Inventory.dropAll("Raw bird meat", "Bones");
         }
-        Rs2Inventory.dropAllExcept(keepItemNames.toArray(new String[0]));
     }
 
     public int getAvailableTraps(int hunterLevel) {

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhunter/BirdHunterScript.java
@@ -49,10 +49,6 @@ public class BirdHunterScript extends Script {
         this.plugin = plugin;
         Microbot.log("Bird Hunter script started.");
 
-        if (!hasRequiredSnares()) {
-            Microbot.log("Not enough bird snares in inventory. Stopping the script.");
-            return false;
-        }
         initialStartTile = Rs2Player.getWorldLocation();
 
         randomBoneThreshold = ThreadLocalRandom.current().nextInt(boneThresholdRange.getLeft(), boneThresholdRange.getRight());
@@ -68,6 +64,14 @@ public class BirdHunterScript extends Script {
 
             try {
                 if (!super.run() || !Microbot.isLoggedIn()) return;
+
+                if (!hasRequiredSnares()) {
+                    int required = getAvailableTraps(Rs2Player.getRealSkillLevel(Skill.HUNTER));
+                    Microbot.showMessage("Bird Hunter needs at least " + required
+                            + " bird snares in inventory for your Hunter level. Stopping plugin.");
+                    Microbot.stopPlugin(plugin);
+                    return;
+                }
 
                 if (!isInHuntingArea()) {
                     Microbot.log("Player is outside the designated hunting area.");
@@ -88,12 +92,12 @@ public class BirdHunterScript extends Script {
 
     private boolean hasRequiredSnares() {
         int hunterLevel = Rs2Player.getRealSkillLevel(Skill.HUNTER);
-        int allowedSnares = getAvailableTraps(hunterLevel);  // Calculate the allowed number of snares
+        int allowedSnares = getAvailableTraps(hunterLevel);
 
         int snaresInInventory = Rs2Inventory.itemQuantity(ItemID.HUNTING_OJIBWAY_BIRD_SNARE);
         Microbot.log("Allowed snares: " + allowedSnares + ", Snares in inventory: " + snaresInInventory);
 
-        return snaresInInventory >= allowedSnares;  // Return true if enough snares, false otherwise
+        return snaresInInventory >= allowedSnares;
     }
 
     public void updateHuntingArea(BirdHunterConfig config) {
@@ -212,7 +216,11 @@ public class BirdHunterScript extends Script {
     private void setTrap(BirdHunterConfig config) {
         if (!Rs2Inventory.contains(ItemID.HUNTING_OJIBWAY_BIRD_SNARE)) return;
 
-        if (Rs2Player.isStandingOnGameObject()) {
+        // Rs2Player.isStandingOnGameObject() also returns true for ground items
+        // (dropped loot), which don't actually block snare placement in-game.
+        // Only skip the tile when there's a real game object on it (existing
+        // trap, tree, rock).
+        if (isGameObjectAt(Rs2Player.getWorldLocation())) {
             if (!movePlayerOffObject())
                 return;
         }
@@ -284,11 +292,16 @@ public class BirdHunterScript extends Script {
 
     private boolean interactWithTrap(Rs2TileObjectModel birdSnare) {
         if (!plugin.getTraps().containsKey(birdSnare.getWorldLocation())) return false;
-        sleep(Rs2Random.randomGaussian(2000, 1250));
-        birdSnare.click();
-        sleepUntil(() -> Rs2Inventory.waitForInventoryChanges(7000));
-        sleep(Rs2Random.randomGaussian(2000, 1250));
 
+        // Retry the click until inventory changes (snare returned / loot received).
+        // Previously a single click with a 7s inventory-changes wait and 2×2s
+        // gaussian sleeps meant ~13s of stall on a missed click.
+        int invBefore = Rs2Inventory.count();
+        for (int attempt = 0; attempt < 3; attempt++) {
+            birdSnare.click();
+            if (sleepUntil(() -> Rs2Inventory.count() != invBefore, 2500)) break;
+        }
+        sleep(Rs2Random.randomGaussian(600, 200));
         return false;
     }
 


### PR DESCRIPTION
## Summary

Fixes several issues in the Bird Hunter plugin (v1.0.2):

- **Trap ownership**: the bot now tracks which snares it laid (spatial-proximity match on `GameObjectSpawned`, mirroring RuneLite's core Hunter plugin) and ignores other players' snares. Previously it would blindly click any matching `ObjectID`, silently failing on foreign traps and wasting ticks.
- **Safer inventory handling**: replaced `dropAllExcept(keepList)` with a strict whitelist — drops only raw bird meat (plus bones when bury-bones is off). The old path could nuke the entire inventory (armor, food, clue scrolls, tailfeathers, etc.) if the keep list was misconfigured. Removed the now-unused `keepItemNames` config.
- **Centered hunting area**: `updateHuntingArea` was building a `(radius² + 1)²` off-center region that biased NE; fixed to `(2·radius + 1)²` centered on the start tile.
- **Nearest walk-back**: `walkBackToArea` picks the nearest valid tile to the player instead of a random one.
- **Proper startup-error stop**: missing-snare precondition now uses the canonical Microbot pattern (`showMessage` + `stopPlugin`) from inside the scheduled loop, instead of silently returning false while the toggle stays on.
- **Click retry**: `interactWithTrap` retries up to 3x, exiting on inventory change. Previously a single click + 7s `waitForInventoryChanges` + 2×2s gaussian sleeps meant a missed click stalled the bot ~13s; now ~1-2s on hit, ~8s worst case.
- **Loot-agnostic placement**: `setTrap` switched from `Rs2Player.isStandingOnGameObject()` (also returns true for ground items) to the existing `isGameObjectAt` helper. Dropped loot no longer forces the bot to walk off a perfectly valid tile.
- **Startup race fix**: seed `lastTickLocalPlayerLocation` on the client thread at `startUp` so the first snare laid before any `GameTick` fires is still recognized as owned. Without this, the filter+`setTrap` path put the bot in a `movePlayerOffObject` loop on its own untracked trap.

## Test plan

- [ ] Lay snares in a hunter area, verify they're tracked (`plugin.getTraps().size()` grows) and interacted with.
- [ ] Have a second player place a snare adjacent to the bot; confirm the bot doesn't click it.
- [ ] Start the plugin with fewer snares than the level cap — confirm a modal message appears and the plugin stops (toggle flips off).
- [ ] Start with raw bird meat already in inventory — confirm it drops the meat at threshold but does NOT touch other items.
- [ ] Trigger a successful catch → dismantle → verify loot enters inventory, trap entry is culled, bot lays a new snare.
- [ ] Drop loot on the trap tile manually — confirm the bot still lays subsequent snares on loot tiles.
- [ ] Walk outside the hunting radius — confirm bot walks to the nearest in-area tile, not a random one.