### PR TITLE
fix(hunter): add black chinchompa shaking box ID to reset logic

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/microhunter/scripts/AutoChinScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/microhunter/scripts/AutoChinScript.java
@@ -116,6 +116,11 @@ public class AutoChinScript extends Script {
                 currentState = State.CATCHING;
                 return;
             }
+            // Black chinchompa shaking box
+            if (Microbot.getRs2TileObjectCache().query().withId(ObjectID.SHAKING_BOX).within(4).interact("reset")) {
+                currentState = State.CATCHING;
+                return;
+            }
 
             if (Microbot.getRs2TileObjectCache().query().withId(ObjectID.BOX_TRAP_9385).within(4).interact("reset")) {
                 currentState = State.CATCHING;


### PR DESCRIPTION
## Summary
- Added `ObjectID.SHAKING_BOX` (721) to the shaking box reset checks in `handleIdleState()`
- This ID is used for black chinchompa caught boxes in the wilderness
- The plugin was previously unable to reset successfully trapped boxes at black chins because this ID was missing

## Test plan
- [x] Tested at black chinchompa hunting area in wilderness
- [x] Verified shaking boxes are now properly reset when a black chin is caught