### PR TITLE
feat(AIFiremaking): add intelligent firemaking plugin with tile scanning

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
@@ -34,6 +34,7 @@ public final class PluginConstants
     public static final String NATE = "<html>[<font color=orange>N</font>] ";
     public static final String SYN = "<html>[<font color=orange>Syn</font>] ";
     public static final String BIGL = "<html>[<font color=#b8f704>BL</font>] ";
+    public static final String DV = "<html>[<font color=#800080>DV</font>] ";
 
     public static final boolean DEFAULT_ENABLED = false;
     public static final boolean IS_EXTERNAL = true; //test

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/FireLine.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/FireLine.java
@@ -1,0 +1,17 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+@RequiredArgsConstructor
+public class FireLine {
+    private final WorldPoint westEnd;
+    private final WorldPoint eastEnd;
+    private final int length;
+
+    public int getY() {
+        return westEnd.getY();
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingConfig.java
@@ -1,0 +1,76 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+
+@ConfigGroup("LeaguesFiremaking")
+@ConfigInformation("<h2>AI Firemaking</h2>" +
+        "<h3>Version: " + LeaguesFiremakingPlugin.version + "</h3>" +
+        "<p>Withdraws logs from the bank, finds open space, and lights fires in lines.</p>" +
+        "<p>Scans surrounding tiles to pick the best row, adapts around existing fires and obstacles.</p>" +
+        "<p>Supports Bank Heist briefcase for instant banking.</p>")
+public interface LeaguesFiremakingConfig extends Config {
+
+    @ConfigSection(
+            name = "General",
+            description = "General settings",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigSection(
+            name = "Banking",
+            description = "Banking settings",
+            position = 1
+    )
+    String bankingSection = "banking";
+
+    @ConfigItem(
+            keyName = "logType",
+            name = "Log type",
+            description = "Which logs to burn",
+            position = 0,
+            section = generalSection
+    )
+    default LogType logType() {
+        return LogType.LOGS;
+    }
+
+    @ConfigItem(
+            keyName = "progressiveMode",
+            name = "Progressive mode",
+            description = "Automatically pick the best log for your Firemaking level",
+            position = 1,
+            section = generalSection
+    )
+    default boolean progressiveMode() {
+        return false;
+    }
+
+    @Range(min = 10, max = 50)
+    @ConfigItem(
+            keyName = "scanRadius",
+            name = "Scan radius",
+            description = "How many tiles to scan around your starting position for open space",
+            position = 2,
+            section = generalSection
+    )
+    default int scanRadius() {
+        return 25;
+    }
+
+    @ConfigItem(
+            keyName = "useBriefcase",
+            name = "Use Bank Heist briefcase",
+            description = "Use the banker's briefcase to teleport to a bank instead of walking (Leagues relic)",
+            position = 0,
+            section = bankingSection
+    )
+    default boolean useBriefcase() {
+        return false;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingOverlay.java
@@ -1,0 +1,57 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class LeaguesFiremakingOverlay extends OverlayPanel {
+
+    @Inject
+    private LeaguesFiremakingScript script;
+
+    @Inject
+    public LeaguesFiremakingOverlay() {
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.setPreferredSize(new Dimension(200, 0));
+
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("AI Firemaking v" + LeaguesFiremakingPlugin.version)
+                .color(Color.GREEN)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status")
+                .right(script.getStatus())
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("State")
+                .right(script.getState().name())
+                .build());
+
+        FireLine line = script.getCurrentLine();
+        if (line != null) {
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Line length")
+                    .right(String.valueOf(line.getLength()))
+                    .build());
+        }
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Microbot")
+                .right(Microbot.status)
+                .build());
+
+        return super.render(graphics);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingPlugin.java
@@ -1,0 +1,54 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+        name = PluginConstants.DV + "AI Firemaking",
+        description = "Lights fires in lines anywhere — withdraws logs, scans for open tiles, adapts around obstacles",
+        tags = {"firemaking", "leagues", "microbot", "skilling"},
+        version = LeaguesFiremakingPlugin.version,
+        minClientVersion = "2.0.13",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class LeaguesFiremakingPlugin extends Plugin {
+    public static final String version = "1.0.0";
+
+    @Inject
+    private LeaguesFiremakingConfig config;
+
+    @Inject
+    private LeaguesFiremakingScript script;
+
+    @Inject
+    private LeaguesFiremakingOverlay overlay;
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Provides
+    LeaguesFiremakingConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(LeaguesFiremakingConfig.class);
+    }
+
+    @Override
+    protected void startUp() {
+        overlayManager.add(overlay);
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LeaguesFiremakingScript.java
@@ -1,0 +1,253 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class LeaguesFiremakingScript extends Script {
+
+    private static final int TINDERBOX_ID = 590;
+    private static final String TINDERBOX_NAME = "Tinderbox";
+
+    @Getter
+    private State state = State.SCANNING;
+    @Getter
+    private String status = "Starting";
+    @Getter
+    private FireLine currentLine;
+
+    private WorldPoint startPosition;
+    private LogType activeLogType;
+
+    public boolean run(LeaguesFiremakingConfig config) {
+        Rs2Antiban.resetAntibanSettings();
+        Rs2Antiban.antibanSetupTemplates.applyFiremakingSetup();
+        Rs2AntibanSettings.actionCooldownChance = 0.1;
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) return;
+                if (Rs2AntibanSettings.actionCooldownActive) return;
+
+                if (startPosition == null) {
+                    startPosition = Rs2Player.getWorldLocation();
+                }
+
+                activeLogType = config.progressiveMode() ? LogType.getBestForLevel() : config.logType();
+
+                if (activeLogType == null || !activeLogType.hasRequiredLevel()) {
+                    status = "Level too low for " + (activeLogType != null ? activeLogType.getLogName() : "any logs");
+                    return;
+                }
+
+                switch (state) {
+                    case SCANNING:
+                        handleScanning(config);
+                        break;
+                    case WALKING_TO_LINE:
+                        handleWalkingToLine();
+                        break;
+                    case BURNING:
+                        handleBurning();
+                        break;
+                    case BANKING:
+                        handleBanking(config);
+                        break;
+                    case WALKING_BACK:
+                        handleWalkingBack(config);
+                        break;
+                }
+            } catch (Exception ex) {
+                log.error("LeaguesFiremaking loop error", ex);
+                Microbot.log(ex.getMessage());
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void handleScanning(LeaguesFiremakingConfig config) {
+        status = "Scanning for open space";
+
+        if (!Rs2Inventory.hasItem(activeLogType.getItemId())) {
+            state = State.BANKING;
+            return;
+        }
+
+        currentLine = TileScanner.findBestLine(startPosition, config.scanRadius());
+
+        if (currentLine == null) {
+            status = "No open space found — try moving to a more open area";
+            return;
+        }
+
+        status = "Found line: " + currentLine.getLength() + " tiles";
+        state = State.WALKING_TO_LINE;
+    }
+
+    private void handleWalkingToLine() {
+        if (currentLine == null) {
+            state = State.SCANNING;
+            return;
+        }
+
+        WorldPoint eastEnd = currentLine.getEastEnd();
+        status = "Walking to east end of line";
+
+        if (Rs2Player.getWorldLocation().distanceTo(eastEnd) <= 1) {
+            state = State.BURNING;
+            return;
+        }
+
+        if (!Rs2Player.isMoving()) {
+            Rs2Walker.walkTo(eastEnd, 0);
+        }
+    }
+
+    private void handleBurning() {
+        if (!Rs2Inventory.hasItem(activeLogType.getItemId())) {
+            status = "Out of logs";
+            state = State.BANKING;
+            return;
+        }
+
+        if (Rs2Player.isMoving()) {
+            status = "Walking after lighting...";
+            return;
+        }
+
+        if (Rs2Player.isAnimating()) {
+            status = "Lighting animation...";
+            return;
+        }
+
+        if (!Rs2Inventory.hasItem(TINDERBOX_NAME)) {
+            status = "No tinderbox — banking";
+            state = State.BANKING;
+            return;
+        }
+
+        // Check if we're standing on a fire — need to step west first
+        WorldPoint playerPos = Rs2Player.getWorldLocation();
+        boolean standingOnFire = TileScanner.hasFire(playerPos);
+
+        if (standingOnFire) {
+            // Step one tile west to get off the fire
+            WorldPoint westTile = new WorldPoint(playerPos.getX() - 1, playerPos.getY(), playerPos.getPlane());
+            if (!Rs2Tile.isWalkable(westTile)) {
+                // Can't go west — line is done, rescan
+                status = "Blocked west — rescanning";
+                state = State.SCANNING;
+                return;
+            }
+            Rs2Walker.walkTo(westTile, 0);
+            sleepUntil(() -> Rs2Player.getWorldLocation().distanceTo(westTile) <= 0, 3000);
+            return;
+        }
+
+        if (!Rs2Tile.isWalkable(playerPos)) {
+            status = "Standing on blocked tile — rescanning";
+            state = State.SCANNING;
+            return;
+        }
+
+        status = "Lighting " + activeLogType.getLogName();
+        WorldPoint beforeLight = Rs2Player.getWorldLocation();
+        Rs2Inventory.combine(TINDERBOX_NAME, activeLogType.getLogName());
+
+        // Wait for XP drop (fire lit) then wait for auto-walk west
+        if (Rs2Player.waitForXpDrop(Skill.FIREMAKING, 10000)) {
+            sleepUntil(() -> !Rs2Player.getWorldLocation().equals(beforeLight), 3000);
+            sleep(200, 400);
+        }
+
+        Rs2Antiban.actionCooldown();
+        Rs2Antiban.takeMicroBreakByChance();
+    }
+
+    private void handleBanking(LeaguesFiremakingConfig config) {
+        if (config.useBriefcase()) {
+            status = "Using briefcase to bank";
+            if (!Rs2Inventory.hasItem("Banker's briefcase")) {
+                status = "No briefcase found — walking to bank";
+                if (!Rs2Bank.walkToBankAndUseBank()) return;
+            } else {
+                if (!Rs2Bank.isOpen()) {
+                    Rs2Inventory.interact("Banker's briefcase", "Bank");
+                    sleepUntil(Rs2Bank::isOpen, 5000);
+                    if (!Rs2Bank.isOpen()) return;
+                }
+            }
+        } else {
+            status = "Walking to bank";
+            if (!Rs2Bank.isOpen()) {
+                if (!Rs2Bank.walkToBankAndUseBank()) return;
+            }
+        }
+
+        status = "Depositing and withdrawing";
+
+        Rs2Bank.depositAll();
+        sleep(150, 300);
+
+        if (!Rs2Bank.hasItem(TINDERBOX_ID)) {
+            status = "No tinderbox in bank — stopping";
+            Microbot.log("No tinderbox found in bank.");
+            shutdown();
+            return;
+        }
+
+        Rs2Bank.withdrawOne(TINDERBOX_ID);
+        sleepUntil(() -> Rs2Inventory.hasItem(TINDERBOX_NAME), 3000);
+        sleep(150, 300);
+
+        if (!Rs2Bank.hasItem(activeLogType.getItemId())) {
+            status = "No " + activeLogType.getLogName() + " in bank — stopping";
+            Microbot.log("No " + activeLogType.getLogName() + " found in bank.");
+            shutdown();
+            return;
+        }
+
+        Rs2Bank.withdrawAll(activeLogType.getItemId());
+        sleepUntil(() -> Rs2Inventory.hasItem(activeLogType.getItemId()), 3000);
+        sleep(150, 300);
+
+        Rs2Bank.closeBank();
+        state = State.WALKING_BACK;
+    }
+
+    private void handleWalkingBack(LeaguesFiremakingConfig config) {
+        status = "Walking back to fire area";
+
+        if (Rs2Player.getWorldLocation().distanceTo(startPosition) <= config.scanRadius()) {
+            state = State.SCANNING;
+            return;
+        }
+
+        if (!Rs2Player.isMoving()) {
+            Rs2Walker.walkTo(startPosition, 3);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        Rs2Antiban.resetAntibanSettings();
+        startPosition = null;
+        currentLine = null;
+        state = State.SCANNING;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LogType.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/LogType.java
@@ -1,0 +1,44 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Skill;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+@Getter
+@RequiredArgsConstructor
+public enum LogType {
+    LOGS("Logs", ItemID.LOGS, 1),
+    OAK("Oak logs", ItemID.OAK_LOGS, 15),
+    WILLOW("Willow logs", ItemID.WILLOW_LOGS, 30),
+    TEAK("Teak logs", ItemID.TEAK_LOGS, 35),
+    MAPLE("Maple logs", ItemID.MAPLE_LOGS, 45),
+    MAHOGANY("Mahogany logs", ItemID.MAHOGANY_LOGS, 50),
+    YEW("Yew logs", ItemID.YEW_LOGS, 60),
+    MAGIC("Magic logs", ItemID.MAGIC_LOGS, 75),
+    REDWOOD("Redwood logs", ItemID.REDWOOD_LOGS, 90);
+
+    private final String logName;
+    private final int itemId;
+    private final int levelRequired;
+
+    public boolean hasRequiredLevel() {
+        return Rs2Player.getSkillRequirement(Skill.FIREMAKING, levelRequired);
+    }
+
+    public static LogType getBestForLevel() {
+        LogType best = LOGS;
+        for (LogType log : values()) {
+            if (log.hasRequiredLevel()) {
+                best = log;
+            }
+        }
+        return best;
+    }
+
+    @Override
+    public String toString() {
+        return logName;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/State.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/State.java
@@ -1,0 +1,9 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+public enum State {
+    SCANNING,
+    WALKING_TO_LINE,
+    BURNING,
+    BANKING,
+    WALKING_BACK
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/TileScanner.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguesfiremaking/TileScanner.java
@@ -1,0 +1,125 @@
+package net.runelite.client.plugins.microbot.leaguesfiremaking;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+public class TileScanner {
+
+    private static final int FIRE_ID = 26185;
+    private static final int FIRE_ID_ALT = 49927;
+
+    public enum TileState {
+        OPEN,
+        FIRE,
+        BLOCKED
+    }
+
+    public static TileState classifyTile(WorldPoint point, Set<WorldPoint> fireTiles, Set<WorldPoint> objectTiles) {
+        if (fireTiles.contains(point)) return TileState.FIRE;
+        if (objectTiles.contains(point)) return TileState.BLOCKED;
+        if (!Rs2Tile.isWalkable(point)) return TileState.BLOCKED;
+        return TileState.OPEN;
+    }
+
+    public static List<FireLine> findFireLines(WorldPoint center, int radius) {
+        Set<WorldPoint> fireTiles = new HashSet<>();
+        Set<WorldPoint> objectTiles = new HashSet<>();
+
+        Microbot.getRs2TileObjectCache().getStream()
+                .filter(obj -> obj.getWorldLocation().distanceTo(center) <= radius)
+                .forEach(obj -> {
+                    int id = obj.getId();
+                    WorldPoint loc = obj.getWorldLocation();
+                    if (id == FIRE_ID || id == FIRE_ID_ALT) {
+                        fireTiles.add(loc);
+                    } else {
+                        objectTiles.add(loc);
+                    }
+                });
+
+        List<FireLine> lines = new ArrayList<>();
+        int plane = center.getPlane();
+
+        for (int y = center.getY() - radius; y <= center.getY() + radius; y++) {
+            int runStartX = -1;
+            int runLength = 0;
+
+            for (int x = center.getX() - radius; x <= center.getX() + radius; x++) {
+                WorldPoint point = new WorldPoint(x, y, plane);
+                TileState state = classifyTile(point, fireTiles, objectTiles);
+
+                if (state == TileState.OPEN) {
+                    if (runStartX == -1) {
+                        runStartX = x;
+                    }
+                    runLength++;
+                } else {
+                    if (runLength >= 5) {
+                        lines.add(new FireLine(
+                                new WorldPoint(runStartX, y, plane),
+                                new WorldPoint(runStartX + runLength - 1, y, plane),
+                                runLength
+                        ));
+                    }
+                    runStartX = -1;
+                    runLength = 0;
+                }
+            }
+            if (runLength >= 5) {
+                lines.add(new FireLine(
+                        new WorldPoint(runStartX, y, plane),
+                        new WorldPoint(runStartX + runLength - 1, y, plane),
+                        runLength
+                ));
+            }
+        }
+
+        // Score lines: balance length vs proximity to start position
+        // A nearby shorter line beats a far-away longer one
+        lines.sort(Comparator.comparingDouble((FireLine l) -> {
+            int distance = center.distanceTo(l.getEastEnd());
+            // Penalize distance heavily: each tile away reduces effective score
+            return -(l.getLength() - distance * 0.5);
+        }));
+
+        return lines;
+    }
+
+    public static FireLine findBestLine(WorldPoint center, int radius) {
+        List<FireLine> lines = findFireLines(center, radius);
+        return lines.isEmpty() ? null : lines.get(0);
+    }
+
+    public static boolean hasFire(WorldPoint point) {
+        return Microbot.getRs2TileObjectCache().getStream()
+                .anyMatch(obj -> obj.getWorldLocation().equals(point)
+                        && (obj.getId() == FIRE_ID || obj.getId() == FIRE_ID_ALT));
+    }
+
+    public static Set<WorldPoint> buildFireSet(WorldPoint center, int radius) {
+        Set<WorldPoint> fireTiles = new HashSet<>();
+        Microbot.getRs2TileObjectCache().getStream()
+                .filter(obj -> obj.getWorldLocation().distanceTo(center) <= radius)
+                .filter(obj -> obj.getId() == FIRE_ID || obj.getId() == FIRE_ID_ALT)
+                .forEach(obj -> fireTiles.add(obj.getWorldLocation()));
+        return fireTiles;
+    }
+
+    public static Set<WorldPoint> buildObjectSet(WorldPoint center, int radius) {
+        Set<WorldPoint> objectTiles = new HashSet<>();
+        Microbot.getRs2TileObjectCache().getStream()
+                .filter(obj -> obj.getWorldLocation().distanceTo(center) <= radius)
+                .filter(obj -> obj.getId() != FIRE_ID && obj.getId() != FIRE_ID_ALT)
+                .forEach(obj -> objectTiles.add(obj.getWorldLocation()));
+        return objectTiles;
+    }
+}


### PR DESCRIPTION
## Summary
- New standalone **[DV] AI Firemaking** plugin that scans surrounding tiles to build a spatial map and find optimal east-west fire lines
- Uses `Rs2TileObjectCache` queryable API to classify tiles as open, fire, or blocked
- Lights fires walking west in a line, banks when empty, rescans on return to adapt around existing fires/obstacles/other players
- Supports Bank Heist briefcase toggle for instant Leagues banking, or standard walk-to-bank
- Config: log type dropdown, progressive mode (auto-pick best log for level), scan radius (default 25), briefcase toggle
- Adds `[DV]` purple prefix to `PluginConstants`

## Test plan
- [ ] Start plugin near a bank with logs + tinderbox, verify it scans, walks east, and lights fires walking west
- [ ] Verify it detects standing on a fire and steps west before attempting to light
- [ ] Verify it banks when out of logs and returns to scan for a new line
- [ ] Verify progressive mode picks the correct log type for player level
- [ ] Test in a cluttered area — confirm it picks a nearby short line over a far long one