### PR TITLE
fix(aiofighter): make NPC attack work inside instances

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 )
 @Slf4j
 public class AIOFighterPlugin extends Plugin {
-    public static final String version = "2.1.6";
+    public static final String version = "2.1.7";
     public static boolean needShopping = false;
     private static final String SET = "Set";
     private static final String CENTER_TILE = ColorUtil.wrapWithColorTag("Center Tile", JagexColors.MENU_TARGET);

--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/AttackNpcScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/combat/AttackNpcScript.java
@@ -4,6 +4,8 @@ import lombok.SneakyThrows;
 import net.runelite.api.Actor;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
@@ -135,14 +137,18 @@ public class AttackNpcScript extends Script {
                 final int attackRadius = config.attackRadius();
                 final boolean requireReachable = config.attackReachableNpcs();
                 final Rs2WorldPoint rs2PlayerPoint = Rs2Player.getRs2WorldPoint();
+                // Inside an instance, npc.getWorldLocation() returns the instance-side coord
+                // (high-corner template region), but centerLocation/centre-tile and
+                // Rs2Player.getWorldLocation() are template/overworld coords. Convert via the
+                // npc's scene-local point so both sides of the radius/path checks match.
+                final WorldView worldView = Microbot.getClient().getTopLevelWorldView();
+                final boolean instanced = worldView != null && worldView.getScene().isInstance();
 
                 List<Rs2NpcModel> attackableNpcs = Microbot.getRs2NpcCache().query()
                         .where(npc -> npc.getCombatLevel() > 0 && !npc.isDead())
                         .where(npc -> !npc.isInteracting() || Objects.equals(npc.getInteracting(), localPlayer))
                         .where(npc -> {
-                            // Single getWorldLocation() call combines the radius and reachable filters
-                            // (each model access is a client-thread invoke; one fetch per NPC per tick).
-                            WorldPoint loc = npc.getWorldLocation();
+                            WorldPoint loc = npcWorldLocation(npc, instanced);
                             if (loc == null) return false;
                             if (loc.distanceTo(centerLocation) > attackRadius) return false;
                             return !requireReachable || rs2PlayerPoint.distanceToPath(loc) < Integer.MAX_VALUE;
@@ -155,7 +161,7 @@ public class AttackNpcScript extends Script {
                         .stream()
                         .sorted(Comparator
                                 .comparingInt((Rs2NpcModel npc) -> Objects.equals(npc.getInteracting(), localPlayer) ? 0 : 1)
-                                .thenComparingInt(npc -> rs2PlayerPoint.distanceToPath(npc.getWorldLocation())))
+                                .thenComparingInt(npc -> rs2PlayerPoint.distanceToPath(npcWorldLocation(npc, instanced))))
                         .collect(Collectors.toList());
 
                 filteredAttackableNpcs.set(attackableNpcs);
@@ -332,6 +338,23 @@ public class AttackNpcScript extends Script {
                     return name != null && name.contains("Reanimated");
                 })
                 .first();
+    }
+
+    /**
+     * Returns the npc's world location in the same coordinate space as
+     * {@code config.centerLocation()} / {@code Rs2Player.getWorldLocation()}.
+     * Inside an instance the raw {@code npc.getWorldLocation()} reports the
+     * instance-side coord (high-corner template region) while the centre tile
+     * is stored as a template/overworld coord, so distances would never match.
+     */
+    private static WorldPoint npcWorldLocation(Rs2NpcModel npc, boolean instanced) {
+        if (instanced) {
+            LocalPoint lp = npc.getLocalLocation();
+            if (lp != null) {
+                return WorldPoint.fromLocalInstance(Microbot.getClient(), lp);
+            }
+        }
+        return npc.getWorldLocation();
     }
 
     @Override


### PR DESCRIPTION
## Summary

- AIO Fighter silently did nothing inside any instanced region (NMZ, slayer caves, fight caves, raids, etc.) because the NPC radius filter compared coordinates in mismatched spaces.
- `npc.getWorldLocation()` returns the instance-side coord (high-corner template region, e.g. ~13000/7000) but `config.centerLocation()` and `Rs2Player.getWorldLocation()` are template/overworld coords, so `distanceTo()` was always ~thousands and every NPC was rejected at `AttackNpcScript.java:147`.
- Convert NPC location via `WorldPoint.fromLocalInstance(client, npc.getLocalLocation())` when `worldView.getScene().isInstance()` for both the radius/reachable filter and the path-distance sort. Plugin version bumped 2.1.6 → 2.1.7.

## Known limitation

The "Attack reachable NPCs only" toggle still doesn't work inside instances — `Rs2WorldPoint.distanceToPath` uses ShortestPath/WebWalker which only knows the static overworld map, so it returns `MAX_VALUE` for any tile in an instanced scene. Workaround: leave that toggle off in instances. Fixing this properly is out of scope for this PR.

## Test plan

- [x] Build: `./gradlew build -PpluginList=AIOFighterPlugin` is green.
- [x] Manual: launched via `runDebug` inside an instance with NPCs visible — script now finds and attacks NPCs (with reachable-only toggle off).
- [x] Verify overworld combat still works (no regression — the `instanced` flag short-circuits to the original code path outside instances).