### PR TITLE
feat(AIOAIO): add record & replay plugin

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/PluginConstants.java
@@ -36,6 +36,7 @@ public final class PluginConstants
     public static final String BIGL = "<html>[<font color=#b8f704>BL</font>] ";
     public static final String PERT = "<html>[<font color=#FFFF00>P</font>] ";
     public static final String DV = "<html>[<font color=#800080>DV</font>] ";
+    public static final String RED_BRACKET = "<html>[<font color=#FF4D4D>RB</font>] ";
 
     public static final boolean DEFAULT_ENABLED = false;
     public static final boolean IS_EXTERNAL = true; //test

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayConfig.java
@@ -1,0 +1,19 @@
+package net.runelite.client.plugins.microbot.actionreplay;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+
+@ConfigGroup(ActionReplayConfig.GROUP)
+@ConfigInformation(
+	"<html>Enable the plugin, then open the panel.<br>" +
+	"Hit <b>Start recording</b>, do the actions in-game, then stop.<br>" +
+	"Play back anytime from the panel.<br>" +
+	"<br>" +
+	"Developed by Red Bracket. Feel free to make improvements,<br>" +
+	"just try to keep it simple :)</html>"
+)
+public interface ActionReplayConfig extends Config
+{
+	String GROUP = "actionReplay";
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayOverlay.java
@@ -1,0 +1,74 @@
+package net.runelite.client.plugins.microbot.actionreplay;
+
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+
+import javax.inject.Inject;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+
+public class ActionReplayOverlay extends Overlay
+{
+	private static final int DOT_RADIUS = 6;
+	private static final Color RECORD_COLOR = new Color(220, 40, 40);
+	private static final Color PLAY_COLOR = new Color(40, 200, 80);
+
+	private final ActionReplayPlugin plugin;
+
+	@Inject
+	public ActionReplayOverlay(ActionReplayPlugin plugin)
+	{
+		this.plugin = plugin;
+		setPosition(OverlayPosition.TOP_RIGHT);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setPriority(OverlayPriority.HIGH);
+	}
+
+	@Override
+	public Dimension render(Graphics2D g)
+	{
+		boolean recording = plugin.isRecording();
+		boolean playing = plugin.isPlaying();
+		if (!recording && !playing)
+		{
+			return null;
+		}
+
+		boolean blink = ((System.currentTimeMillis() / 500) % 2) == 0;
+		Color color = recording ? RECORD_COLOR : PLAY_COLOR;
+		String label = recording ? "AIO AIO REC" : "AIO AIO PLAY";
+
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+		g.setFont(FontManager.getRunescapeSmallFont());
+		int labelWidth = g.getFontMetrics().stringWidth(label);
+		int textBaseline = g.getFontMetrics().getAscent();
+		int height = Math.max(DOT_RADIUS * 2 + 2, textBaseline + 2);
+		int width = DOT_RADIUS * 2 + 6 + labelWidth;
+
+		int dotY = (height - DOT_RADIUS * 2) / 2;
+		if (blink || playing)
+		{
+			g.setColor(color);
+			g.fillOval(0, dotY, DOT_RADIUS * 2, DOT_RADIUS * 2);
+		}
+		g.setColor(color.darker());
+		g.setStroke(new BasicStroke(1f));
+		g.drawOval(0, dotY, DOT_RADIUS * 2, DOT_RADIUS * 2);
+
+		int textX = DOT_RADIUS * 2 + 6;
+		int textY = (height + textBaseline) / 2 - 1;
+		g.setColor(Color.BLACK);
+		g.drawString(label, textX + 1, textY + 1);
+		g.setColor(Color.WHITE);
+		g.drawString(label, textX, textY);
+
+		return new Dimension(width, height);
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPanel.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPanel.java
@@ -6,7 +6,6 @@ import net.runelite.client.plugins.microbot.actionreplay.model.ConditionType;
 import net.runelite.client.plugins.microbot.actionreplay.model.RecordedAction;
 import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
 import net.runelite.client.plugins.microbot.actionreplay.model.StatKind;
-import net.runelite.client.plugins.microbot.actionreplay.model.TargetType;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
@@ -599,7 +598,7 @@ public class ActionReplayPanel extends PluginPanel
 
 		gc.gridx = 0;
 		JTextField verbField = new JTextField(a.getMenuOption() == null ? "" : a.getMenuOption(), 12);
-		JTextField targetField = new JTextField(a.getMenuTarget() == null ? "" : a.getMenuTarget(), 15);
+		JTextField targetField = new JTextField(a.getTargetName() == null ? "" : a.getTargetName(), 15);
 
 		gc.gridy = 0;
 		form.add(new JLabel("Action:"), gc);
@@ -649,12 +648,7 @@ public class ActionReplayPanel extends PluginPanel
 		String newVerb = verbField.getText().trim();
 		a.setMenuOption(newVerb.isEmpty() ? null : newVerb);
 		String newTarget = targetField.getText().trim();
-		a.setMenuTarget(newTarget.isEmpty() ? null : newTarget);
-		TargetType tt = a.getTargetType();
-		if (tt == TargetType.NPC || tt == TargetType.GAME_OBJECT || tt == TargetType.GROUND_ITEM)
-		{
-			a.setTargetName(newTarget.isEmpty() ? null : newTarget);
-		}
+		a.setTargetName(newTarget.isEmpty() ? null : newTarget);
 		a.setCondition(buildCondition(typeCombo, statCmpCombo, statSpinner, npcNameField, npcPresentCombo,
 			objNameField, objPresentCombo, invNameField, invCountSpinner, invPresentCombo));
 		reloadActionList();

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPanel.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPanel.java
@@ -1,7 +1,12 @@
 package net.runelite.client.plugins.microbot.actionreplay;
 
+import net.runelite.client.plugins.microbot.actionreplay.model.Condition;
+import net.runelite.client.plugins.microbot.actionreplay.model.ConditionComparator;
+import net.runelite.client.plugins.microbot.actionreplay.model.ConditionType;
 import net.runelite.client.plugins.microbot.actionreplay.model.RecordedAction;
 import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
+import net.runelite.client.plugins.microbot.actionreplay.model.StatKind;
+import net.runelite.client.plugins.microbot.actionreplay.model.TargetType;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
@@ -18,11 +23,13 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
+import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import java.awt.BorderLayout;
+import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -39,12 +46,13 @@ import java.util.List;
 public class ActionReplayPanel extends PluginPanel
 {
 	private static final Color MUTED = new Color(160, 160, 160);
-	private static final String CURRENT_LABEL = "(Current recording)";
+	private static final String NO_SCRIPTS_PLACEHOLDER = "(no scripts)";
 
 	private ActionReplayPlugin plugin;
 
 	private final JLabel countLabel = new JLabel(" ");
 	private final JButton recordButton = new JButton("● Record script");
+	private final JButton appendButton = new JButton("⊕");
 	private final JButton stopPlaybackButton = new JButton("■ Stop script");
 
 	private final JComboBox<String> scriptSelector = new JComboBox<>();
@@ -55,13 +63,11 @@ public class ActionReplayPanel extends PluginPanel
 	private final JButton downButton = new JButton("↓");
 	private final JButton deleteStepButton = new JButton("✕");
 	private final JButton editStepButton = new JButton("✎");
-	private final JButton duplicateStepButton = new JButton("⧉");
 	private final JButton playButton = new JButton("▶ Run script");
 	private final JButton renameButton = new JButton("✎ Rename");
 	private final JButton deleteScriptButton = new JButton("🗑 Delete");
 
 	private Recording viewedRecording;
-	private Recording lastLiveRecording;
 	private List<Recording> savedRecordings = new ArrayList<>();
 	private boolean suppressSelectorEvents = false;
 
@@ -102,7 +108,7 @@ public class ActionReplayPanel extends PluginPanel
 		playButton.setAlignmentX(Component.LEFT_ALIGNMENT);
 		playButton.setForeground(Color.WHITE);
 		playButton.setToolTipText("Loop selected script until stopped");
-		playButton.addActionListener(e -> onPlay(true));
+		playButton.addActionListener(e -> onPlay());
 
 		stopPlaybackButton.setAlignmentX(Component.LEFT_ALIGNMENT);
 		stopPlaybackButton.setForeground(Color.WHITE);
@@ -186,9 +192,9 @@ public class ActionReplayPanel extends PluginPanel
 		editStepButton.addActionListener(e -> onEditStep());
 		editRow.add(editStepButton);
 
-		initSmallButton(duplicateStepButton, "Duplicate selected step");
-		duplicateStepButton.addActionListener(e -> onDuplicateStep());
-		editRow.add(duplicateStepButton);
+		initSmallButton(appendButton, "Append more actions to the selected script");
+		appendButton.addActionListener(e -> onAppendClicked());
+		editRow.add(appendButton);
 
 		initSmallButton(deleteStepButton, "Delete selected step(s)");
 		deleteStepButton.addActionListener(e -> onDeleteStep());
@@ -237,36 +243,30 @@ public class ActionReplayPanel extends PluginPanel
 		{
 			boolean rec = plugin.isRecording();
 			boolean play = plugin.isPlaying();
+			boolean appending = plugin.isAppendingToExisting();
 
 			if (rec)
 			{
-				recordButton.setText("■ Stop recording");
 				countLabel.setText("Captured: " + plugin.getCurrentRecordingSize() + " actions");
 				countLabel.setForeground(MUTED);
 			}
 			else
 			{
-				recordButton.setText("● Record script");
 				countLabel.setText(" ");
 			}
-			recordButton.setEnabled(!play);
-			stopPlaybackButton.setEnabled(play);
 
-			if (rec)
-			{
-				viewedRecording = null;
-			}
+			stopPlaybackButton.setEnabled(play);
 
 			refreshSelector();
 			reloadActionList();
-			updateButtonEnabled(rec, play);
+			updateButtonEnabled(rec, play, appending);
 
 			revalidate();
 			repaint();
 		});
 	}
 
-	private void updateButtonEnabled(boolean rec, boolean play)
+	private void updateButtonEnabled(boolean rec, boolean play, boolean appending)
 	{
 		Recording selected = getSelectedRecording();
 		boolean hasActions = selected != null && selected.size() > 0;
@@ -276,13 +276,34 @@ public class ActionReplayPanel extends PluginPanel
 		downButton.setEnabled(canEditSteps);
 		deleteStepButton.setEnabled(canEditSteps);
 		editStepButton.setEnabled(canEditSteps);
-		duplicateStepButton.setEnabled(canEditSteps);
 
 		playButton.setEnabled(!rec && !play && hasActions);
 		renameButton.setEnabled(!rec && !play && viewedRecording != null);
 		deleteScriptButton.setEnabled(!rec && !play && viewedRecording != null);
 
-		scriptSelector.setEnabled(!rec);
+		scriptSelector.setEnabled(!rec && !savedRecordings.isEmpty());
+
+		if (rec && !appending)
+		{
+			recordButton.setText("■ Stop recording");
+			recordButton.setEnabled(true);
+			appendButton.setText("⊕");
+			appendButton.setEnabled(false);
+		}
+		else if (rec)
+		{
+			recordButton.setText("● Record script");
+			recordButton.setEnabled(false);
+			appendButton.setText("■");
+			appendButton.setEnabled(true);
+		}
+		else
+		{
+			recordButton.setText("● Record script");
+			recordButton.setEnabled(!play);
+			appendButton.setText("⊕");
+			appendButton.setEnabled(!play && viewedRecording != null);
+		}
 	}
 
 	private void refreshSelector()
@@ -290,29 +311,37 @@ public class ActionReplayPanel extends PluginPanel
 		suppressSelectorEvents = true;
 		try
 		{
-			String prev = viewedRecording != null ? viewedRecording.getName() : CURRENT_LABEL;
-			scriptSelector.removeAllItems();
-			scriptSelector.addItem(CURRENT_LABEL);
 			savedRecordings = plugin.listRecordings();
+			scriptSelector.removeAllItems();
+
+			if (savedRecordings.isEmpty())
+			{
+				scriptSelector.addItem(NO_SCRIPTS_PLACEHOLDER);
+				scriptSelector.setSelectedIndex(0);
+				viewedRecording = null;
+				return;
+			}
+
 			for (Recording r : savedRecordings)
 			{
 				scriptSelector.addItem(r.getName());
 			}
-			boolean matched = false;
-			for (int i = 0; i < scriptSelector.getItemCount(); i++)
+
+			String targetName = viewedRecording != null ? viewedRecording.getName() : null;
+			int selectedIdx = 0;
+			if (targetName != null)
 			{
-				if (prev.equals(scriptSelector.getItemAt(i)))
+				for (int i = 0; i < savedRecordings.size(); i++)
 				{
-					scriptSelector.setSelectedIndex(i);
-					matched = true;
-					break;
+					if (targetName.equals(savedRecordings.get(i).getName()))
+					{
+						selectedIdx = i;
+						break;
+					}
 				}
 			}
-			if (!matched)
-			{
-				scriptSelector.setSelectedIndex(0);
-				viewedRecording = null;
-			}
+			scriptSelector.setSelectedIndex(selectedIdx);
+			viewedRecording = savedRecordings.get(selectedIdx);
 		}
 		finally
 		{
@@ -323,33 +352,25 @@ public class ActionReplayPanel extends PluginPanel
 	private void onSelectorChanged()
 	{
 		int idx = scriptSelector.getSelectedIndex();
-		if (idx <= 0)
+		if (idx >= 0 && idx < savedRecordings.size())
 		{
-			viewedRecording = null;
+			viewedRecording = savedRecordings.get(idx);
 		}
 		else
 		{
-			int savedIdx = idx - 1;
-			if (savedIdx >= 0 && savedIdx < savedRecordings.size())
-			{
-				viewedRecording = savedRecordings.get(savedIdx);
-			}
+			viewedRecording = null;
 		}
 		reloadActionList();
-		updateButtonEnabled(plugin.isRecording(), plugin.isPlaying());
+		updateButtonEnabled(plugin.isRecording(), plugin.isPlaying(), plugin.isAppendingToExisting());
 	}
 
 	private Recording getSelectedRecording()
 	{
-		if (viewedRecording != null)
-		{
-			return viewedRecording;
-		}
 		if (plugin.isRecording())
 		{
 			return plugin.getCurrentRecording();
 		}
-		return lastLiveRecording;
+		return viewedRecording;
 	}
 
 	private void reloadActionList()
@@ -375,7 +396,7 @@ public class ActionReplayPanel extends PluginPanel
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			if (viewedRecording == null)
+			if (plugin.isRecording())
 			{
 				int idx = actionsModel.size();
 				actionsModel.addElement(format(idx, action));
@@ -393,17 +414,33 @@ public class ActionReplayPanel extends PluginPanel
 			Recording saved = plugin.stopRecording(true);
 			if (saved != null)
 			{
-				lastLiveRecording = saved;
+				viewedRecording = saved;
 			}
-			viewedRecording = null;
 			refresh();
 		}
 		else
 		{
 			actionsModel.clear();
 			viewedRecording = null;
-			lastLiveRecording = null;
-			plugin.startRecording();
+			plugin.startRecording(null);
+			refresh();
+		}
+	}
+
+	private void onAppendClicked()
+	{
+		if (plugin.isRecording())
+		{
+			plugin.stopRecording(true);
+			refresh();
+		}
+		else
+		{
+			if (viewedRecording == null)
+			{
+				return;
+			}
+			plugin.startRecording(viewedRecording);
 			refresh();
 		}
 	}
@@ -489,75 +526,205 @@ public class ActionReplayPanel extends PluginPanel
 		SpinnerNumberModel spinnerModel = new SpinnerNumberModel(currentTicks, 0, 1000, 1);
 		JSpinner ticksSpinner = new JSpinner(spinnerModel);
 
+		String[] typeOptions = {"None", "HP", "Prayer", "NPC nearby", "Object nearby", "Inventory"};
+		JComboBox<String> typeCombo = new JComboBox<>(typeOptions);
+		JComboBox<String> statCmpCombo = new JComboBox<>(new String[]{"below", "above"});
+		JSpinner statSpinner = new JSpinner(new SpinnerNumberModel(20, 0, 9999, 1));
+		JTextField npcNameField = new JTextField(15);
+		JComboBox<String> npcPresentCombo = new JComboBox<>(new String[]{"present", "absent"});
+		JTextField objNameField = new JTextField(15);
+		JComboBox<String> objPresentCombo = new JComboBox<>(new String[]{"present", "absent"});
+		JTextField invNameField = new JTextField(15);
+		JSpinner invCountSpinner = new JSpinner(new SpinnerNumberModel(1, 1, 9999, 1));
+		JComboBox<String> invPresentCombo = new JComboBox<>(new String[]{"present", "absent"});
+
+		Condition existing = a.getCondition();
+		if (existing != null && existing.getType() != null)
+		{
+			switch (existing.getType())
+			{
+				case STAT:
+					typeCombo.setSelectedItem(existing.getStat() == StatKind.PRAYER ? "Prayer" : "HP");
+					statCmpCombo.setSelectedItem(existing.getComparator() == ConditionComparator.ABOVE ? "above" : "below");
+					if (existing.getThreshold() != null) statSpinner.setValue(existing.getThreshold());
+					break;
+				case NPC_NEARBY:
+					typeCombo.setSelectedItem("NPC nearby");
+					if (existing.getName() != null) npcNameField.setText(existing.getName());
+					npcPresentCombo.setSelectedItem(Boolean.FALSE.equals(existing.getPresent()) ? "absent" : "present");
+					break;
+				case OBJECT_NEARBY:
+					typeCombo.setSelectedItem("Object nearby");
+					if (existing.getName() != null) objNameField.setText(existing.getName());
+					objPresentCombo.setSelectedItem(Boolean.FALSE.equals(existing.getPresent()) ? "absent" : "present");
+					break;
+				case INVENTORY:
+					typeCombo.setSelectedItem("Inventory");
+					if (existing.getName() != null) invNameField.setText(existing.getName());
+					if (existing.getMinCount() != null && existing.getMinCount() > 0) invCountSpinner.setValue(existing.getMinCount());
+					invPresentCombo.setSelectedItem(Boolean.FALSE.equals(existing.getPresent()) ? "absent" : "present");
+					break;
+			}
+		}
+
+		JPanel statPanel = hBox(statCmpCombo, statSpinner);
+		JPanel npcPanel = hBox(new JLabel("name:"), npcNameField, npcPresentCombo);
+		JPanel objPanel = hBox(new JLabel("name:"), objNameField, objPresentCombo);
+		JPanel invPanel = hBox(new JLabel("item:"), invNameField, new JLabel("min:"), invCountSpinner, invPresentCombo);
+
+		CardLayout cardLayout = new CardLayout();
+		JPanel cards = new JPanel(cardLayout);
+		cards.add(new JPanel(), "None");
+		cards.add(statPanel, "Stat");
+		cards.add(npcPanel, "NPC nearby");
+		cards.add(objPanel, "Object nearby");
+		cards.add(invPanel, "Inventory");
+
+		Runnable showCard = () ->
+		{
+			String sel = (String) typeCombo.getSelectedItem();
+			String card;
+			if ("HP".equals(sel) || "Prayer".equals(sel)) card = "Stat";
+			else if (sel == null || "None".equals(sel)) card = "None";
+			else card = sel;
+			cardLayout.show(cards, card);
+		};
+		typeCombo.addActionListener(e -> showCard.run());
+		showCard.run();
+
 		JPanel form = new JPanel(new GridBagLayout());
 		GridBagConstraints gc = new GridBagConstraints();
 		gc.insets = new Insets(4, 4, 4, 4);
 		gc.anchor = GridBagConstraints.WEST;
 
 		gc.gridx = 0;
+		JTextField verbField = new JTextField(a.getMenuOption() == null ? "" : a.getMenuOption(), 12);
+		JTextField targetField = new JTextField(a.getMenuTarget() == null ? "" : a.getMenuTarget(), 15);
+
 		gc.gridy = 0;
 		form.add(new JLabel("Action:"), gc);
 		gc.gridx = 1;
-		form.add(new JLabel(a.describe()), gc);
+		form.add(verbField, gc);
 
 		gc.gridx = 0;
 		gc.gridy = 1;
+		form.add(new JLabel("Target:"), gc);
+		gc.gridx = 1;
+		form.add(targetField, gc);
+
+		gc.gridx = 0;
+		gc.gridy = 2;
 		form.add(new JLabel("Delay before (ticks):"), gc);
 		gc.gridx = 1;
 		form.add(ticksSpinner, gc);
 
-		int choice = JOptionPane.showConfirmDialog(this, form, "Edit step #" + (idx + 1),
-			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
-		if (choice != JOptionPane.OK_OPTION)
+		gc.gridx = 0;
+		gc.gridy = 3;
+		form.add(new JLabel("Condition:"), gc);
+		gc.gridx = 1;
+		form.add(typeCombo, gc);
+
+		gc.gridx = 0;
+		gc.gridy = 4;
+		gc.gridwidth = 2;
+		form.add(cards, gc);
+
+		Object[] options = {"OK", "Delete", "Cancel"};
+		int choice = JOptionPane.showOptionDialog(this, form, "Edit step #" + (idx + 1),
+			JOptionPane.DEFAULT_OPTION, JOptionPane.PLAIN_MESSAGE, null, options, options[0]);
+		if (choice == 1)
+		{
+			r.getActions().remove(idx);
+			reloadActionList();
+			persistIfSaved(r);
+			return;
+		}
+		if (choice != 0)
 		{
 			return;
 		}
 
 		int newTicks = (Integer) ticksSpinner.getValue();
 		a.setDelayTicksBefore(newTicks);
-		a.setDelayMsBefore(newTicks * 600L);
+		String newVerb = verbField.getText().trim();
+		a.setMenuOption(newVerb.isEmpty() ? null : newVerb);
+		String newTarget = targetField.getText().trim();
+		a.setMenuTarget(newTarget.isEmpty() ? null : newTarget);
+		TargetType tt = a.getTargetType();
+		if (tt == TargetType.NPC || tt == TargetType.GAME_OBJECT || tt == TargetType.GROUND_ITEM)
+		{
+			a.setTargetName(newTarget.isEmpty() ? null : newTarget);
+		}
+		a.setCondition(buildCondition(typeCombo, statCmpCombo, statSpinner, npcNameField, npcPresentCombo,
+			objNameField, objPresentCombo, invNameField, invCountSpinner, invPresentCombo));
 		reloadActionList();
 		actionsList.setSelectedIndex(idx);
 		persistIfSaved(r);
 	}
 
-	private void onDuplicateStep()
+	private static JPanel hBox(Component... components)
 	{
-		Recording r = getSelectedRecording();
-		if (r == null)
+		JPanel p = new JPanel();
+		p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
+		for (int i = 0; i < components.length; i++)
 		{
-			return;
+			if (i > 0) p.add(Box.createHorizontalStrut(4));
+			p.add(components[i]);
 		}
-		int idx = actionsList.getSelectedIndex();
-		if (idx < 0 || idx >= r.getActions().size())
-		{
-			return;
-		}
-		RecordedAction copy = cloneAction(r.getActions().get(idx));
-		r.getActions().add(idx + 1, copy);
-		reloadActionList();
-		actionsList.setSelectedIndex(idx + 1);
-		persistIfSaved(r);
+		return p;
 	}
 
-	private static RecordedAction cloneAction(RecordedAction src)
+	private static Condition buildCondition(JComboBox<String> typeCombo, JComboBox<String> statCmpCombo, JSpinner statSpinner,
+		JTextField npcNameField, JComboBox<String> npcPresentCombo,
+		JTextField objNameField, JComboBox<String> objPresentCombo,
+		JTextField invNameField, JSpinner invCountSpinner, JComboBox<String> invPresentCombo)
 	{
-		RecordedAction dst = new RecordedAction();
-		dst.setDelayMsBefore(src.getDelayMsBefore());
-		dst.setDelayTicksBefore(src.getDelayTicksBefore());
-		dst.setMenuOption(src.getMenuOption());
-		dst.setMenuTarget(src.getMenuTarget());
-		dst.setMenuAction(src.getMenuAction());
-		dst.setTargetType(src.getTargetType());
-		dst.setIdentifier(src.getIdentifier());
-		dst.setParam0(src.getParam0());
-		dst.setParam1(src.getParam1());
-		dst.setItemId(src.getItemId());
-		dst.setTargetName(src.getTargetName());
-		dst.setTargetId(src.getTargetId());
-		dst.setCanvasX(src.getCanvasX());
-		dst.setCanvasY(src.getCanvasY());
-		return dst;
+		String sel = (String) typeCombo.getSelectedItem();
+		if (sel == null || "None".equals(sel))
+		{
+			return null;
+		}
+		Condition c = new Condition();
+		switch (sel)
+		{
+			case "HP":
+			case "Prayer":
+				c.setType(ConditionType.STAT);
+				c.setStat("Prayer".equals(sel) ? StatKind.PRAYER : StatKind.HEALTH);
+				c.setComparator("above".equals(statCmpCombo.getSelectedItem()) ? ConditionComparator.ABOVE : ConditionComparator.BELOW);
+				c.setThreshold((Integer) statSpinner.getValue());
+				return c;
+			case "NPC nearby":
+			{
+				String nm = npcNameField.getText().trim();
+				if (nm.isEmpty()) return null;
+				c.setType(ConditionType.NPC_NEARBY);
+				c.setName(nm);
+				c.setPresent(!"absent".equals(npcPresentCombo.getSelectedItem()));
+				return c;
+			}
+			case "Object nearby":
+			{
+				String nm = objNameField.getText().trim();
+				if (nm.isEmpty()) return null;
+				c.setType(ConditionType.OBJECT_NEARBY);
+				c.setName(nm);
+				c.setPresent(!"absent".equals(objPresentCombo.getSelectedItem()));
+				return c;
+			}
+			case "Inventory":
+			{
+				String nm = invNameField.getText().trim();
+				if (nm.isEmpty()) return null;
+				c.setType(ConditionType.INVENTORY);
+				c.setName(nm);
+				c.setMinCount((Integer) invCountSpinner.getValue());
+				c.setPresent(!"absent".equals(invPresentCombo.getSelectedItem()));
+				return c;
+			}
+			default:
+				return null;
+		}
 	}
 
 	private void persistIfSaved(Recording r)
@@ -578,14 +745,14 @@ public class ActionReplayPanel extends PluginPanel
 		}
 	}
 
