### PR TITLE
feat: add Shilo Village and Anywhere options to jewelry crafter

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/JewelryScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/JewelryScript.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.crafting.jewelry;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.crafting.jewelry.enums.*;
@@ -308,11 +309,17 @@ public class JewelryScript extends Script {
                         
                         break;
                     case CRAFTING:
+                        WorldPoint furnaceLocation = plugin.getCraftingLocation().getFurnaceLocation();
+                        WorldPoint anchor = furnaceLocation != null ? furnaceLocation : Rs2Player.getWorldLocation();
                         Rs2TileObjectModel furnaceObject = Microbot.getRs2TileObjectCache().query()
-                                .withId(plugin.getCraftingLocation().getFurnanceObjectID()).nearest();
+                                .withName("Furnace")
+                                .where(o -> Rs2GameObject.hasAction(o, "Smelt"))
+                                .nearest(anchor, 20);
 
                         if (furnaceObject == null) {
-                            Rs2Walker.walkTo(plugin.getCraftingLocation().getFurnaceLocation());
+                            if (furnaceLocation != null) {
+                                Rs2Walker.walkTo(furnaceLocation);
+                            }
                             return;
                         }
 

--- a/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/enums/CraftingLocation.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/enums/CraftingLocation.java
@@ -2,7 +2,6 @@ package net.runelite.client.plugins.microbot.crafting.jewelry.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.ObjectID;
 import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.coords.WorldPoint;
@@ -12,17 +11,18 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 @Getter
 @RequiredArgsConstructor
 public enum CraftingLocation {
-    
-    EDGEVILLE(new WorldPoint(3109, 3499, 0), ObjectID.FURNACE_16469, BankLocation.EDGEVILLE),
-    PORT_PHASMATYS(new WorldPoint(3687, 3479, 0), ObjectID.FURNACE_24009, BankLocation.PORT_PHASMATYS),
-    MOUNT_KARUULM(new WorldPoint(1324, 3808, 0), ObjectID.VOLCANIC_FURNACE, BankLocation.MOUNT_KARUULM),
-    ZANARIS(new WorldPoint(2401, 4473, 0), ObjectID.FURNACE_12100, BankLocation.ZANARIS),
-    FALADOR(new WorldPoint(2975, 3369, 0), ObjectID.FURNACE_24009, BankLocation.FALADOR_WEST);
-    
+
+    ANYWHERE(null, null),
+    EDGEVILLE(new WorldPoint(3109, 3499, 0), BankLocation.EDGEVILLE),
+    PORT_PHASMATYS(new WorldPoint(3687, 3479, 0), BankLocation.PORT_PHASMATYS),
+    MOUNT_KARUULM(new WorldPoint(1324, 3808, 0), BankLocation.MOUNT_KARUULM),
+    ZANARIS(new WorldPoint(2401, 4473, 0), BankLocation.ZANARIS),
+    FALADOR(new WorldPoint(2975, 3369, 0), BankLocation.FALADOR_WEST),
+    SHILO_VILLAGE(new WorldPoint(2856, 2967, 0), BankLocation.SHILO_VILLAGE);
+
     private final WorldPoint furnaceLocation;
-    private final int furnanceObjectID;
     private final BankLocation bankLocation;
-    
+
     public boolean hasRequirements() {
         switch (this) {
             case PORT_PHASMATYS:

--- a/src/test/java/net/runelite/client/Microbot.java
+++ b/src/test/java/net/runelite/client/Microbot.java
@@ -9,6 +9,7 @@ import net.runelite.client.plugins.microbot.agentserver.AgentServerPlugin;
 import net.runelite.client.plugins.microbot.aiofighter.AIOFighterPlugin;
 import net.runelite.client.plugins.microbot.astralrc.AstralRunesPlugin;
 import net.runelite.client.plugins.microbot.autofishing.AutoFishingPlugin;
+import net.runelite.client.plugins.microbot.crafting.jewelry.JewelryPlugin;
 import net.runelite.client.plugins.microbot.example.ExamplePlugin;
 import net.runelite.client.plugins.microbot.leftclickcast.LeftClickCastPlugin;
 import net.runelite.client.plugins.microbot.sailing.MSailingPlugin;
@@ -22,7 +23,8 @@ public class Microbot
 	private static final Class<?>[] debugPlugins = {
 		AIOFighterPlugin.class,
 		AgentServerPlugin.class,
-		LeftClickCastPlugin.class
+		LeftClickCastPlugin.class,
+		JewelryPlugin.class
 	};
 
     public static void main(String[] args) throws Exception


### PR DESCRIPTION
## Summary
- Drop per-location `furnanceObjectID` in `CraftingLocation`; find the furnace via `Microbot.getRs2TileObjectCache().query()` filtered by name (`"Furnace"`) and a `Smelt` action check. Anchor is the enum's `WorldPoint` when set, otherwise the player's current position.
- Add `ANYWHERE` — no `WorldPoint`/`BankLocation`; uses the nearest smelt-capable furnace to the player without walking anywhere.
- Add `SHILO_VILLAGE` at (2856, 2967, 0) with `BankLocation.SHILO_VILLAGE`. Quest gating stays where it already lives (on `BankLocation`).

## Test plan
- [ ] `EDGEVILLE` → walks to the Edgeville furnace and smelts as before (regression).
- [x] `ANYWHERE` standing next to a smelt-capable furnace → interacts without walking. Away from any furnace → no-ops instead of walking somewhere random.
- [x] `SHILO_VILLAGE` (quest complete) → walks to Shilo furnace and smelts.
- [ ] A "Furnace"-named object that lacks the `Smelt` action (e.g. decorative) in range → ignored by the action filter.