### PR TITLE
fix(auto-looter): stop world-hopping while walking to/from bank

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/looter/AutoLooterPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/looter/AutoLooterPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class AutoLooterPlugin extends Plugin {
-    public static final String version = "1.1.2";
+    public static final String version = "1.1.3";
     @Inject
     DefaultScript defaultScript;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/looter/scripts/DefaultScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/looter/scripts/DefaultScript.java
@@ -50,6 +50,10 @@ public class DefaultScript extends Script {
 
                 switch (state) {
                     case LOOTING:
+                        // Walker may still be carrying us back (post-bank or post-stray).
+                        // Scanning from the wrong tile would trip the world-hop counter.
+                        if (isAwayFromBase(config)) return;
+
                         if (config.worldHop()) {
                             if (config.looterStyle() == DefaultLooterStyle.ITEM_LIST) {
                                 lootExists = Arrays.stream(config.listOfItemsToLoot().trim().split(","))
@@ -129,7 +133,12 @@ public class DefaultScript extends Script {
                         break;
 
                     case BANKING:
+                        // Stay in BANKING until the bank trip is fully complete: items deposited
+                        // AND we're back at the loot spot. Flipping to LOOTING mid-walk-back
+                        // would let the loot scan run from the bank tile.
                         if (Rs2Inventory.emptySlotCount() <= config.minFreeSlots()) return;
+                        if (isAwayFromBase(config)) return;
+                        failedLootAttempts = 0;
                         state = LooterState.LOOTING;
                         break;
                 }
@@ -182,6 +191,12 @@ public class DefaultScript extends Script {
             }
         }, 0, 1000, TimeUnit.MILLISECONDS);
         return true;
+    }
+
+    private boolean isAwayFromBase(AutoLooterConfig config) {
+        return initialPlayerLocation == null
+                || Rs2Player.isMoving()
+                || Rs2Player.getWorldLocation().distanceTo(initialPlayerLocation) > config.distanceToStray();
     }
 
     private void applyAntiBanSettings() {


### PR DESCRIPTION
## Summary
- The Auto Looter was hopping worlds repeatedly during bank trips. `DefaultScript` runs two concurrent schedulers (200ms state machine, 1000ms walk handler). After deposit, the `BANKING -> LOOTING` transition fired the moment inventory emptied, while the player was still walking back from the bank. The next LOOTING tick scanned `Rs2GroundItem` from the bank tile, found nothing, and after 5 misses (~1s) called `Microbot.hopToWorld(...)`. Same hazard during stray-walk-back.
- Added `isAwayFromBase()` helper: true when `initialPlayerLocation` is unset, `Rs2Player.isMoving()`, or `distanceTo(initialPlayerLocation) > distanceToStray`.
- LOOTING short-circuits while away from base — no scan, no `failedLootAttempts++`, no world hop.
- BANKING no longer transitions to LOOTING until inventory is empty AND the player is parked at the loot spot. `failedLootAttempts` resets on the transition so each return to the spot gets a fresh 5-tick window.
- Bumped AutoLooter to `1.1.3`.

Refs #1747

## Test plan
- [ ] Run Auto Looter in DEFAULT mode with `worldHop=true`, fill inventory, and confirm a bank trip completes without a world hop mid-walk.
- [ ] Stray past `distanceToStray` while looting and confirm the walker brings the player back without spurious world-hop ticks during travel.
- [ ] With a genuinely empty loot spot after a bank-and-return, confirm world hop still triggers after 5 stationary failed scans.