### PR TITLE
fix(Fletching): match "Logs" item name when using LOG material

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/fletching/FletchingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/fletching/FletchingPlugin.java
@@ -27,7 +27,7 @@ import java.awt.*;
 @Slf4j
 public class FletchingPlugin extends Plugin {
 
-    public static final String version = "1.6.3";
+    public static final String version = "1.6.4";
 
     @Inject
     private FletchingConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/fletching/FletchingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/fletching/FletchingScript.java
@@ -71,7 +71,7 @@ public class FletchingScript extends Script {
                 primaryItemToFletch = fletchingMode.getItemName();
 
                 if (fletchingMode == FletchingMode.PROGRESSIVE) {
-                    secondaryItemToFletch = (model.getFletchingMaterial().getName() + " logs").trim();
+                    secondaryItemToFletch = model.getFletchingMaterial().getLogItemName();
                     hasRequirementsToFletch = Rs2Inventory.hasItem(primaryItemToFletch)
                             && Rs2Inventory.hasItemAmount(secondaryItemToFletch, model.getFletchingItem().getAmountRequired());
                     hasRequirementsToBank = !Rs2Inventory.hasItem(primaryItemToFletch)
@@ -84,7 +84,7 @@ public class FletchingScript extends Script {
                 } else {
                     secondaryItemToFletch = fletchingMode == FletchingMode.STRUNG
                             ? config.fletchingMaterial().getName() + " " + config.fletchingItem().getContainsInventoryName() + " (u)"
-                            : (config.fletchingMaterial().getName() + " logs").trim();
+                            : config.fletchingMaterial().getLogItemName();
                     hasRequirementsToFletch = Rs2Inventory.hasItem(primaryItemToFletch)
                             && Rs2Inventory.hasItemAmount(secondaryItemToFletch, config.fletchingItem().getAmountRequired());
                     hasRequirementsToBank = !Rs2Inventory.hasItem(primaryItemToFletch)
@@ -115,7 +115,7 @@ public class FletchingScript extends Script {
             case PROGRESSIVE:
                 Rs2Bank.depositAll(model.getFletchingItem().getContainsInventoryName());
                 calculateItemToFletch();
-                secondaryItemToFletch = (model.getFletchingMaterial().getName() + " logs").trim();
+                secondaryItemToFletch = model.getFletchingMaterial().getLogItemName();
                 break;
             case PROGRESSIVE_STRUNG:
                 Rs2Bank.depositAll();

--- a/src/main/java/net/runelite/client/plugins/microbot/fletching/enums/FletchingMaterial.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/fletching/enums/FletchingMaterial.java
@@ -18,6 +18,9 @@ public enum FletchingMaterial
 
     private final String name;
 
+    public String getLogItemName() {
+        return this == LOG ? "Logs" : name + " logs";
+    }
 
     @Override
     public String toString()


### PR DESCRIPTION
## Summary
- Fixes a bug where the Fletching plugin could not find regular **Logs** in the bank
- Root cause: secondary item name was constructed as \`material.getName() + \" logs\"\`, producing \`\"Log logs\"\` for \`LOG\` material, which doesn't match the actual OSRS item name \`\"Logs\"\`
- Added \`FletchingMaterial.getLogItemName()\` that special-cases \`LOG\` → \`\"Logs\"\` and returns \`\"<name> logs\"\` for all other materials
- Updated all three call sites in \`FletchingScript\` (progressive, manual, and banking paths)
- Bumped plugin version to 1.6.4

## Test plan
- [ ] Start plugin with material=LOG and a stack of regular Logs in the bank, verify it withdraws them successfully
- [ ] Verify other materials (Oak, Willow, Maple, Yew, Magic, Redwood) still work correctly
- [ ] Verify progressive mode correctly picks up plain Logs when level < 15