### PR TITLE
feat(Crafting): add Nemus Retreat flax spinning location

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/FlaxSpinLocations.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/crafting/enums/FlaxSpinLocations.java
@@ -12,7 +12,8 @@ public enum FlaxSpinLocations {
     FALADOR("Falador", new WorldPoint(2982, 3314, 0), ObjectID.SPINNING_WHEEL_14889),
     SEERS_VILLAGE("Seers Village", new WorldPoint(2711, 3471, 1), ObjectID.SPINNING_WHEEL_25824),
     RELLEKKA("Rellekka", new WorldPoint(2617, 3660, 0), ObjectID.SPINNING_WHEEL),
-    TREE_GNOME_STRONGHOLD("Tree Gnome Stronghold", new WorldPoint(2488, 3409, 1), ObjectID.SPINNING_WHEEL_14889);
+    TREE_GNOME_STRONGHOLD("Tree Gnome Stronghold", new WorldPoint(2488, 3409, 1), ObjectID.SPINNING_WHEEL_14889),
+    NEMUS_RETREAT("Nemus Retreat", new WorldPoint(1373, 3313, 0), 55330);
     // LUMBRIDGE_CASTLE(new WorldPoint(3209, 3213, 1), ObjectID.SPINNING_WHEEL_14889), Issue with web-walker when banking
 
 


### PR DESCRIPTION
## Summary
- Adds **Nemus Retreat** (Varlamore) to the flax spinning location dropdown in the Crafting plugin
- WorldPoint: `(1373, 3313, 0)`, spinning wheel object ID: `55330`

## Test plan
- [ ] Select "Nemus Retreat" in the Crafting plugin's flax spin location dropdown
- [ ] Verify the script walks to the spinning wheel and spins flax correctly
- [ ] Verify banking works from the Nemus Retreat area