-	private void onPlay(boolean loop)
+	private void onPlay()
 	{
 		Recording r = getSelectedRecording();
 		if (r == null || r.size() == 0)
 		{
 			return;
 		}
-		plugin.play(r, loop);
+		plugin.play(r);
 	}
 
 	private void onRename()
@@ -643,6 +810,15 @@ public class ActionReplayPanel extends PluginPanel
 	{
 		Integer ticks = a.getDelayTicksBefore();
 		String delay = ticks == null ? "—" : ticks + "t";
-		return String.format("%03d  %s  (%s)", idx + 1, a.describe(), delay);
+		String prefix = "";
+		if (a.getCondition() != null)
+		{
+			String desc = a.getCondition().describe();
+			if (!desc.isEmpty())
+			{
+				prefix = "[" + desc + "]  ";
+			}
+		}
+		return prefix + a.describe() + "  (" + delay + ")";
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPanel.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPanel.java
@@ -1,0 +1,648 @@
+package net.runelite.client.plugins.microbot.actionreplay;
+
+import net.runelite.client.plugins.microbot.actionreplay.model.RecordedAction;
+import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.PluginPanel;
+
+import javax.inject.Inject;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSpinner;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ActionReplayPanel extends PluginPanel
+{
+	private static final Color MUTED = new Color(160, 160, 160);
+	private static final String CURRENT_LABEL = "(Current recording)";
+
+	private ActionReplayPlugin plugin;
+
+	private final JLabel countLabel = new JLabel(" ");
+	private final JButton recordButton = new JButton("● Record script");
+	private final JButton stopPlaybackButton = new JButton("■ Stop script");
+
+	private final JComboBox<String> scriptSelector = new JComboBox<>();
+	private final DefaultListModel<String> actionsModel = new DefaultListModel<>();
+	private final JList<String> actionsList = new JList<>(actionsModel);
+
+	private final JButton upButton = new JButton("↑");
+	private final JButton downButton = new JButton("↓");
+	private final JButton deleteStepButton = new JButton("✕");
+	private final JButton editStepButton = new JButton("✎");
+	private final JButton duplicateStepButton = new JButton("⧉");
+	private final JButton playButton = new JButton("▶ Run script");
+	private final JButton renameButton = new JButton("✎ Rename");
+	private final JButton deleteScriptButton = new JButton("🗑 Delete");
+
+	private Recording viewedRecording;
+	private Recording lastLiveRecording;
+	private List<Recording> savedRecordings = new ArrayList<>();
+	private boolean suppressSelectorEvents = false;
+
+	@Inject
+	public ActionReplayPanel()
+	{
+		super(false);
+		setBorder(new EmptyBorder(10, 10, 10, 10));
+		setLayout(new BorderLayout(0, 10));
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		add(buildHeader(), BorderLayout.NORTH);
+		add(buildCenter(), BorderLayout.CENTER);
+	}
+
+	private JPanel buildHeader()
+	{
+		JPanel header = new JPanel();
+		header.setLayout(new BoxLayout(header, BoxLayout.Y_AXIS));
+		header.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JLabel title = new JLabel("AIO AIO");
+		title.setFont(FontManager.getRunescapeBoldFont());
+		title.setForeground(Color.WHITE);
+		title.setAlignmentX(Component.LEFT_ALIGNMENT);
+		header.add(title);
+		header.add(Box.createVerticalStrut(6));
+
+		countLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		header.add(countLabel);
+
+		header.add(Box.createVerticalStrut(8));
+
+		recordButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+		recordButton.setForeground(Color.WHITE);
+		recordButton.addActionListener(e -> onRecordClicked());
+
+		playButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+		playButton.setForeground(Color.WHITE);
+		playButton.setToolTipText("Loop selected script until stopped");
+		playButton.addActionListener(e -> onPlay(true));
+
+		stopPlaybackButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+		stopPlaybackButton.setForeground(Color.WHITE);
+		stopPlaybackButton.addActionListener(e -> plugin.stopPlayback());
+
+		header.add(playButton);
+		header.add(Box.createVerticalStrut(4));
+		header.add(stopPlaybackButton);
+		header.add(Box.createVerticalStrut(4));
+		header.add(recordButton);
+
+		return header;
+	}
+
+	private JPanel buildCenter()
+	{
+		JPanel center = new JPanel();
+		center.setLayout(new BoxLayout(center, BoxLayout.Y_AXIS));
+		center.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JLabel selectorLabel = new JLabel("Script:");
+		selectorLabel.setForeground(MUTED);
+		selectorLabel.setFont(selectorLabel.getFont().deriveFont(11f));
+		selectorLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		center.add(selectorLabel);
+		center.add(Box.createVerticalStrut(2));
+
+		scriptSelector.setAlignmentX(Component.LEFT_ALIGNMENT);
+		scriptSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, 24));
+		scriptSelector.addActionListener(e ->
+		{
+			if (!suppressSelectorEvents)
+			{
+				onSelectorChanged();
+			}
+		});
+		center.add(scriptSelector);
+		center.add(Box.createVerticalStrut(4));
+
+		actionsList.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		actionsList.setForeground(Color.WHITE);
+		actionsList.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				if (e.getClickCount() == 2)
+				{
+					int idx = actionsList.locationToIndex(e.getPoint());
+					if (idx >= 0)
+					{
+						actionsList.setSelectedIndex(idx);
+						onEditStep();
+					}
+				}
+			}
+		});
+		JScrollPane scroll = new JScrollPane(actionsList);
+		scroll.setPreferredSize(new Dimension(220, 200));
+		scroll.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		scroll.setAlignmentX(Component.LEFT_ALIGNMENT);
+		scroll.setBorder(null);
+		scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		center.add(scroll);
+		center.add(Box.createVerticalStrut(6));
+
+		JPanel editRow = new JPanel(new GridLayout(1, 5, 3, 0));
+		editRow.setOpaque(false);
+		editRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+		editRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
+
+		initSmallButton(upButton, "Move step up");
+		upButton.addActionListener(e -> onMoveUp());
+		editRow.add(upButton);
+
+		initSmallButton(downButton, "Move step down");
+		downButton.addActionListener(e -> onMoveDown());
+		editRow.add(downButton);
+
+		initSmallButton(editStepButton, "Edit step (double-click works too)");
+		editStepButton.addActionListener(e -> onEditStep());
+		editRow.add(editStepButton);
+
+		initSmallButton(duplicateStepButton, "Duplicate selected step");
+		duplicateStepButton.addActionListener(e -> onDuplicateStep());
+		editRow.add(duplicateStepButton);
+
+		initSmallButton(deleteStepButton, "Delete selected step(s)");
+		deleteStepButton.addActionListener(e -> onDeleteStep());
+		editRow.add(deleteStepButton);
+
+		center.add(editRow);
+		center.add(Box.createVerticalStrut(6));
+
+		JPanel scriptRow = new JPanel(new GridLayout(1, 2, 4, 4));
+		scriptRow.setOpaque(false);
+		scriptRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+		scriptRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, 32));
+
+		renameButton.setToolTipText("Rename selected script");
+		renameButton.addActionListener(e -> onRename());
+		scriptRow.add(renameButton);
+
+		deleteScriptButton.setToolTipText("Delete selected script");
+		deleteScriptButton.addActionListener(e -> onDeleteScript());
+		scriptRow.add(deleteScriptButton);
+
+		center.add(scriptRow);
+
+		return center;
+	}
+
+	private void initSmallButton(JButton b, String tooltip)
+	{
+		b.setToolTipText(tooltip);
+		b.setMargin(new java.awt.Insets(2, 4, 2, 4));
+		b.setFocusPainted(false);
+	}
+
+	public void setPlugin(ActionReplayPlugin plugin)
+	{
+		this.plugin = plugin;
+	}
+
+	public void refresh()
+	{
+		if (plugin == null)
+		{
+			return;
+		}
+		SwingUtilities.invokeLater(() ->
+		{
+			boolean rec = plugin.isRecording();
+			boolean play = plugin.isPlaying();
+
+			if (rec)
+			{
+				recordButton.setText("■ Stop recording");
+				countLabel.setText("Captured: " + plugin.getCurrentRecordingSize() + " actions");
+				countLabel.setForeground(MUTED);
+			}
+			else
+			{
+				recordButton.setText("● Record script");
+				countLabel.setText(" ");
+			}
+			recordButton.setEnabled(!play);
+			stopPlaybackButton.setEnabled(play);
+
+			if (rec)
+			{
+				viewedRecording = null;
+			}
+
+			refreshSelector();
+			reloadActionList();
+			updateButtonEnabled(rec, play);
+
+			revalidate();
+			repaint();
+		});
+	}
+
+	private void updateButtonEnabled(boolean rec, boolean play)
+	{
+		Recording selected = getSelectedRecording();
+		boolean hasActions = selected != null && selected.size() > 0;
+		boolean canEditSteps = !rec && !play && hasActions;
+
+		upButton.setEnabled(canEditSteps);
+		downButton.setEnabled(canEditSteps);
+		deleteStepButton.setEnabled(canEditSteps);
+		editStepButton.setEnabled(canEditSteps);
+		duplicateStepButton.setEnabled(canEditSteps);
+
+		playButton.setEnabled(!rec && !play && hasActions);
+		renameButton.setEnabled(!rec && !play && viewedRecording != null);
+		deleteScriptButton.setEnabled(!rec && !play && viewedRecording != null);
+
+		scriptSelector.setEnabled(!rec);
+	}
+
+	private void refreshSelector()
+	{
+		suppressSelectorEvents = true;
+		try
+		{
+			String prev = viewedRecording != null ? viewedRecording.getName() : CURRENT_LABEL;
+			scriptSelector.removeAllItems();
+			scriptSelector.addItem(CURRENT_LABEL);
+			savedRecordings = plugin.listRecordings();
+			for (Recording r : savedRecordings)
+			{
+				scriptSelector.addItem(r.getName());
+			}
+			boolean matched = false;
+			for (int i = 0; i < scriptSelector.getItemCount(); i++)
+			{
+				if (prev.equals(scriptSelector.getItemAt(i)))
+				{
+					scriptSelector.setSelectedIndex(i);
+					matched = true;
+					break;
+				}
+			}
+			if (!matched)
+			{
+				scriptSelector.setSelectedIndex(0);
+				viewedRecording = null;
+			}
+		}
+		finally
+		{
+			suppressSelectorEvents = false;
+		}
+	}
+
+	private void onSelectorChanged()
+	{
+		int idx = scriptSelector.getSelectedIndex();
+		if (idx <= 0)
+		{
+			viewedRecording = null;
+		}
+		else
+		{
+			int savedIdx = idx - 1;
+			if (savedIdx >= 0 && savedIdx < savedRecordings.size())
+			{
+				viewedRecording = savedRecordings.get(savedIdx);
+			}
+		}
+		reloadActionList();
+		updateButtonEnabled(plugin.isRecording(), plugin.isPlaying());
+	}
+
+	private Recording getSelectedRecording()
+	{
+		if (viewedRecording != null)
+		{
+			return viewedRecording;
+		}
+		if (plugin.isRecording())
+		{
+			return plugin.getCurrentRecording();
+		}
+		return lastLiveRecording;
+	}
+
+	private void reloadActionList()
+	{
+		int prevSelected = actionsList.getSelectedIndex();
+		Recording r = getSelectedRecording();
+		actionsModel.clear();
+		if (r == null || r.getActions() == null || r.getActions().isEmpty())
+		{
+			return;
+		}
+		for (int i = 0; i < r.getActions().size(); i++)
+		{
+			actionsModel.addElement(format(i, r.getActions().get(i)));
+		}
+		if (prevSelected >= 0 && prevSelected < actionsModel.size())
+		{
+			actionsList.setSelectedIndex(prevSelected);
+		}
+	}
+
+	public void onActionRecorded(RecordedAction action)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			if (viewedRecording == null)
+			{
+				int idx = actionsModel.size();
+				actionsModel.addElement(format(idx, action));
+				actionsList.ensureIndexIsVisible(idx);
+			}
+			countLabel.setText("Captured: " + plugin.getCurrentRecordingSize() + " actions");
+			countLabel.setForeground(MUTED);
+		});
+	}
+
+	private void onRecordClicked()
+	{
+		if (plugin.isRecording())
+		{
+			Recording saved = plugin.stopRecording(true);
+			if (saved != null)
+			{
+				lastLiveRecording = saved;
+			}
+			viewedRecording = null;
+			refresh();
+		}
+		else
+		{
+			actionsModel.clear();
+			viewedRecording = null;
+			lastLiveRecording = null;
+			plugin.startRecording();
+			refresh();
+		}
+	}
+
+	private void onMoveUp()
+	{
+		Recording r = getSelectedRecording();
+		if (r == null)
+		{
+			return;
+		}
+		int idx = actionsList.getSelectedIndex();
+		if (idx <= 0)
+		{
+			return;
+		}
+		List<RecordedAction> actions = r.getActions();
+		RecordedAction moved = actions.remove(idx);
+		actions.add(idx - 1, moved);
+		reloadActionList();
+		actionsList.setSelectedIndex(idx - 1);
+		persistIfSaved(r);
+	}
+
+	private void onMoveDown()
+	{
+		Recording r = getSelectedRecording();
+		if (r == null)
+		{
+			return;
+		}
+		int idx = actionsList.getSelectedIndex();
+		if (idx < 0 || idx >= r.getActions().size() - 1)
+		{
+			return;
+		}
+		List<RecordedAction> actions = r.getActions();
+		RecordedAction moved = actions.remove(idx);
+		actions.add(idx + 1, moved);
+		reloadActionList();
+		actionsList.setSelectedIndex(idx + 1);
+		persistIfSaved(r);
+	}
+
+	private void onDeleteStep()
+	{
+		Recording r = getSelectedRecording();
+		if (r == null)
+		{
+			return;
+		}
+		int[] selected = actionsList.getSelectedIndices();
+		if (selected.length == 0)
+		{
+			return;
+		}
+		for (int i = selected.length - 1; i >= 0; i--)
+		{
+			if (selected[i] >= 0 && selected[i] < r.getActions().size())
+			{
+				r.getActions().remove(selected[i]);
+			}
+		}
+		reloadActionList();
+		persistIfSaved(r);
+	}
+
+	private void onEditStep()
+	{
+		Recording r = getSelectedRecording();
+		if (r == null)
+		{
+			return;
+		}
+		int idx = actionsList.getSelectedIndex();
+		if (idx < 0 || idx >= r.getActions().size())
+		{
+			return;
+		}
+		RecordedAction a = r.getActions().get(idx);
+
+		int currentTicks = a.getDelayTicksBefore() != null ? a.getDelayTicksBefore() : 0;
+		SpinnerNumberModel spinnerModel = new SpinnerNumberModel(currentTicks, 0, 1000, 1);
+		JSpinner ticksSpinner = new JSpinner(spinnerModel);
+
+		JPanel form = new JPanel(new GridBagLayout());
+		GridBagConstraints gc = new GridBagConstraints();
+		gc.insets = new Insets(4, 4, 4, 4);
+		gc.anchor = GridBagConstraints.WEST;
+
+		gc.gridx = 0;
+		gc.gridy = 0;
+		form.add(new JLabel("Action:"), gc);
+		gc.gridx = 1;
+		form.add(new JLabel(a.describe()), gc);
+
+		gc.gridx = 0;
+		gc.gridy = 1;
+		form.add(new JLabel("Delay before (ticks):"), gc);
+		gc.gridx = 1;
+		form.add(ticksSpinner, gc);
+
+		int choice = JOptionPane.showConfirmDialog(this, form, "Edit step #" + (idx + 1),
+			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+		if (choice != JOptionPane.OK_OPTION)
+		{
+			return;
+		}
+
+		int newTicks = (Integer) ticksSpinner.getValue();
+		a.setDelayTicksBefore(newTicks);
+		a.setDelayMsBefore(newTicks * 600L);
+		reloadActionList();
+		actionsList.setSelectedIndex(idx);
+		persistIfSaved(r);
+	}
+
+	private void onDuplicateStep()
+	{
+		Recording r = getSelectedRecording();
+		if (r == null)
+		{
+			return;
+		}
+		int idx = actionsList.getSelectedIndex();
+		if (idx < 0 || idx >= r.getActions().size())
+		{
+			return;
+		}
+		RecordedAction copy = cloneAction(r.getActions().get(idx));
+		r.getActions().add(idx + 1, copy);
+		reloadActionList();
+		actionsList.setSelectedIndex(idx + 1);
+		persistIfSaved(r);
+	}
+
+	private static RecordedAction cloneAction(RecordedAction src)
+	{
+		RecordedAction dst = new RecordedAction();
+		dst.setDelayMsBefore(src.getDelayMsBefore());
+		dst.setDelayTicksBefore(src.getDelayTicksBefore());
+		dst.setMenuOption(src.getMenuOption());
+		dst.setMenuTarget(src.getMenuTarget());
+		dst.setMenuAction(src.getMenuAction());
+		dst.setTargetType(src.getTargetType());
+		dst.setIdentifier(src.getIdentifier());
+		dst.setParam0(src.getParam0());
+		dst.setParam1(src.getParam1());
+		dst.setItemId(src.getItemId());
+		dst.setTargetName(src.getTargetName());
+		dst.setTargetId(src.getTargetId());
+		dst.setCanvasX(src.getCanvasX());
+		dst.setCanvasY(src.getCanvasY());
+		return dst;
+	}
+
+	private void persistIfSaved(Recording r)
+	{
+		if (r == null || viewedRecording == null)
+		{
+			return;
+		}
+		try
+		{
+			plugin.save(r);
+		}
+		catch (IOException ex)
+		{
+			JOptionPane.showMessageDialog(this,
+				"Save failed: " + ex.getMessage(),
+				"AIO AIO", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	private void onPlay(boolean loop)
+	{
+		Recording r = getSelectedRecording();
+		if (r == null || r.size() == 0)
+		{
+			return;
+		}
+		plugin.play(r, loop);
+	}
+
+	private void onRename()
+	{
+		if (viewedRecording == null)
+		{
+			return;
+		}
+		String name = JOptionPane.showInputDialog(this, "New name:", viewedRecording.getName());
+		if (name == null || name.trim().isEmpty())
+		{
+			return;
+		}
+		try
+		{
+			plugin.rename(viewedRecording, name.trim());
+		}
+		catch (IOException | IllegalArgumentException ex)
+		{
+			JOptionPane.showMessageDialog(this,
+				"Rename failed: " + ex.getMessage(),
+				"AIO AIO", JOptionPane.ERROR_MESSAGE);
+		}
+		refresh();
+	}
+
+	private void onDeleteScript()
+	{
+		if (viewedRecording == null)
+		{
+			return;
+		}
+		int choice = JOptionPane.showConfirmDialog(this,
+			"Delete recording '" + viewedRecording.getName() + "'?",
+			"AIO AIO", JOptionPane.OK_CANCEL_OPTION);
+		if (choice != JOptionPane.OK_OPTION)
+		{
+			return;
+		}
+		try
+		{
+			plugin.delete(viewedRecording);
+		}
+		catch (IOException ex)
+		{
+			JOptionPane.showMessageDialog(this,
+				"Delete failed: " + ex.getMessage(),
+				"AIO AIO", JOptionPane.ERROR_MESSAGE);
+		}
+		viewedRecording = null;
+		refresh();
+	}
+
+	private static String format(int idx, RecordedAction a)
+	{
+		Integer ticks = a.getDelayTicksBefore();
+		String delay = ticks == null ? "—" : ticks + "t";
+		return String.format("%03d  %s  (%s)", idx + 1, a.describe(), delay);
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPlugin.java
@@ -1,0 +1,488 @@
+package net.runelite.client.plugins.microbot.actionreplay;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Provides;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Point;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.plugins.microbot.actionreplay.model.RecordedAction;
+import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
+import net.runelite.client.plugins.microbot.actionreplay.model.TargetType;
+import net.runelite.client.RuneLite;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ImageUtil;
+
+import javax.imageio.ImageIO;
+import javax.inject.Inject;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+@PluginDescriptor(
+	name = PluginConstants.DEFAULT_PREFIX + "AIO AIO</html>",
+	description = "Record and replay sequences of in-game actions. 80/20 automation for one-off tasks.",
+	tags = {"microbot", "aio", "record", "replay", "macro", "automation"},
+	authors = { "Red Bracket" },
+	version = ActionReplayPlugin.version,
+	minClientVersion = "2.1.32",
+	iconUrl = "https://chsami.github.io/Microbot-Hub/ActionReplayPlugin/assets/icon.png",
+	cardUrl = "https://chsami.github.io/Microbot-Hub/ActionReplayPlugin/assets/card.png",
+	enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+	isExternal = PluginConstants.IS_EXTERNAL
+)
+public class ActionReplayPlugin extends Plugin
+{
+	public static final String version = "1.0.0";
+
+	static final Path RECORDINGS_DIR = RuneLite.RUNELITE_DIR.toPath().resolve("microbot-recordings");
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+	@Inject
+	private ActionReplayConfig config;
+
+	@Inject
+	private ClientToolbar clientToolbar;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private ActionReplayOverlay overlay;
+
+	@Inject
+	private ActionReplayScript script;
+
+	@Getter
+	private volatile boolean recording = false;
+	@Getter
+	private volatile boolean playing = false;
+
+	@Getter
+	private Recording currentRecording;
+	private long lastActionMs;
+	private int gameTickCounter;
+	private int lastActionTickCounter;
+
+	private ActionReplayPanel panel;
+	private NavigationButton navButton;
+
+	@Provides
+	ActionReplayConfig provideConfig(ConfigManager cm)
+	{
+		return cm.getConfig(ActionReplayConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		try
+		{
+			Files.createDirectories(RECORDINGS_DIR);
+		}
+		catch (IOException e)
+		{
+			throw new IllegalStateException("ActionReplay: could not create recordings dir " + RECORDINGS_DIR, e);
+		}
+
+		panel = injector.getInstance(ActionReplayPanel.class);
+		panel.setPlugin(this);
+		panel.refresh();
+
+		BufferedImage icon = loadIcon();
+		navButton = NavigationButton.builder()
+			.tooltip("AIO AIO")
+			.icon(icon)
+			.priority(7)
+			.panel(panel)
+			.build();
+		clientToolbar.addNavigation(navButton);
+
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		stopRecording(false);
+		stopPlayback();
+		overlayManager.remove(overlay);
+		if (navButton != null)
+		{
+			clientToolbar.removeNavigation(navButton);
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (recording)
+		{
+			gameTickCounter++;
+		}
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked e)
+	{
+		Recording rec = currentRecording;
+		if (!recording || rec == null || e.isConsumed())
+		{
+			return;
+		}
+
+		long now = System.currentTimeMillis();
+		long gap = lastActionMs == 0 ? 0 : now - lastActionMs;
+		lastActionMs = now;
+
+		int tickDelta = rec.size() == 0 ? 0 : Math.max(0, gameTickCounter - lastActionTickCounter);
+		lastActionTickCounter = gameTickCounter;
+
+		RecordedAction a = new RecordedAction();
+		a.setDelayMsBefore(gap);
+		a.setDelayTicksBefore(tickDelta);
+		a.setMenuOption(stripColorTags(e.getMenuOption()));
+		a.setMenuTarget(stripColorTags(e.getMenuTarget()));
+		a.setMenuAction(e.getMenuAction() == null ? null : e.getMenuAction().name());
+		a.setTargetType(TargetType.fromMenuAction(e.getMenuAction()));
+		a.setIdentifier(e.getId());
+		a.setParam0(e.getParam0());
+		a.setParam1(e.getParam1());
+		a.setItemId(e.getItemId());
+
+		Point mouse = Microbot.getClient().getMouseCanvasPosition();
+		if (mouse != null)
+		{
+			a.setCanvasX(mouse.getX());
+			a.setCanvasY(mouse.getY());
+		}
+
+		switch (a.getTargetType())
+		{
+			case NPC:
+				if (e.getMenuEntry() != null && e.getMenuEntry().getNpc() != null)
+				{
+					a.setTargetName(e.getMenuEntry().getNpc().getName());
+					a.setTargetId(e.getMenuEntry().getNpc().getId());
+				}
+				break;
+			case GAME_OBJECT:
+				a.setTargetId(e.getId());
+				a.setTargetName(stripColorTags(e.getMenuTarget()));
+				break;
+			case GROUND_ITEM:
+				a.setTargetId(e.getId());
+				a.setTargetName(stripColorTags(e.getMenuTarget()));
+				break;
+			default:
+				break;
+		}
+
+		rec.getActions().add(a);
+		if (panel != null)
+		{
+			panel.onActionRecorded(a);
+		}
+	}
+
+	public void startRecording()
+	{
+		if (recording)
+		{
+			return;
+		}
+		long now = System.currentTimeMillis();
+		currentRecording = new Recording();
+		currentRecording.setCreatedAtEpochMs(now);
+		currentRecording.setLastUsedAtEpochMs(now);
+		currentRecording.setName("Recording");
+		lastActionMs = 0;
+		gameTickCounter = 0;
+		lastActionTickCounter = 0;
+		recording = true;
+		log.info("ActionReplay: recording started");
+	}
+
+	public Recording stopRecording(boolean save)
+	{
+		if (!recording)
+		{
+			return null;
+		}
+		recording = false;
+		Recording r = currentRecording;
+		currentRecording = null;
+		if (r == null || r.size() == 0)
+		{
+			log.info("ActionReplay: recording stopped (empty, not saved)");
+			if (panel != null)
+			{
+				panel.refresh();
+			}
+			return null;
+		}
+		if (save)
+		{
+			enrichName(r);
+			r.setName(uniqueName(r.getName()));
+			try
+			{
+				save(r);
+			}
+			catch (IOException e)
+			{
+				throw new IllegalStateException("ActionReplay: failed to save recording " + r.getName(), e);
+			}
+		}
+		log.info("ActionReplay: recording stopped ({} actions)", r.size());
+		if (panel != null)
+		{
+			panel.refresh();
+		}
+		return r;
+	}
+
+	public int getCurrentRecordingSize()
+	{
+		return currentRecording == null ? 0 : currentRecording.size();
+	}
+
+	public void play(Recording r, boolean loop)
+	{
+		if (playing)
+		{
+			return;
+		}
+		if (r == null || r.size() == 0)
+		{
+			log.warn("ActionReplay: recording is empty, nothing to play");
+			return;
+		}
+		r.setLastUsedAtEpochMs(System.currentTimeMillis());
+		Path savedFile = RECORDINGS_DIR.resolve(r.getName() + ".json");
+		if (Files.exists(savedFile))
+		{
+			try
+			{
+				save(r);
+			}
+			catch (IOException e)
+			{
+				log.warn("ActionReplay: failed to persist lastUsedAt for {}: {}", r.getName(), e.getMessage());
+			}
+		}
+		playing = true;
+		if (panel != null)
+		{
+			panel.refresh();
+		}
+		boolean started = script.play(r, config, loop, () ->
+		{
+			playing = false;
+			if (panel != null)
+			{
+				panel.refresh();
+			}
+			log.info("ActionReplay: playback finished");
+		});
+		if (!started)
+		{
+			playing = false;
+			if (panel != null)
+			{
+				panel.refresh();
+			}
+		}
+	}
+
+	public void stopPlayback()
+	{
+		if (!playing)
+		{
+			return;
+		}
+		script.shutdown();
+		playing = false;
+		if (panel != null)
+		{
+			panel.refresh();
+		}
+	}
+
+	public List<Recording> listRecordings()
+	{
+		List<Recording> out = new ArrayList<>();
+		if (!Files.isDirectory(RECORDINGS_DIR))
+		{
+			return out;
+		}
+		try (Stream<Path> files = Files.list(RECORDINGS_DIR))
+		{
+			files.filter(p -> p.getFileName().toString().endsWith(".json"))
+				.forEach(p ->
+				{
+					try
+					{
+						String json = new String(Files.readAllBytes(p));
+						Recording r = GSON.fromJson(json, Recording.class);
+						if (r != null)
+						{
+							if (r.getName() == null)
+							{
+								String fn = p.getFileName().toString();
+								r.setName(fn.substring(0, fn.length() - 5));
+							}
+							if (r.getLastUsedAtEpochMs() == 0)
+							{
+								r.setLastUsedAtEpochMs(Files.getLastModifiedTime(p).toMillis());
+							}
+							out.add(r);
+						}
+					}
+					catch (IOException ex)
+					{
+						log.warn("ActionReplay: failed to read {}: {}", p, ex.getMessage());
+					}
+				});
+		}
+		catch (IOException e)
+		{
+			throw new IllegalStateException("ActionReplay: failed to list recordings in " + RECORDINGS_DIR, e);
+		}
+		out.sort(Comparator.comparingLong(Recording::getLastUsedAtEpochMs).reversed());
+		return out;
+	}
+
+	public void save(Recording r) throws IOException
+	{
+		Files.createDirectories(RECORDINGS_DIR);
+		Path file = RECORDINGS_DIR.resolve(r.getName() + ".json");
+		Files.write(file, GSON.toJson(r).getBytes());
+		log.info("ActionReplay: saved {}", file);
+	}
+
+	public void rename(Recording r, String newName) throws IOException
+	{
+		String clean = sanitize(newName);
+		if (clean.isEmpty())
+		{
+			throw new IllegalArgumentException("ActionReplay: recording name cannot be empty");
+		}
+		Path oldFile = RECORDINGS_DIR.resolve(r.getName() + ".json");
+		Path newFile = RECORDINGS_DIR.resolve(clean + ".json");
+		r.setName(clean);
+		Files.write(newFile, GSON.toJson(r).getBytes());
+		if (!oldFile.equals(newFile) && Files.exists(oldFile))
+		{
+			Files.delete(oldFile);
+		}
+	}
+
+	public void delete(Recording r) throws IOException
+	{
+		Path file = RECORDINGS_DIR.resolve(r.getName() + ".json");
+		Files.deleteIfExists(file);
+	}
+
+	private static String sanitize(String s)
+	{
+		if (s == null)
+		{
+			return "";
+		}
+		return s.replaceAll("[^a-zA-Z0-9_.-]", "_").trim();
+	}
+
+	private void enrichName(Recording r)
+	{
+		if (r == null || r.size() == 0)
+		{
+			return;
+		}
+		RecordedAction first = r.getActions().get(0);
+		String verb = sanitize(first.getMenuOption());
+		String target = sanitize(first.getTargetName() != null ? first.getTargetName() : first.getMenuTarget());
+		StringBuilder name = new StringBuilder();
+		if (!verb.isEmpty())
+		{
+			name.append(verb);
+		}
+		if (!target.isEmpty())
+		{
+			if (name.length() > 0)
+			{
+				name.append("-");
+			}
+			name.append(target);
+		}
+		if (name.length() > 0)
+		{
+			r.setName(name.toString());
+		}
+	}
+
+	private String uniqueName(String base)
+	{
+		if (base == null || base.isEmpty())
+		{
+			base = "Recording";
+		}
+		String candidate = base;
+		int n = 2;
+		while (Files.exists(RECORDINGS_DIR.resolve(candidate + ".json")))
+		{
+			candidate = base + "-" + n;
+			n++;
+		}
+		return candidate;
+	}
+
+	private static String stripColorTags(String s)
+	{
+		if (s == null)
+		{
+			return null;
+		}
+		return s.replaceAll("<[^>]+>", "");
+	}
+
+	private BufferedImage loadIcon()
+	{
+		try
+		{
+			return ImageUtil.loadImageResource(ActionReplayPlugin.class, "panel_icon.png");
+		}
+		catch (Exception ex)
+		{
+			BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+			java.awt.Graphics2D g = img.createGraphics();
+			try
+			{
+				g.setColor(new java.awt.Color(220, 40, 40));
+				g.fillOval(2, 2, 12, 12);
+			}
+			finally
+			{
+				g.dispose();
+			}
+			return img;
+		}
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPlugin.java
@@ -21,12 +21,9 @@ import net.runelite.client.RuneLite;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.client.util.ImageUtil;
 
-import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import java.awt.image.BufferedImage;
-import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +34,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 @PluginDescriptor(
-	name = PluginConstants.DEFAULT_PREFIX + "AIO AIO</html>",
+	name = PluginConstants.RED_BRACKET + "AIO AIO</html>",
 	description = "Record and replay sequences of in-game actions. 80/20 automation for one-off tasks.",
 	tags = {"microbot", "aio", "record", "replay", "macro", "automation"},
 	authors = { "Red Bracket" },
@@ -50,7 +47,7 @@ import java.util.stream.Stream;
 )
 public class ActionReplayPlugin extends Plugin
 {
-	public static final String version = "1.0.0";
+	public static final String version = "1.1.0";
 
 	static final Path RECORDINGS_DIR = RuneLite.RUNELITE_DIR.toPath().resolve("microbot-recordings");
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
@@ -77,7 +74,8 @@ public class ActionReplayPlugin extends Plugin
 
 	@Getter
 	private Recording currentRecording;
-	private long lastActionMs;
+	@Getter
+	private boolean appendingToExisting;
 	private int gameTickCounter;
 	private int lastActionTickCounter;
 
@@ -106,10 +104,9 @@ public class ActionReplayPlugin extends Plugin
 		panel.setPlugin(this);
 		panel.refresh();
 
-		BufferedImage icon = loadIcon();
 		navButton = NavigationButton.builder()
 			.tooltip("AIO AIO")
-			.icon(icon)
+			.icon(buildIcon())
 			.priority(7)
 			.panel(panel)
 			.build();
@@ -148,15 +145,10 @@ public class ActionReplayPlugin extends Plugin
 			return;
 		}
 
-		long now = System.currentTimeMillis();
-		long gap = lastActionMs == 0 ? 0 : now - lastActionMs;
-		lastActionMs = now;
-
 		int tickDelta = rec.size() == 0 ? 0 : Math.max(0, gameTickCounter - lastActionTickCounter);
 		lastActionTickCounter = gameTickCounter;
 
 		RecordedAction a = new RecordedAction();
-		a.setDelayMsBefore(gap);
 		a.setDelayTicksBefore(tickDelta);
 		a.setMenuOption(stripColorTags(e.getMenuOption()));
 		a.setMenuTarget(stripColorTags(e.getMenuTarget()));
@@ -180,15 +172,10 @@ public class ActionReplayPlugin extends Plugin
 				if (e.getMenuEntry() != null && e.getMenuEntry().getNpc() != null)
 				{
 					a.setTargetName(e.getMenuEntry().getNpc().getName());
-					a.setTargetId(e.getMenuEntry().getNpc().getId());
 				}
 				break;
 			case GAME_OBJECT:
-				a.setTargetId(e.getId());
-				a.setTargetName(stripColorTags(e.getMenuTarget()));
-				break;
 			case GROUND_ITEM:
-				a.setTargetId(e.getId());
 				a.setTargetName(stripColorTags(e.getMenuTarget()));
 				break;
 			default:
@@ -202,22 +189,29 @@ public class ActionReplayPlugin extends Plugin
 		}
 	}
 
-	public void startRecording()
+	public void startRecording(Recording existing)
 	{
 		if (recording)
 		{
 			return;
 		}
-		long now = System.currentTimeMillis();
-		currentRecording = new Recording();
-		currentRecording.setCreatedAtEpochMs(now);
-		currentRecording.setLastUsedAtEpochMs(now);
-		currentRecording.setName("Recording");
-		lastActionMs = 0;
+		if (existing != null)
+		{
+			currentRecording = existing;
+			appendingToExisting = true;
+			log.info("ActionReplay: recording started (appending to '{}')", existing.getName());
+		}
+		else
+		{
+			currentRecording = new Recording();
+			currentRecording.setLastUsedAtEpochMs(System.currentTimeMillis());
+			currentRecording.setName("Recording");
+			appendingToExisting = false;
+			log.info("ActionReplay: recording started (new)");
+		}
 		gameTickCounter = 0;
 		lastActionTickCounter = 0;
 		recording = true;
-		log.info("ActionReplay: recording started");
 	}
 
 	public Recording stopRecording(boolean save)
@@ -240,8 +234,11 @@ public class ActionReplayPlugin extends Plugin
 		}
 		if (save)
 		{
-			enrichName(r);
-			r.setName(uniqueName(r.getName()));
+			if (!appendingToExisting)
+			{
+				enrichName(r);
+				r.setName(uniqueName(r.getName()));
+			}
 			try
 			{
 				save(r);
@@ -264,7 +261,7 @@ public class ActionReplayPlugin extends Plugin
 		return currentRecording == null ? 0 : currentRecording.size();
 	}
 
-	public void play(Recording r, boolean loop)
+	public void play(Recording r)
 	{
 		if (playing)
 		{
@@ -293,7 +290,7 @@ public class ActionReplayPlugin extends Plugin
 		{
 			panel.refresh();
 		}
-		boolean started = script.play(r, config, loop, () ->
+		boolean started = script.play(r, () ->
 		{
 			playing = false;
 			if (panel != null)
@@ -463,26 +460,19 @@ public class ActionReplayPlugin extends Plugin
 		return s.replaceAll("<[^>]+>", "");
 	}
 
-	private BufferedImage loadIcon()
+	private static BufferedImage buildIcon()
 	{
+		BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+		java.awt.Graphics2D g = img.createGraphics();
 		try
 		{
-			return ImageUtil.loadImageResource(ActionReplayPlugin.class, "panel_icon.png");
+			g.setColor(new java.awt.Color(220, 40, 40));
+			g.fillOval(2, 2, 12, 12);
 		}
-		catch (Exception ex)
+		finally
 		{
-			BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
-			java.awt.Graphics2D g = img.createGraphics();
-			try
-			{
-				g.setColor(new java.awt.Color(220, 40, 40));
-				g.fillOval(2, 2, 12, 12);
-			}
-			finally
-			{
-				g.dispose();
-			}
-			return img;
+			g.dispose();
 		}
+		return img;
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayPlugin.java
@@ -151,7 +151,7 @@ public class ActionReplayPlugin extends Plugin
 		RecordedAction a = new RecordedAction();
 		a.setDelayTicksBefore(tickDelta);
 		a.setMenuOption(stripColorTags(e.getMenuOption()));
-		a.setMenuTarget(stripColorTags(e.getMenuTarget()));
+		a.setTargetName(cleanTarget(e.getMenuTarget()));
 		a.setMenuAction(e.getMenuAction() == null ? null : e.getMenuAction().name());
 		a.setTargetType(TargetType.fromMenuAction(e.getMenuAction()));
 		a.setIdentifier(e.getId());
@@ -164,22 +164,6 @@ public class ActionReplayPlugin extends Plugin
 		{
 			a.setCanvasX(mouse.getX());
 			a.setCanvasY(mouse.getY());
-		}
-
-		switch (a.getTargetType())
-		{
-			case NPC:
-				if (e.getMenuEntry() != null && e.getMenuEntry().getNpc() != null)
-				{
-					a.setTargetName(e.getMenuEntry().getNpc().getName());
-				}
-				break;
-			case GAME_OBJECT:
-			case GROUND_ITEM:
-				a.setTargetName(stripColorTags(e.getMenuTarget()));
-				break;
-			default:
-				break;
 		}
 
 		rec.getActions().add(a);
@@ -415,7 +399,7 @@ public class ActionReplayPlugin extends Plugin
 		}
 		RecordedAction first = r.getActions().get(0);
 		String verb = sanitize(first.getMenuOption());
-		String target = sanitize(first.getTargetName() != null ? first.getTargetName() : first.getMenuTarget());
+		String target = sanitize(first.getTargetName());
 		StringBuilder name = new StringBuilder();
 		if (!verb.isEmpty())
 		{
@@ -458,6 +442,16 @@ public class ActionReplayPlugin extends Plugin
 			return null;
 		}
 		return s.replaceAll("<[^>]+>", "");
+	}
+
+	private static String cleanTarget(String menuTarget)
+	{
+		String s = stripColorTags(menuTarget);
+		if (s == null)
+		{
+			return null;
+		}
+		return s.replaceAll("\\s*\\(level-\\d+\\)\\s*$", "").trim();
 	}
 
 	private static BufferedImage buildIcon()

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayScript.java
@@ -9,13 +9,10 @@ import net.runelite.client.plugins.microbot.actionreplay.model.RecordedAction;
 import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
 import net.runelite.client.plugins.microbot.actionreplay.model.TargetType;
 import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
-import net.runelite.client.plugins.microbot.api.tileitem.models.Rs2TileItemModel;
 import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
-import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
-import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
@@ -27,19 +24,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Slf4j
 public class ActionReplayScript extends Script
 {
-	private static final int PLAYBACK_SPEED_PERCENT = 100;
-	private static final int MIN_STEP_DELAY_MS = 600;
-	private static final boolean SKIP_MISSING_TARGETS = true;
 	private static final int TARGET_LOOKUP_RADIUS = 20;
 
 	private final AtomicBoolean abortFlag = new AtomicBoolean(false);
 	private Recording recording;
-	private boolean loop;
 	private Runnable onFinished;
-	private int currentIndex;
 	private boolean priorNaturalMouse;
 
-	public boolean play(Recording recording, ActionReplayConfig config, boolean loop, Runnable onFinished)
+	public boolean play(Recording recording, Runnable onFinished)
 	{
 		if (recording == null || recording.getActions() == null || recording.getActions().isEmpty())
 		{
@@ -47,7 +39,6 @@ public class ActionReplayScript extends Script
 			return false;
 		}
 		this.recording = recording;
-		this.loop = loop;
 		this.onFinished = onFinished;
 		this.abortFlag.set(false);
 
@@ -57,11 +48,6 @@ public class ActionReplayScript extends Script
 
 		mainScheduledFuture = scheduledExecutorService.schedule(this::playbackLoop, 0, TimeUnit.MILLISECONDS);
 		return true;
-	}
-
-	public int getCurrentIndex()
-	{
-		return currentIndex;
 	}
 
 	@Override
@@ -75,11 +61,10 @@ public class ActionReplayScript extends Script
 	{
 		try
 		{
-			do
+			while (!abortFlag.get())
 			{
 				runOnce();
 			}
-			while (loop && !abortFlag.get());
 		}
 		catch (Exception e)
 		{
@@ -105,23 +90,12 @@ public class ActionReplayScript extends Script
 			{
 				return;
 			}
-			currentIndex = i;
 			RecordedAction action = recording.getActions().get(i);
 
 			Integer ticks = action.getDelayTicksBefore();
-			long delayMs;
-			if (ticks != null)
+			if (ticks != null && ticks > 0)
 			{
-				delayMs = ticks * 600L;
-			}
-			else
-			{
-				delayMs = Math.max(MIN_STEP_DELAY_MS, action.getDelayMsBefore());
-			}
-			long scaled = (delayMs * 100L) / PLAYBACK_SPEED_PERCENT;
-			if (scaled > 0)
-			{
-				sleep((int) scaled);
+				sleep(ticks * 600);
 			}
 
 			if (!Microbot.isLoggedIn())
@@ -130,18 +104,16 @@ public class ActionReplayScript extends Script
 				return;
 			}
 
-			boolean ok = executeStep(action);
-			if (!ok)
+			if (action.getCondition() != null && !action.getCondition().check())
 			{
-				if (SKIP_MISSING_TARGETS)
-				{
-					log.warn("ActionReplay: skipping step #{} ({})", i, action.describe());
-				}
-				else
-				{
-					log.warn("ActionReplay: aborting playback at step #{} ({})", i, action.describe());
-					return;
-				}
+				log.info("ActionReplay: skipping step #{} ({}) — condition '{}' false",
+					i, action.describe(), action.getCondition().describe());
+				continue;
+			}
+
+			if (!executeStep(action))
+			{
+				log.warn("ActionReplay: skipping step #{} ({})", i, action.describe());
 			}
 		}
 	}
@@ -155,7 +127,7 @@ public class ActionReplayScript extends Script
 		}
 
 		String option = a.getMenuOption();
-		log.debug("ActionReplay: step {} {} (id={}, type={})", option, a.getTargetName(), a.getTargetId(), type);
+		log.debug("ActionReplay: step {} {} (type={})", option, a.getTargetName(), type);
 
 		switch (type)
 		{
@@ -176,19 +148,13 @@ public class ActionReplayScript extends Script
 
 	private boolean replayNpc(RecordedAction a)
 	{
-		Rs2NpcModel match = null;
-		if (a.getTargetId() != null)
+		if (a.getTargetName() == null)
 		{
-			match = Microbot.getRs2NpcCache().query()
-				.withId(a.getTargetId())
-				.nearest(TARGET_LOOKUP_RADIUS);
+			return false;
 		}
-		if (match == null && a.getTargetName() != null)
-		{
-			match = Microbot.getRs2NpcCache().query()
-				.withName(a.getTargetName())
-				.nearest(TARGET_LOOKUP_RADIUS);
-		}
+		Rs2NpcModel match = Microbot.getRs2NpcCache().query()
+			.withName(a.getTargetName())
+			.nearest(TARGET_LOOKUP_RADIUS);
 		if (match == null)
 		{
 			return false;
@@ -198,44 +164,27 @@ public class ActionReplayScript extends Script
 
 	private boolean replayGameObject(RecordedAction a)
 	{
-		Rs2TileObjectModel match = null;
-		if (a.getTargetId() != null)
+		if (a.getTargetName() == null)
 		{
-			match = Microbot.getRs2TileObjectCache().query()
-				.withId(a.getTargetId())
-				.nearest(TARGET_LOOKUP_RADIUS);
+			return false;
 		}
-		if (match == null && a.getTargetName() != null)
-		{
-			match = Microbot.getRs2TileObjectCache().query()
-				.withName(a.getTargetName())
-				.nearest(TARGET_LOOKUP_RADIUS);
-		}
+		Rs2TileObjectModel match = Microbot.getRs2TileObjectCache().query()
+			.withName(a.getTargetName())
+			.nearest(TARGET_LOOKUP_RADIUS);
 		if (match == null)
 		{
-			return Rs2GameObject.interact(a.getIdentifier(), a.getMenuOption());
+			return false;
 		}
 		return match.click(a.getMenuOption());
 	}
 
 	private boolean replayGroundItem(RecordedAction a)
 	{
-		if (a.getItemId() != 0)
+		if (a.getTargetName() == null)
 		{
-			Rs2TileItemModel match = Microbot.getRs2TileItemCache().query()
-				.withId(a.getItemId())
-				.nearest(TARGET_LOOKUP_RADIUS);
-			if (match == null)
-			{
-				return false;
-			}
-			return Rs2GroundItem.loot(a.getItemId(), TARGET_LOOKUP_RADIUS);
+			return false;
 		}
-		if (a.getTargetName() != null)
-		{
-			return Rs2GroundItem.loot(a.getTargetName(), TARGET_LOOKUP_RADIUS);
-		}
-		return false;
+		return Rs2GroundItem.loot(a.getTargetName(), TARGET_LOOKUP_RADIUS);
 	}
 
 	private boolean replayRaw(RecordedAction a)
@@ -261,15 +210,23 @@ public class ActionReplayScript extends Script
 		// stored NewMenuEntry directly is fragile: stale canvas coords mean the
 		// physical click may land on an empty slot, at which point no MenuEntryAdded
 		// fires and MicrobotPlugin's targetMenu injection silently no-ops.
+		// Match by name (exact, case-insensitive) rather than id — stack-count
+		// variants (e.g. Coin pouch x1 vs x3) have different ids but the same name.
 		if (a.getItemId() > 0 && param1 > 0 && (param1 >>> 16) == InterfaceID.INVENTORY
 			&& a.getMenuOption() != null && !a.getMenuOption().isEmpty())
 		{
-			if (!Rs2Inventory.hasItem(a.getItemId()))
+			String itemName = a.getMenuTarget();
+			if (itemName == null || itemName.isEmpty())
 			{
-				log.warn("ActionReplay: item {} not in inventory, skipping '{}'", a.getItemId(), a.describe());
+				log.warn("ActionReplay: no item name for inventory step, skipping '{}'", a.describe());
 				return false;
 			}
-			return Rs2Inventory.interact(a.getItemId(), a.getMenuOption());
+			if (!Rs2Inventory.hasItem(itemName, true))
+			{
+				log.warn("ActionReplay: item '{}' not in inventory, skipping '{}'", itemName, a.describe());
+				return false;
+			}
+			return Rs2Inventory.interact(itemName, a.getMenuOption(), true);
 		}
 
 		String target = a.getMenuTarget() != null ? a.getMenuTarget() : "";

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayScript.java
@@ -1,0 +1,328 @@
+package net.runelite.client.plugins.microbot.actionreplay;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.MenuAction;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.actionreplay.model.RecordedAction;
+import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
+import net.runelite.client.plugins.microbot.actionreplay.model.TargetType;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.api.tileitem.models.Rs2TileItemModel;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+
+import java.awt.Rectangle;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+public class ActionReplayScript extends Script
+{
+	private static final int PLAYBACK_SPEED_PERCENT = 100;
+	private static final int MIN_STEP_DELAY_MS = 600;
+	private static final boolean SKIP_MISSING_TARGETS = true;
+	private static final int TARGET_LOOKUP_RADIUS = 20;
+
+	private final AtomicBoolean abortFlag = new AtomicBoolean(false);
+	private Recording recording;
+	private boolean loop;
+	private Runnable onFinished;
+	private int currentIndex;
+	private boolean priorNaturalMouse;
+
+	public boolean play(Recording recording, ActionReplayConfig config, boolean loop, Runnable onFinished)
+	{
+		if (recording == null || recording.getActions() == null || recording.getActions().isEmpty())
+		{
+			log.warn("ActionReplay: recording is empty, nothing to play");
+			return false;
+		}
+		this.recording = recording;
+		this.loop = loop;
+		this.onFinished = onFinished;
+		this.abortFlag.set(false);
+
+		priorNaturalMouse = Rs2AntibanSettings.naturalMouse;
+		Rs2AntibanSettings.naturalMouse = true;
+		log.info("ActionReplay: enabling naturalMouse for playback (was {})", priorNaturalMouse);
+
+		mainScheduledFuture = scheduledExecutorService.schedule(this::playbackLoop, 0, TimeUnit.MILLISECONDS);
+		return true;
+	}
+
+	public int getCurrentIndex()
+	{
+		return currentIndex;
+	}
+
+	@Override
+	public void shutdown()
+	{
+		abortFlag.set(true);
+		super.shutdown();
+	}
+
+	private void playbackLoop()
+	{
+		try
+		{
+			do
+			{
+				runOnce();
+			}
+			while (loop && !abortFlag.get());
+		}
+		catch (Exception e)
+		{
+			log.error("ActionReplay playback failed", e);
+		}
+		finally
+		{
+			Rs2AntibanSettings.naturalMouse = priorNaturalMouse;
+			Runnable cb = onFinished;
+			onFinished = null;
+			if (cb != null)
+			{
+				cb.run();
+			}
+		}
+	}
+
+	private void runOnce()
+	{
+		for (int i = 0; i < recording.getActions().size(); i++)
+		{
+			if (abortFlag.get())
+			{
+				return;
+			}
+			currentIndex = i;
+			RecordedAction action = recording.getActions().get(i);
+
+			Integer ticks = action.getDelayTicksBefore();
+			long delayMs;
+			if (ticks != null)
+			{
+				delayMs = ticks * 600L;
+			}
+			else
+			{
+				delayMs = Math.max(MIN_STEP_DELAY_MS, action.getDelayMsBefore());
+			}
+			long scaled = (delayMs * 100L) / PLAYBACK_SPEED_PERCENT;
+			if (scaled > 0)
+			{
+				sleep((int) scaled);
+			}
+
+			if (!Microbot.isLoggedIn())
+			{
+				log.warn("ActionReplay: not logged in, aborting playback");
+				return;
+			}
+
+			boolean ok = executeStep(action);
+			if (!ok)
+			{
+				if (SKIP_MISSING_TARGETS)
+				{
+					log.warn("ActionReplay: skipping step #{} ({})", i, action.describe());
+				}
+				else
+				{
+					log.warn("ActionReplay: aborting playback at step #{} ({})", i, action.describe());
+					return;
+				}
+			}
+		}
+	}
+
+	private boolean executeStep(RecordedAction a)
+	{
+		TargetType type = a.getTargetType();
+		if (type == null)
+		{
+			type = TargetType.UNKNOWN;
+		}
+
+		String option = a.getMenuOption();
+		log.debug("ActionReplay: step {} {} (id={}, type={})", option, a.getTargetName(), a.getTargetId(), type);
+
+		switch (type)
+		{
+			case NPC:
+				return replayNpc(a);
+			case GAME_OBJECT:
+				return replayGameObject(a);
+			case GROUND_ITEM:
+				return replayGroundItem(a);
+			case WIDGET:
+			case WALK:
+			case PLAYER:
+			case UNKNOWN:
+			default:
+				return replayRaw(a);
+		}
+	}
+
+	private boolean replayNpc(RecordedAction a)
+	{
+		Rs2NpcModel match = null;
+		if (a.getTargetId() != null)
+		{
+			match = Microbot.getRs2NpcCache().query()
+				.withId(a.getTargetId())
+				.nearest(TARGET_LOOKUP_RADIUS);
+		}
+		if (match == null && a.getTargetName() != null)
+		{
+			match = Microbot.getRs2NpcCache().query()
+				.withName(a.getTargetName())
+				.nearest(TARGET_LOOKUP_RADIUS);
+		}
+		if (match == null)
+		{
+			return false;
+		}
+		return Rs2Npc.interact(match.getId(), a.getMenuOption());
+	}
+
+	private boolean replayGameObject(RecordedAction a)
+	{
+		Rs2TileObjectModel match = null;
+		if (a.getTargetId() != null)
+		{
+			match = Microbot.getRs2TileObjectCache().query()
+				.withId(a.getTargetId())
+				.nearest(TARGET_LOOKUP_RADIUS);
+		}
+		if (match == null && a.getTargetName() != null)
+		{
+			match = Microbot.getRs2TileObjectCache().query()
+				.withName(a.getTargetName())
+				.nearest(TARGET_LOOKUP_RADIUS);
+		}
+		if (match == null)
+		{
+			return Rs2GameObject.interact(a.getIdentifier(), a.getMenuOption());
+		}
+		return match.click(a.getMenuOption());
+	}
+
+	private boolean replayGroundItem(RecordedAction a)
+	{
+		if (a.getItemId() != 0)
+		{
+			Rs2TileItemModel match = Microbot.getRs2TileItemCache().query()
+				.withId(a.getItemId())
+				.nearest(TARGET_LOOKUP_RADIUS);
+			if (match == null)
+			{
+				return false;
+			}
+			return Rs2GroundItem.loot(a.getItemId(), TARGET_LOOKUP_RADIUS);
+		}
+		if (a.getTargetName() != null)
+		{
+			return Rs2GroundItem.loot(a.getTargetName(), TARGET_LOOKUP_RADIUS);
+		}
+		return false;
+	}
+
+	private boolean replayRaw(RecordedAction a)
+	{
+		MenuAction ma = parseMenuAction(a.getMenuAction());
+		if (ma == null)
+		{
+			log.warn("ActionReplay: unknown MenuAction '{}', cannot replay raw step", a.getMenuAction());
+			return false;
+		}
+
+		int param1 = a.getParam1();
+
+		if (param1 > 0 && !Rs2Widget.isWidgetVisible(param1))
+		{
+			log.warn("ActionReplay: widget {} not visible, skipping '{}'", param1, a.describe());
+			return false;
+		}
+
+		// Inventory item actions → delegate to Rs2Inventory.interact. It resolves the
+		// correct inventory widget (normal/bank/deposit/GE/shop), finds the item's
+		// current slot + bounds, and invokes with the correct params. Replaying a
+		// stored NewMenuEntry directly is fragile: stale canvas coords mean the
+		// physical click may land on an empty slot, at which point no MenuEntryAdded
+		// fires and MicrobotPlugin's targetMenu injection silently no-ops.
+		if (a.getItemId() > 0 && param1 > 0 && (param1 >>> 16) == InterfaceID.INVENTORY
+			&& a.getMenuOption() != null && !a.getMenuOption().isEmpty())
+		{
+			if (!Rs2Inventory.hasItem(a.getItemId()))
+			{
+				log.warn("ActionReplay: item {} not in inventory, skipping '{}'", a.getItemId(), a.describe());
+				return false;
+			}
+			return Rs2Inventory.interact(a.getItemId(), a.getMenuOption());
+		}
+
+		String target = a.getMenuTarget() != null ? a.getMenuTarget() : "";
+		NewMenuEntry entry = new NewMenuEntry(
+			a.getMenuOption(),
+			target,
+			a.getIdentifier(),
+			ma,
+			a.getParam0(),
+			param1,
+			false
+		);
+		entry.setItemId(a.getItemId());
+		try
+		{
+			Rectangle rect = buildClickRect(a);
+			Microbot.doInvoke(entry, rect);
+			return true;
+		}
+		catch (Exception e)
+		{
+			log.warn("ActionReplay: doInvoke failed for step {}: {}", a.describe(), e.getMessage());
+			return false;
+		}
+	}
+
+	private Rectangle buildClickRect(RecordedAction a)
+	{
+		if (a.getCanvasX() > 0 && a.getCanvasY() > 0)
+		{
+			return new Rectangle(a.getCanvasX() - 2, a.getCanvasY() - 2, 4, 4);
+		}
+		return new Rectangle(1, 1);
+	}
+
+	private MenuAction parseMenuAction(String s)
+	{
+		if (s == null || s.isEmpty())
+		{
+			return null;
+		}
+		try
+		{
+			return MenuAction.valueOf(s);
+		}
+		catch (IllegalArgumentException ex)
+		{
+			return null;
+		}
+	}
+
+	public boolean isPlaying()
+	{
+		return mainScheduledFuture != null && !mainScheduledFuture.isDone() && !abortFlag.get();
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/ActionReplayScript.java
@@ -10,10 +10,10 @@ import net.runelite.client.plugins.microbot.actionreplay.model.Recording;
 import net.runelite.client.plugins.microbot.actionreplay.model.TargetType;
 import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
-import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
@@ -29,7 +29,6 @@ public class ActionReplayScript extends Script
 	private final AtomicBoolean abortFlag = new AtomicBoolean(false);
 	private Recording recording;
 	private Runnable onFinished;
-	private boolean priorNaturalMouse;
 
 	public boolean play(Recording recording, Runnable onFinished)
 	{
@@ -42,9 +41,7 @@ public class ActionReplayScript extends Script
 		this.onFinished = onFinished;
 		this.abortFlag.set(false);
 
-		priorNaturalMouse = Rs2AntibanSettings.naturalMouse;
-		Rs2AntibanSettings.naturalMouse = true;
-		log.info("ActionReplay: enabling naturalMouse for playback (was {})", priorNaturalMouse);
+		log.info("ActionReplay: starting playback of '{}' ({} actions)", recording.getName(), recording.size());
 
 		mainScheduledFuture = scheduledExecutorService.schedule(this::playbackLoop, 0, TimeUnit.MILLISECONDS);
 		return true;
@@ -66,13 +63,19 @@ public class ActionReplayScript extends Script
 				runOnce();
 			}
 		}
-		catch (Exception e)
+		catch (RuntimeException e)
 		{
-			log.error("ActionReplay playback failed", e);
+			if (e.getCause() instanceof InterruptedException || abortFlag.get())
+			{
+				log.info("ActionReplay: playback stopped");
+			}
+			else
+			{
+				log.error("ActionReplay playback failed", e);
+			}
 		}
 		finally
 		{
-			Rs2AntibanSettings.naturalMouse = priorNaturalMouse;
 			Runnable cb = onFinished;
 			onFinished = null;
 			if (cb != null)
@@ -152,9 +155,9 @@ public class ActionReplayScript extends Script
 		{
 			return false;
 		}
-		Rs2NpcModel match = Microbot.getRs2NpcCache().query()
+Rs2NpcModel match = Microbot.getRs2NpcCache().query()
 			.withName(a.getTargetName())
-			.nearest(TARGET_LOOKUP_RADIUS);
+			.nearestOnClientThread(TARGET_LOOKUP_RADIUS);
 		if (match == null)
 		{
 			return false;
@@ -166,13 +169,16 @@ public class ActionReplayScript extends Script
 	{
 		if (a.getTargetName() == null)
 		{
+			log.warn("ActionReplay: no target name for game object step, skipping '{}'", a.describe());
 			return false;
 		}
-		Rs2TileObjectModel match = Microbot.getRs2TileObjectCache().query()
+Rs2TileObjectModel match = Microbot.getRs2TileObjectCache().query()
 			.withName(a.getTargetName())
-			.nearest(TARGET_LOOKUP_RADIUS);
+			.nearestOnClientThread(TARGET_LOOKUP_RADIUS);
 		if (match == null)
 		{
+			log.warn("ActionReplay: no '{}' within {} tiles, skipping '{}'",
+				a.getTargetName(), TARGET_LOOKUP_RADIUS, a.describe());
 			return false;
 		}
 		return match.click(a.getMenuOption());
@@ -198,24 +204,16 @@ public class ActionReplayScript extends Script
 
 		int param1 = a.getParam1();
 
-		if (param1 > 0 && !Rs2Widget.isWidgetVisible(param1))
+		if ((param1 >>> 16) > 0 && !Rs2Widget.isWidgetVisible(param1))
 		{
 			log.warn("ActionReplay: widget {} not visible, skipping '{}'", param1, a.describe());
 			return false;
 		}
 
-		// Inventory item actions → delegate to Rs2Inventory.interact. It resolves the
-		// correct inventory widget (normal/bank/deposit/GE/shop), finds the item's
-		// current slot + bounds, and invokes with the correct params. Replaying a
-		// stored NewMenuEntry directly is fragile: stale canvas coords mean the
-		// physical click may land on an empty slot, at which point no MenuEntryAdded
-		// fires and MicrobotPlugin's targetMenu injection silently no-ops.
-		// Match by name (exact, case-insensitive) rather than id — stack-count
-		// variants (e.g. Coin pouch x1 vs x3) have different ids but the same name.
 		if (a.getItemId() > 0 && param1 > 0 && (param1 >>> 16) == InterfaceID.INVENTORY
 			&& a.getMenuOption() != null && !a.getMenuOption().isEmpty())
 		{
-			String itemName = a.getMenuTarget();
+			String itemName = a.getTargetName();
 			if (itemName == null || itemName.isEmpty())
 			{
 				log.warn("ActionReplay: no item name for inventory step, skipping '{}'", a.describe());
@@ -229,10 +227,9 @@ public class ActionReplayScript extends Script
 			return Rs2Inventory.interact(itemName, a.getMenuOption(), true);
 		}
 
-		String target = a.getMenuTarget() != null ? a.getMenuTarget() : "";
 		NewMenuEntry entry = new NewMenuEntry(
 			a.getMenuOption(),
-			target,
+			a.getTargetName() != null ? a.getTargetName() : "",
 			a.getIdentifier(),
 			ma,
 			a.getParam0(),

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Condition.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Condition.java
@@ -1,0 +1,128 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+import lombok.Data;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+@Data
+public class Condition
+{
+	public static final int NEARBY_RADIUS = 20;
+
+	private ConditionType type;
+	private StatKind stat;
+	private ConditionComparator comparator;
+	private Integer threshold;
+	private String name;
+	private Boolean present;
+	private Integer minCount;
+
+	public boolean check()
+	{
+		if (type == null)
+		{
+			return true;
+		}
+		switch (type)
+		{
+			case STAT:
+				return checkStat();
+			case NPC_NEARBY:
+				return checkNpcNearby();
+			case OBJECT_NEARBY:
+				return checkObjectNearby();
+			case INVENTORY:
+				return checkInventory();
+			default:
+				return true;
+		}
+	}
+
+	private boolean checkStat()
+	{
+		if (stat == null || comparator == null || threshold == null)
+		{
+			return true;
+		}
+		Skill skill = stat == StatKind.HEALTH ? Skill.HITPOINTS : Skill.PRAYER;
+		int current = Rs2Player.getBoostedSkillLevel(skill);
+		return comparator == ConditionComparator.ABOVE ? current > threshold : current < threshold;
+	}
+
+	private boolean checkNpcNearby()
+	{
+		if (name == null || name.isEmpty() || present == null)
+		{
+			return true;
+		}
+		boolean found = Microbot.getRs2NpcCache().query()
+			.withName(name)
+			.nearest(NEARBY_RADIUS) != null;
+		return found == present;
+	}
+
+	private boolean checkObjectNearby()
+	{
+		if (name == null || name.isEmpty() || present == null)
+		{
+			return true;
+		}
+		boolean found = Microbot.getRs2TileObjectCache().query()
+			.withName(name)
+			.nearest(NEARBY_RADIUS) != null;
+		return found == present;
+	}
+
+	private boolean checkInventory()
+	{
+		if (name == null || name.isEmpty() || present == null)
+		{
+			return true;
+		}
+		int need = minCount == null ? 1 : Math.max(1, minCount);
+		int have = Rs2Inventory.count(name, true);
+		boolean meets = have >= need;
+		return meets == present;
+	}
+
+	public String describe()
+	{
+		if (type == null)
+		{
+			return "";
+		}
+		switch (type)
+		{
+			case STAT:
+				if (stat == null || comparator == null || threshold == null)
+				{
+					return "";
+				}
+				String sn = stat == StatKind.HEALTH ? "HP" : "Prayer";
+				String op = comparator == ConditionComparator.ABOVE ? ">" : "<";
+				return "if " + sn + op + threshold;
+			case NPC_NEARBY:
+			case OBJECT_NEARBY:
+				if (name == null || present == null)
+				{
+					return "";
+				}
+				return "if " + (present ? "" : "no ") + name + " nearby";
+			case INVENTORY:
+				if (name == null || present == null)
+				{
+					return "";
+				}
+				int need = minCount == null ? 1 : Math.max(1, minCount);
+				if (present)
+				{
+					return "if inv has " + (need > 1 ? need + "x " : "") + name;
+				}
+				return "if inv lacks " + name;
+			default:
+				return "";
+		}
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Condition.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Condition.java
@@ -59,7 +59,7 @@ public class Condition
 		}
 		boolean found = Microbot.getRs2NpcCache().query()
 			.withName(name)
-			.nearest(NEARBY_RADIUS) != null;
+			.nearestOnClientThread(NEARBY_RADIUS) != null;
 		return found == present;
 	}
 
@@ -71,7 +71,7 @@ public class Condition
 		}
 		boolean found = Microbot.getRs2TileObjectCache().query()
 			.withName(name)
-			.nearest(NEARBY_RADIUS) != null;
+			.nearestOnClientThread(NEARBY_RADIUS) != null;
 		return found == present;
 	}
 

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/ConditionComparator.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/ConditionComparator.java
@@ -1,0 +1,7 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+public enum ConditionComparator
+{
+	ABOVE,
+	BELOW
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/ConditionType.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/ConditionType.java
@@ -1,0 +1,9 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+public enum ConditionType
+{
+	STAT,
+	NPC_NEARBY,
+	OBJECT_NEARBY,
+	INVENTORY
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/RecordedAction.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/RecordedAction.java
@@ -7,7 +7,6 @@ public class RecordedAction
 {
 	private Integer delayTicksBefore;
 	private String menuOption;
-	private String menuTarget;
 	private String menuAction;
 	private TargetType targetType;
 	private int identifier;
@@ -21,11 +20,10 @@ public class RecordedAction
 
 	public String describe()
 	{
-		String target = targetName != null ? targetName : menuTarget;
-		if (target == null || target.isEmpty())
+		if (targetName == null || targetName.isEmpty())
 		{
 			return menuOption;
 		}
-		return menuOption + " → " + target;
+		return menuOption + " → " + targetName;
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/RecordedAction.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/RecordedAction.java
@@ -5,7 +5,6 @@ import lombok.Data;
 @Data
 public class RecordedAction
 {
-	private long delayMsBefore;
 	private Integer delayTicksBefore;
 	private String menuOption;
 	private String menuTarget;
@@ -16,9 +15,9 @@ public class RecordedAction
 	private int param1;
 	private int itemId;
 	private String targetName;
-	private Integer targetId;
 	private int canvasX;
 	private int canvasY;
+	private Condition condition;
 
 	public String describe()
 	{

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/RecordedAction.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/RecordedAction.java
@@ -1,0 +1,32 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+import lombok.Data;
+
+@Data
+public class RecordedAction
+{
+	private long delayMsBefore;
+	private Integer delayTicksBefore;
+	private String menuOption;
+	private String menuTarget;
+	private String menuAction;
+	private TargetType targetType;
+	private int identifier;
+	private int param0;
+	private int param1;
+	private int itemId;
+	private String targetName;
+	private Integer targetId;
+	private int canvasX;
+	private int canvasY;
+
+	public String describe()
+	{
+		String target = targetName != null ? targetName : menuTarget;
+		if (target == null || target.isEmpty())
+		{
+			return menuOption;
+		}
+		return menuOption + " → " + target;
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Recording.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Recording.java
@@ -1,0 +1,23 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class Recording
+{
+	public static final int CURRENT_VERSION = 1;
+
+	private int version = CURRENT_VERSION;
+	private String name;
+	private long createdAtEpochMs;
+	private long lastUsedAtEpochMs;
+	private List<RecordedAction> actions = new ArrayList<>();
+
+	public int size()
+	{
+		return actions == null ? 0 : actions.size();
+	}
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Recording.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/Recording.java
@@ -8,11 +8,7 @@ import java.util.List;
 @Data
 public class Recording
 {
-	public static final int CURRENT_VERSION = 1;
-
-	private int version = CURRENT_VERSION;
 	private String name;
-	private long createdAtEpochMs;
 	private long lastUsedAtEpochMs;
 	private List<RecordedAction> actions = new ArrayList<>();
 

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/StatKind.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/StatKind.java
@@ -1,0 +1,7 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+public enum StatKind
+{
+	HEALTH,
+	PRAYER
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/TargetType.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionreplay/model/TargetType.java
@@ -1,0 +1,71 @@
+package net.runelite.client.plugins.microbot.actionreplay.model;
+
+import net.runelite.api.MenuAction;
+
+public enum TargetType
+{
+	NPC,
+	GAME_OBJECT,
+	GROUND_ITEM,
+	PLAYER,
+	WIDGET,
+	WALK,
+	UNKNOWN;
+
+	public static TargetType fromMenuAction(MenuAction action)
+	{
+		if (action == null)
+		{
+			return UNKNOWN;
+		}
+		switch (action)
+		{
+			case NPC_FIRST_OPTION:
+			case NPC_SECOND_OPTION:
+			case NPC_THIRD_OPTION:
+			case NPC_FOURTH_OPTION:
+			case NPC_FIFTH_OPTION:
+			case EXAMINE_NPC:
+				return NPC;
+			case GAME_OBJECT_FIRST_OPTION:
+			case GAME_OBJECT_SECOND_OPTION:
+			case GAME_OBJECT_THIRD_OPTION:
+			case GAME_OBJECT_FOURTH_OPTION:
+			case GAME_OBJECT_FIFTH_OPTION:
+			case EXAMINE_OBJECT:
+				return GAME_OBJECT;
+			case GROUND_ITEM_FIRST_OPTION:
+			case GROUND_ITEM_SECOND_OPTION:
+			case GROUND_ITEM_THIRD_OPTION:
+			case GROUND_ITEM_FOURTH_OPTION:
+			case GROUND_ITEM_FIFTH_OPTION:
+			case EXAMINE_ITEM_GROUND:
+				return GROUND_ITEM;
+			case PLAYER_FIRST_OPTION:
+			case PLAYER_SECOND_OPTION:
+			case PLAYER_THIRD_OPTION:
+			case PLAYER_FOURTH_OPTION:
+			case PLAYER_FIFTH_OPTION:
+			case PLAYER_SIXTH_OPTION:
+			case PLAYER_SEVENTH_OPTION:
+			case PLAYER_EIGHTH_OPTION:
+				return PLAYER;
+			case WALK:
+				return WALK;
+			case CC_OP:
+			case CC_OP_LOW_PRIORITY:
+			case WIDGET_TYPE_1:
+			case WIDGET_TYPE_4:
+			case WIDGET_TYPE_5:
+			case WIDGET_TARGET:
+			case WIDGET_TARGET_ON_GAME_OBJECT:
+			case WIDGET_TARGET_ON_GROUND_ITEM:
+			case WIDGET_TARGET_ON_NPC:
+			case WIDGET_TARGET_ON_PLAYER:
+			case WIDGET_TARGET_ON_WIDGET:
+				return WIDGET;
+			default:
+				return UNKNOWN;
+		}
+	}
+}

--- a/src/main/resources/net/runelite/client/plugins/microbot/actionreplay/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/actionreplay/docs/README.md
@@ -1,0 +1,28 @@
+# AIO AIO — Record & Replay
+
+Record a sequence of in-game menu actions, then play it back on demand or on loop. 80/20 automation for one-off tasks.
+
+## What it does
+
+- Captures `MenuOptionClicked` events (NPC/object/ground-item interactions, inventory actions, widget clicks)
+- Saves recordings as JSON under `~/.runelite/microbot-recordings/`
+- Replays them with proper tick pacing; for inventory item actions it delegates to `Rs2Inventory.interact()` so stale slot positions don't cause misses
+- For NPCs/objects/ground items it re-resolves the target by id/name each run (via the queryable cache) — your recording keeps working even if the target moves or respawns
+
+## Usage
+
+1. Enable the plugin, open the AIO AIO side panel
+2. Click **Record script**, perform the actions in-game, click **Stop** when done
+3. The recording shows in the **Script:** dropdown (sorted by last recorded/played time)
+4. Select it, hit **Run script** — loops until you hit **Stop script**
+
+## Editing a recording
+
+- Double-click or ✎ to edit a step's pre-delay (in ticks)
+- ↑ / ↓ to reorder, ⧉ to duplicate, ✕ to delete
+- ✎ Rename / 🗑 Delete on the whole script
+
+## Limits
+
+- Actions whose target can't be found at replay time are skipped (see logs)
+- The playback loop enables `naturalMouse` while running and restores it on exit


### PR DESCRIPTION
Adds the AIO AIO plugin: record in-game menu actions and play them back on demand or on loop. Captures MenuOptionClicked events, persists recordings as JSON under ~/.runelite/microbot-recordings/, and re-resolves NPC/object/ground-item targets by id/name at replay time via the queryable cache so recordings survive target movement and respawns. Inventory item actions delegate to Rs2Inventory.interact() to avoid stale-slot misses.

Panel UI supports renaming, deleting, reordering, duplicating, and editing per-step tick delays. Recordings sort by last-used timestamp.

Fully vibe coded but code reviewed and thoroughly tested
<img width="2319" height="1229" alt="image" src="https://github.com/user-attachments/assets/b890a861-11bb-4f22-b7c0-cda8022dc76d" />

<img width="2515" height="1256" alt="image" src="https://github.com/user-attachments/assets/a8ee392e-6962-40c8-ad4b-e701e3ab223b" />

