### PR TITLE
fix(qol): drop FieldUtil reflective writes that crash on client 2.5.4

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -32,7 +32,6 @@ import net.runelite.client.plugins.microbot.qualityoflife.scripts.pvp.PvpScript;
 import net.runelite.client.plugins.microbot.qualityoflife.scripts.wintertodt.WintertodtOverlay;
 import net.runelite.client.plugins.microbot.qualityoflife.scripts.wintertodt.WintertodtScript;
 import net.runelite.client.plugins.microbot.util.Global;
-import net.runelite.client.plugins.microbot.util.antiban.FieldUtil;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -47,7 +46,6 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
-import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.SplashScreen;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
@@ -59,7 +57,6 @@ import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -84,7 +81,7 @@ import static net.runelite.client.plugins.microbot.util.Global.awaitExecutionUnt
 )
 @Slf4j
 public class QoLPlugin extends Plugin implements KeyListener {
-    public static final String version = "1.8.12";
+    public static final String version = "1.8.13";
     public static final List<NewMenuEntry> bankMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> furnaceMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> anvilMenuEntries = new LinkedList<>();
@@ -748,18 +745,6 @@ public class QoLPlugin extends Plugin implements KeyListener {
      */
     private boolean updateUiElements() {
         try {
-            // Get the Field object for the accent color (BRAND_ORANGE) in the ColorScheme class
-            Field accentColorField = ColorScheme.class.getDeclaredField("BRAND_ORANGE");
-            // Update the accent color with the value from the config
-            FieldUtil.setFinalStatic(accentColorField, config.accentColor());
-
-            // Get the PluginToggleButton class to access its ON_SWITCHER field
-            Class<?> pluginButton = Class.forName("net.runelite.client.plugins.microbot.ui.MicrobotPluginToggleButton");
-            Field onSwitcherPluginPanel = pluginButton.getDeclaredField("ON_SWITCHER");
-            onSwitcherPluginPanel.setAccessible(true);
-            // Update the ON_SWITCHER field with a remapped image based on the config toggle button color
-            FieldUtil.setFinalStatic(onSwitcherPluginPanel, remapImage(SWITCHER_ON_IMG, config.toggleButtonColor()));
-
             // Find the ConfigPlugin instance from the plugin manager
             MicrobotPlugin microbotPlugin = (MicrobotPlugin) Microbot.getPluginManager().getPlugins().stream()
                     .filter(plugin -> plugin instanceof MicrobotPlugin)


### PR DESCRIPTION
## Summary

- ` QoLPlugin.updateUiElements()` reflectively wrote `ColorScheme.BRAND_ORANGE` and `MicrobotPluginToggleButton.ON_SWITCHER` via `util/antiban/FieldUtil.setFinalStatic`, which used `sun.misc.Unsafe` under the hood.
- Upstream commit `chsami/Microbot@048a44d213` deleted `FieldUtil` (zero call sites in the client tree, plus a forensic-bot fingerprint concern) and added `UnsafeUsageGuardTest` to block its return.
- Result: against the official `microbot-2.5.4.jar`, this plugin throws `NoClassDefFoundError: net/runelite/client/plugins/microbot/util/antiban/FieldUtil` from every `onGameStateChanged`, cascading into `BlockingEventManager` timeouts and freezing the client until shutdown.

## Fix

- Remove the two `FieldUtil.setFinalStatic` calls.
- Drop the now-unused imports (`FieldUtil`, `ColorScheme`, `java.lang.reflect.Field`).
- Bump `version` 1.8.12 -> 1.8.13.

## Behavioral impact

| Behavior | Status |
|---|---|
| `pluginLabelColor` (per-component) | preserved |
| `toggleButtonColor` recolor on existing toggles via `setSelectedIcon` | preserved |
| Global `BRAND_ORANGE` accent override | dropped |
| Default `ON_SWITCHER` for newly-created toggles | dropped |

The two dropped behaviors were already partly cosmetic theater: client UI like `MicrobotConfigPanel`, `MicrobotPluginListItem`, and `MicrobotPluginHubPanel` read `BRAND_ORANGE` once at construction, so the override only retinted UI built after the override fired. There is no supported JDK 17+ replacement for writing static-final fields of another class. A proper accent-color hook would need to be exposed by the Microbot client/RuneLite UI layer.

## Test plan

- [x] ` ./gradlew build -PpluginList=QoLPlugin` succeeds (no compile errors).
- [x] Drop-in replacement of `~/.runelite/microbot-plugins/QoLPlugin.jar` on a 2.5.4 client launches without `NoClassDefFoundError` and the canvas no longer freezes.