### PR TITLE
feat(Kraken): slayer-task gate, food check, spawn recovery, fix Leagues loot

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenConfig.java
@@ -36,4 +36,14 @@ public interface KrakenConfig extends Config {
     default int minPriceOfItemsToLoot() {
         return 5000;
     }
+
+    @ConfigItem(
+            keyName = "stopWhenOutOfFood",
+            name = "Stop when out of food",
+            description = "If on, stop the plugin when the inventory has no edible food. Only checked between kills (during IDLE) so a kill is never aborted mid-fight.",
+            position = 3
+    )
+    default boolean stopWhenOutOfFood() {
+        return true;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenConfig.java
@@ -1,0 +1,39 @@
+package net.runelite.client.plugins.microbot.kraken;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("kraken")
+public interface KrakenConfig extends Config {
+
+    @ConfigItem(
+            keyName = "listOfItemsToLoot",
+            name = "Extra loot names",
+            description = "Comma-separated item names to loot in addition to Kraken uniques (which are always looted).",
+            position = 0
+    )
+    default String listOfItemsToLoot() {
+        return "dragon trident";
+    }
+
+    @ConfigItem(
+            keyName = "toggleLootByValue",
+            name = "Also loot by GE value",
+            description = "If on, also loot any item above the min price below. If off, only uniques + extra names are looted.",
+            position = 1
+    )
+    default boolean toggleLootByValue() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "minPriceOfItemsToLoot",
+            name = "Min GE value",
+            description = "Min GE value (price × qty) to loot. Only used when 'Also loot by GE value' is on.",
+            position = 2
+    )
+    default int minPriceOfItemsToLoot() {
+        return 5000;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenOverlay.java
@@ -1,0 +1,51 @@
+package net.runelite.client.plugins.microbot.kraken;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+
+public class KrakenOverlay extends OverlayPanel {
+
+    private final KrakenScript script;
+
+    @Inject
+    KrakenOverlay(KrakenPlugin plugin, KrakenScript script) {
+        super(plugin);
+        this.script = script;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        try {
+            panelComponent.setPreferredSize(new Dimension(210, 120));
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("Kraken " + KrakenPlugin.version)
+                    .color(Color.CYAN)
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder().build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("State:")
+                    .right(script.getState().name())
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Kills:")
+                    .right(String.valueOf(script.getKillCount()))
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left(Microbot.status == null ? "" : Microbot.status)
+                    .build());
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        return super.render(graphics);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenPlugin.java
@@ -1,0 +1,56 @@
+package net.runelite.client.plugins.microbot.kraken;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+        name = PluginConstants.PERT + "Kraken",
+        description = "AFK Kraken boss: disturbs whirlpools, auto-fights, loots.",
+        tags = {"kraken", "boss", "slayer", "afk"},
+        authors = {"Pert"},
+        version = KrakenPlugin.version,
+        minClientVersion = "2.0.13",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class KrakenPlugin extends Plugin {
+    public static final String version = "1.0.0";
+
+    @Inject
+    private KrakenConfig config;
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private KrakenOverlay overlay;
+    @Inject
+    private KrakenScript script;
+
+    @Provides
+    KrakenConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(KrakenConfig.class);
+    }
+
+    @Override
+    protected void startUp() {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        if (overlayManager != null) {
+            overlayManager.remove(overlay);
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenPlugin.java
@@ -2,7 +2,10 @@ package net.runelite.client.plugins.microbot.kraken;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.PluginConstants;
@@ -51,6 +54,23 @@ public class KrakenPlugin extends Plugin {
         script.shutdown();
         if (overlayManager != null) {
             overlayManager.remove(overlay);
+        }
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage event) {
+        if (event.getType() != ChatMessageType.GAMEMESSAGE) return;
+        String msg = event.getMessage().toLowerCase();
+        if (msg.contains("stick to your slayer")
+                || msg.contains("not on a slayer task")
+                || msg.contains("not currently assigned")) {
+            script.requestStop("Off-task chat message: \"" + event.getMessage() + "\"");
+            return;
+        }
+        if (msg.contains("you've completed your task")
+                || msg.contains("you have completed your task")
+                || msg.contains("completed your slayer task")) {
+            script.requestStop("Slayer task completed.");
         }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenScript.java
@@ -13,6 +13,7 @@ import net.runelite.client.plugins.microbot.util.grounditem.Rs2LootEngine;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.skills.slayer.Rs2Slayer;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -74,11 +75,33 @@ public class KrakenScript extends Script {
 
     private void handleIdle(KrakenConfig config) {
         Microbot.status = "Kraken: waiting for whirlpools";
+        // Slayer-task gate: Kraken can only be killed while assigned. Re-checked every
+        // cycle so we exit the moment the task finishes.
+        if (!isOnKrakenTask()) {
+            requestStop("Not on a Kraken slayer task.");
+            return;
+        }
+        // Out-of-food gate. Only checked here (between kills) so we never abort mid-fight.
+        if (config.stopWhenOutOfFood() && Rs2Inventory.getInventoryFood().isEmpty()) {
+            requestStop("Out of food.");
+            return;
+        }
         if (anyWhirlpoolSpawned()) {
             // Small human reaction delay before the first click fires.
             sleep((int) Rs2Random.normalRange(150L, 400L, 0.0));
             state = KrakenState.DISTURBING;
         }
+    }
+
+    public void requestStop(String reason) {
+        if (state == KrakenState.STOPPED) return;
+        Microbot.log("[Kraken] Stopping: " + reason);
+        state = KrakenState.STOPPED;
+    }
+
+    private static boolean isOnKrakenTask() {
+        String task = Rs2Slayer.getSlayerTask();
+        return task != null && task.toLowerCase().contains("kraken");
     }
 
     private void handleDisturb(KrakenConfig config) {
@@ -122,6 +145,17 @@ public class KrakenScript extends Script {
 
     private void handleFighting(KrakenConfig config) {
         Microbot.status = "Kraken: fighting";
+        // Confirm the 5-click sequence actually spawned the boss. If a small was
+        // missed, the main stays as a whirlpool and Kraken never emerges.
+        boolean spawned = sleepUntil(() -> Microbot.getRs2NpcCache().query()
+                .withId(KRAKEN_NPC_ID)
+                .first() != null, 8_000);
+        if (!spawned) {
+            Microbot.log("[Kraken] Boss didn't spawn — retrying disturb sequence.");
+            clickedSmallIndexes.clear();
+            state = KrakenState.IDLE;
+            return;
+        }
         // Death signal: the attackable Kraken NPC despawns the moment it dies.
         // (isInCombat() lingers ~8s after the last hit — don't use that here.)
         sleepUntil(() -> Microbot.getRs2NpcCache().query()
@@ -150,11 +184,11 @@ public class KrakenScript extends Script {
         Rs2LootEngine.Builder builder = Rs2LootEngine.with(params)
                 .withLootAction(Rs2GroundItem::coreLoot);
 
-        // Always: uniques, name list, coins, untradables. Value threshold is opt-in.
+        // Only: hardcoded uniques + user's name list. Value threshold is opt-in.
+        // No addCoins/addUntradables — on Leagues, drops are account-bound and report
+        // as untradeable, which would sweep up every noted stack (monkfish, staves, runes).
         builder.addCustom("kraken-uniques", KrakenScript::isKrakenUnique, null);
         addCustomNames(builder, config.listOfItemsToLoot());
-        builder.addCoins();
-        builder.addUntradables();
         if (config.toggleLootByValue()) {
             builder.addByValue();
         }

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenScript.java
@@ -1,0 +1,227 @@
+package net.runelite.client.plugins.microbot.kraken;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.NPCComposition;
+import net.runelite.client.plugins.grounditems.GroundItem;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2LootEngine;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+@Slf4j
+public class KrakenScript extends Script {
+
+    private static final int SMALL_WHIRLPOOL_NPC_ID = 5534;
+    private static final int MAIN_WHIRLPOOL_NPC_ID = 496;
+    // Attackable Kraken form. Used only to detect death (despawn = kill signal) — we never click it.
+    private static final int KRAKEN_NPC_ID = 494;
+
+    @Getter
+    private volatile KrakenState state = KrakenState.IDLE;
+    @Getter
+    private volatile int killCount = 0;
+
+    // Tracks NPC scene indexes of small whirlpools we've already clicked this kill,
+    // so we can fire clicks in sequence without waiting for each to transform.
+    private final Set<Integer> clickedSmallIndexes = new HashSet<>();
+
+    public boolean run(KrakenConfig config) {
+        state = KrakenState.IDLE;
+        killCount = 0;
+        clickedSmallIndexes.clear();
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                if (!super.run()) return;
+                if (Microbot.pauseAllScripts.get()) return;
+
+                switch (state) {
+                    case IDLE:
+                        handleIdle(config);
+                        break;
+                    case DISTURBING:
+                        handleDisturb(config);
+                        break;
+                    case FIGHTING:
+                        handleFighting(config);
+                        break;
+                    case LOOTING:
+                        handleLooting(config);
+                        break;
+                    case STOPPED:
+                        return;
+                }
+            } catch (Exception ex) {
+                log.error("[Kraken] loop error: {}", ex.getMessage(), ex);
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    private void handleIdle(KrakenConfig config) {
+        Microbot.status = "Kraken: waiting for whirlpools";
+        if (anyWhirlpoolSpawned()) {
+            // Small human reaction delay before the first click fires.
+            sleep((int) Rs2Random.normalRange(150L, 400L, 0.0));
+            state = KrakenState.DISTURBING;
+        }
+    }
+
+    private void handleDisturb(KrakenConfig config) {
+        // Fire all 5 clicks in sequence: 4 small whirlpools + main. 2s between clicks —
+        // enough to queue each attack. We don't wait for transforms; NPC index dedup
+        // guarantees no double-clicks on the smalls.
+        java.util.List<Rs2NpcModel> smalls = Microbot.getRs2NpcCache().query()
+                .withId(SMALL_WHIRLPOOL_NPC_ID)
+                .where(npc -> hasAction(npc, "Disturb"))
+                .where(npc -> !clickedSmallIndexes.contains(npc.getIndex()))
+                .toList();
+
+        int smallsClicked = clickedSmallIndexes.size();
+        for (Rs2NpcModel npc : smalls) {
+            if (smallsClicked >= 4) break;
+            Microbot.status = "Kraken: whirlpool " + (smallsClicked + 1) + "/5";
+            if (npc.click("Disturb")) {
+                clickedSmallIndexes.add(npc.getIndex());
+                smallsClicked++;
+            }
+            sleep(clickDelayMs());
+        }
+
+        Microbot.status = "Kraken: whirlpool 5/5";
+        Rs2NpcModel main = Microbot.getRs2NpcCache().query()
+                .withId(MAIN_WHIRLPOOL_NPC_ID)
+                .where(npc -> hasAction(npc, "Disturb"))
+                .nearest();
+        if (main != null) {
+            main.click("Disturb");
+            sleep(clickDelayMs());
+        }
+
+        state = KrakenState.FIGHTING;
+    }
+
+    // Skewed-Gaussian around 2000ms, bounded to [1800, 2400] with a long right tail.
+    private static int clickDelayMs() {
+        return (int) Rs2Random.skewedRand(2000L, 1800L, 2400L, 0.0);
+    }
+
+    private void handleFighting(KrakenConfig config) {
+        Microbot.status = "Kraken: fighting";
+        // Death signal: the attackable Kraken NPC despawns the moment it dies.
+        // (isInCombat() lingers ~8s after the last hit — don't use that here.)
+        sleepUntil(() -> Microbot.getRs2NpcCache().query()
+                .withId(KRAKEN_NPC_ID)
+                .first() == null, 120_000);
+        // Short human-ish reaction delay before starting to loot.
+        sleep((int) Rs2Random.normalRange(250L, 600L, 0.0));
+        killCount++;
+        state = KrakenState.LOOTING;
+    }
+
+    private void handleLooting(KrakenConfig config) {
+        Microbot.status = "Kraken: looting";
+
+        // Instanced, so no range / ownership filters needed. No max price, no delay.
+        LootingParameters params = new LootingParameters(
+                config.minPriceOfItemsToLoot(),
+                Integer.MAX_VALUE,
+                Integer.MAX_VALUE,
+                /* minItems */ 1,
+                /* minInvSlots */ 0,
+                /* delayedLooting */ false,
+                /* antiLureProtection */ false
+        );
+
+        Rs2LootEngine.Builder builder = Rs2LootEngine.with(params)
+                .withLootAction(Rs2GroundItem::coreLoot);
+
+        // Always: uniques, name list, coins, untradables. Value threshold is opt-in.
+        builder.addCustom("kraken-uniques", KrakenScript::isKrakenUnique, null);
+        addCustomNames(builder, config.listOfItemsToLoot());
+        builder.addCoins();
+        builder.addUntradables();
+        if (config.toggleLootByValue()) {
+            builder.addByValue();
+        }
+
+        builder.loot();
+        sleep((int) Rs2Random.normalRange(150L, 400L, 0.0));
+
+        clickedSmallIndexes.clear();
+        if (Rs2Inventory.isFull()) {
+            Microbot.log("[Kraken] Inventory full — stopping.");
+            state = KrakenState.STOPPED;
+        } else {
+            // Back to IDLE — anyWhirlpoolSpawned() polling picks up the respawn quickly.
+            state = KrakenState.IDLE;
+        }
+    }
+
+    private static boolean hasAction(Rs2NpcModel npc, String action) {
+        NPCComposition comp = npc.getNpc().getTransformedComposition();
+        if (comp == null) return false;
+        for (String a : comp.getActions()) {
+            if (action.equalsIgnoreCase(a)) return true;
+        }
+        return false;
+    }
+
+    private static boolean anyWhirlpoolSpawned() {
+        return Microbot.getRs2NpcCache().query()
+                .withId(SMALL_WHIRLPOOL_NPC_ID)
+                .where(npc -> hasAction(npc, "Disturb"))
+                .first() != null
+                || Microbot.getRs2NpcCache().query()
+                .withId(MAIN_WHIRLPOOL_NPC_ID)
+                .where(npc -> hasAction(npc, "Disturb"))
+                .first() != null;
+    }
+
+    private static boolean isKrakenUnique(GroundItem gi) {
+        String n = gi.getName() == null ? "" : gi.getName().trim().toLowerCase();
+        return n.contains("kraken tentacle")
+                || n.contains("trident of the seas")
+                || n.contains("jar of dirt")
+                || n.contains("pet kraken");
+    }
+
+    private static void addCustomNames(Rs2LootEngine.Builder builder, String csvNames) {
+        if (csvNames == null) return;
+        Set<String> needles = new HashSet<>();
+        Arrays.stream(csvNames.split(","))
+                .map(s -> s == null ? "" : s.trim().toLowerCase())
+                .filter(s -> !s.isEmpty())
+                .forEach(needles::add);
+        if (needles.isEmpty()) return;
+
+        Predicate<GroundItem> byNames = gi -> {
+            String n = gi.getName() == null ? "" : gi.getName().trim().toLowerCase();
+            for (String needle : needles) {
+                if (n.contains(needle)) return true;
+            }
+            return false;
+        };
+        builder.addCustom("names", byNames, null);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        state = KrakenState.STOPPED;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenScript.java
@@ -105,8 +105,8 @@ public class KrakenScript extends Script {
     }
 
     private void handleDisturb(KrakenConfig config) {
-        // Fire all 5 clicks in sequence: 4 small whirlpools + main. 2s between clicks —
-        // enough to queue each attack. We don't wait for transforms; NPC index dedup
+        // Fire all 5 clicks in sequence: 4 small whirlpools + main. The click alone is
+        // enough — we don't need to wait for an attack to land. NPC index dedup
         // guarantees no double-clicks on the smalls.
         java.util.List<Rs2NpcModel> smalls = Microbot.getRs2NpcCache().query()
                 .withId(SMALL_WHIRLPOOL_NPC_ID)
@@ -138,9 +138,10 @@ public class KrakenScript extends Script {
         state = KrakenState.FIGHTING;
     }
 
-    // Skewed-Gaussian around 2000ms, bounded to [1800, 2400] with a long right tail.
+    // Smooth click cadence — mode ~180ms, bounded to [100, 350] with a long right tail.
+    // Just enough variance to avoid metronomic timing without slowing the sequence down.
     private static int clickDelayMs() {
-        return (int) Rs2Random.skewedRand(2000L, 1800L, 2400L, 0.0);
+        return (int) Rs2Random.skewedRand(180L, 100L, 350L, 0.0);
     }
 
     private void handleFighting(KrakenConfig config) {

--- a/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenState.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kraken/KrakenState.java
@@ -1,0 +1,9 @@
+package net.runelite.client.plugins.microbot.kraken;
+
+public enum KrakenState {
+    IDLE,
+    DISTURBING,
+    FIGHTING,
+    LOOTING,
+    STOPPED
+}

--- a/src/test/java/net/runelite/client/Microbot.java
+++ b/src/test/java/net/runelite/client/Microbot.java
@@ -10,6 +10,7 @@ import net.runelite.client.plugins.microbot.aiofighter.AIOFighterPlugin;
 import net.runelite.client.plugins.microbot.astralrc.AstralRunesPlugin;
 import net.runelite.client.plugins.microbot.autofishing.AutoFishingPlugin;
 import net.runelite.client.plugins.microbot.example.ExamplePlugin;
+import net.runelite.client.plugins.microbot.kraken.KrakenPlugin;
 import net.runelite.client.plugins.microbot.leftclickcast.LeftClickCastPlugin;
 import net.runelite.client.plugins.microbot.sailing.MSailingPlugin;
 import net.runelite.client.plugins.microbot.thieving.ThievingPlugin;
@@ -22,7 +23,8 @@ public class Microbot
 	private static final Class<?>[] debugPlugins = {
 		AIOFighterPlugin.class,
 		AgentServerPlugin.class,
-		LeftClickCastPlugin.class
+		LeftClickCastPlugin.class,
+		KrakenPlugin.class
 	};
 
     public static void main(String[] args) throws Exception


### PR DESCRIPTION
## Summary
- **Slayer-task gate** — varbit check via Rs2Slayer in IDLE plus a chat-message backstop in `onChatMessage`. Stops the plugin once the assigned task no longer contains "kraken".
- **Stop when out of food** — new config toggle (default on), evaluated only during IDLE so a kill is never aborted mid-fight.
- **Spawn-failure recovery** — FIGHTING now waits up to 8s for the Kraken NPC to appear before counting a kill. If a small whirlpool was missed, falls back to IDLE without inflating kill count.
- **Loot fix for Leagues** — removed unconditional `addCoins()` / `addUntradables()`. On Leagues, drops are account-bound and report as untradeable, which was sweeping every noted stack (monkfish, battlestaves, soul runes). Now strictly hardcoded uniques + user's name list + opt-in by-value.

Plugin is attributed to Pert (`[P]` prefix via `PluginConstants.PERT`, `authors = {"Pert"}`).

## Test plan
- [ ] On a Kraken slayer task: kill loop runs end-to-end; stops on task completion (chat or varbit).
- [ ] Off-task: plugin stops on first IDLE with logged reason.
- [ ] No food in inventory: plugin stops on first IDLE with logged reason.
- [ ] One small whirlpool missed mid-sequence: FIGHTING falls back to IDLE, re-clicks the missed small, kill count not inflated.
- [ ] Leagues: only Kraken uniques + configured names are looted; noted monkfish/staves/runes left on the floor.