### PR TITLE
feat(AutoMining): add League mode to prevent AFK logout

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningConfig.java
@@ -87,6 +87,17 @@ public interface AutoMiningConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "leagueMode",
+            name = "League mode (anti-AFK)",
+            description = "Periodically presses a key to reset the idle timer so you never get logged out",
+            position = 4,
+            section = generalSection
+    )
+    default boolean leagueMode() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "UseBank",
             name = "UseBank",
             description = "Use bank and walk back to original location",

--- a/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningPlugin.java
@@ -24,7 +24,7 @@ import java.awt.*;
 )
 @Slf4j
 public class AutoMiningPlugin extends Plugin {
-    public static final String version = "1.0.11";
+    public static final String version = "1.0.12";
     @Inject
     private AutoMiningConfig config;
     @Provides

--- a/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mining/AutoMiningScript.java
@@ -19,12 +19,14 @@ import net.runelite.client.plugins.microbot.util.depositbox.Rs2DepositBox;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.security.Login;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 
 import java.util.ArrayList;
+import java.awt.event.KeyEvent;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -54,6 +56,10 @@ public class AutoMiningScript extends Script {
             try {
                 if (!super.run()) return;
                 if (!Microbot.isLoggedIn()) return;
+                if (config.leagueMode() && Rs2Player.checkIdleLogout(Rs2Random.between(500, 1500))) {
+                    int[] arrowKeys = { KeyEvent.VK_LEFT, KeyEvent.VK_RIGHT, KeyEvent.VK_UP, KeyEvent.VK_DOWN };
+                    Rs2Keyboard.keyPress(arrowKeys[Rs2Random.between(0, arrowKeys.length - 1)]);
+                }
                 if (Rs2AntibanSettings.actionCooldownActive) return;
                 if (initialPlayerLocation == null) {
                     initialPlayerLocation = Rs2Player.getWorldLocation();


### PR DESCRIPTION
## Summary
- Adds a new **League mode (anti-AFK)** toggle to the AutoMining General config section
- When enabled, the script presses a random arrow key whenever the client's idle ticks approach its idle-timeout threshold, resetting the keyboard idle counter and preventing logout
- Intended for Leagues where the auto-bank relic lets you mine indefinitely without any interaction that would otherwise reset the AFK timer

## Test plan
- [ ] Enable League mode in config, start mining on a Leagues world, verify no AFK logout after 6+ minutes of continuous mining
- [ ] Disable League mode, verify plugin behaves identically to previous version (no extra key presses)
- [ ] Verify the toggle appears in the General section at position 4