### PR TITLE
fix(moonsofperil): retry walker to reach boss lobby reliably

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/moonsofperil/MoonsOfPerilPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/moonsofperil/MoonsOfPerilPlugin.java
@@ -35,7 +35,7 @@ import java.time.Instant;
 )
 @Slf4j
 public class MoonsOfPerilPlugin extends Plugin {
-    static final String version = "1.0.3";
+    static final String version = "1.0.4";
     @Inject
     private MoonsOfPerilConfig config;
     @Provides

--- a/src/main/java/net/runelite/client/plugins/microbot/moonsofperil/handlers/BossHandler.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/moonsofperil/handlers/BossHandler.java
@@ -37,19 +37,34 @@ public final class BossHandler {
         this.debugLogging = cfg.debugLogging();
     }
 
-    /** Walks to the chosen boss lobby. */
+    /** Walks to the chosen boss lobby.
+     *
+     * Loops the walker with a reached-distance tolerance. The previous implementation called
+     * {@code walkWithState(bossWorldPoint, 0)} (exact-tile match) followed by a
+     * {@code walkFastCanvas(bossWorldPoint)} fallback; when the walker exited early on a single
+     * pass (e.g. cross-region transport, door handler interrupt) the canvas-click fallback tried
+     * to click a tile dozens of tiles off-screen, {@code LocalPoint.fromWorld} returned null,
+     * and the plugin looped forever without the player ever moving.
+     */
     public void walkToBoss(Rs2InventorySetup inventorySetup, String bossName, WorldPoint bossWorldPoint) {
         if (inventorySetup != null) {
             equipInventorySetup(inventorySetup);
         }
         if (debugLogging) {Microbot.log("Walking to " + bossName + " lobby");}
-        Rs2Walker.walkWithState(bossWorldPoint, 0);
-        sleep(600);
-        if (!Rs2Player.getWorldLocation().equals(bossWorldPoint)) {
-            Rs2Walker.walkFastCanvas(bossWorldPoint);
-            sleepUntil(() -> Rs2Player.getWorldLocation().equals(bossWorldPoint));
+
+        final int reachedDistance = 3;
+        final long deadlineMs = System.currentTimeMillis() + 90_000L;
+        while (System.currentTimeMillis() < deadlineMs) {
+            WorldPoint loc = Rs2Player.getWorldLocation();
+            if (loc != null && loc.distanceTo(bossWorldPoint) <= reachedDistance) {
+                break;
+            }
+            Rs2Walker.walkWithState(bossWorldPoint, reachedDistance);
+            sleep(600);
         }
-        if (Rs2Player.getWorldLocation().distanceTo(bossWorldPoint) <= 3) {
+
+        WorldPoint finalLoc = Rs2Player.getWorldLocation();
+        if (finalLoc != null && finalLoc.distanceTo(bossWorldPoint) <= reachedDistance) {
             if (debugLogging) {Microbot.log("Arrived at " + bossName + " lobby");}
             return;
         }


### PR DESCRIPTION
## Summary
- Replace the single-pass `walkWithState(bp, 0)` + `walkFastCanvas(bp)` fallback in `BossHandler.walkToBoss` with a bounded retry loop. The old path never recovered when the walker exited early on a cross-region transport or door-handler interrupt: the canvas-click fallback tried to click the final boss tile while it was dozens of tiles off-screen, `LocalPoint.fromWorld` returned null, and the script looped forever emitting `Tried to walk worldpoint ... using the canvas but localpoint returned null` with the player never moving.
- Null-guard `Rs2Player.getWorldLocation()` to prevent the NPE observed at `BossHandler.java:50` during region transitions.
- Bump plugin version `1.0.3` -> `1.0.4`.

Callers (`BlueMoonHandler`, `EclipseMoonHandler`, `BloodMoonHandler`, `RewardHandler`) only need scene proximity; each follows `walkToBoss` with its own exact-tile interaction (`enterBossArena` / chest `interact`), so the loosened `reachedDistance = 3` tolerance is safe.

## Test plan
- [x] Run Moons of Peril through the Neypotzli cave transport to the Blue / Eclipse / Blood Moon lobby; lobby reached within 90s each time.
- [x] Confirm no repeating `Tried to walk worldpoint ... localpoint returned null` errors in the client log.
- [x] Rewards Chest path still works end-to-end (`RewardHandler` also calls `walkToBoss`).
- [x] If the walker still reports `Interrupted waiting for client thread` in `handleDoors`, confirm that retries now succeed instead of wedging the plugin.