### PR TITLE
fix(MKE_Wintertodt): brazier behavior, snowfall-safe fletch, antiban hardening

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtConfig.java
@@ -103,7 +103,7 @@ public interface MKE_WintertodtConfig extends Config {
 
     @ConfigItem(
             keyName = "FletchRoots",
-            name = "🔪 Fletch Roots to Kindling",
+            name = "➳ Fletch Roots to Kindling",
             description = "Convert bruma roots to kindling for fletching XP and more points",
             position = 2,
             section = generalSection
@@ -114,7 +114,7 @@ public interface MKE_WintertodtConfig extends Config {
 
     @ConfigItem(
             keyName = "FixBrazier",
-            name = "🔧 Fix Broken Braziers",
+            name = "⚒️ Fix Broken Braziers",
             description = "Repair broken braziers with hammer",
             position = 3,
             section = generalSection

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtConfig.java
@@ -123,6 +123,17 @@ public interface MKE_WintertodtConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "DodgeSnowfall",
+            name = "❄️ Dodge Snowfall",
+            description = "Step out of incoming snowfall AoE damage. Most players don't bother — eating food/potions is usually more efficient than interrupting your action to step.",
+            position = 4,
+            section = generalSection
+    )
+    default boolean dodgeSnowfall() {
+        return false;
+    }
+
     // ==================== HEALING METHOD ====================
     @ConfigItem(
             keyName = "HealingMethod",

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
@@ -42,7 +42,7 @@ import java.time.Instant;
 )
 @Slf4j
 public class MKE_WintertodtPlugin extends Plugin {
-    static final String version = "2.1.3";
+    static final String version = "2.1.7";
 
     // Core plugin components
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
@@ -42,7 +42,7 @@ import java.time.Instant;
 )
 @Slf4j
 public class MKE_WintertodtPlugin extends Plugin {
-    static final String version = "2.1.7";
+    static final String version = "2.2.0";
 
     // Core plugin components
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -151,6 +151,11 @@ public class MKE_WintertodtScript extends Script {
     // Flag to prioritize brazier lighting at round start
     private static boolean shouldPriorizeBrazierAtStart = false;
 
+    // One-shot: walk to the snowfall-safe fletch tile only on a fresh entry to
+    // FLETCH_LOGS (i.e. coming from chopping). Resumed fletches after a brazier
+    // fix/light or an eat tick don't count — we fletch in place.
+    private static boolean needFletchTileWalk = false;
+
     // For overlay
     public static double historicalEstimateSecondsLeft = 0;
 
@@ -905,6 +910,11 @@ public class MKE_WintertodtScript extends Script {
         if (state == State.CHOP_ROOTS)  lastWoodcuttingXpDropTime = 0;
         if (state == State.FLETCH_LOGS) lastFletchingXpDropTime   = 0;
         if (state == State.BURN_LOGS)   lastFiremakingXpDropTime  = 0;
+
+        // Fresh entry to FLETCH_LOGS → arm the one-shot walk to the safe tile.
+        if (newState == State.FLETCH_LOGS) {
+            needFletchTileWalk = true;
+        }
 
         System.out.println(String.format("[%d] State transition: %s -> %s %s",
                 System.currentTimeMillis(), state, newState, lock ? "(LOCKED)" : ""));
@@ -2428,9 +2438,14 @@ public class MKE_WintertodtScript extends Script {
                 if (random.nextInt(100) < 10) {
                     sleepGaussian(400, 600);
                 }
-                // Fletch on a snowfall-safe tile rather than at the brazier.
-                // Feeding still walks back to the brazier-stand tile.
-                navigateToFletchSpot();
+                // Walk to the snowfall-safe fletch tile only on the first
+                // fletch of this state entry (i.e. fresh from chopping).
+                // Resumed fletches after a brazier fix/light/eat happen in
+                // place — no point trekking back for a partial pile.
+                if (needFletchTileWalk) {
+                    navigateToFletchSpot();
+                    needFletchTileWalk = false;
+                }
 
                 // Keep knife in slot-27 optimisation
                 Rs2ItemModel knife = Rs2Inventory.get(WintertodtInventoryManager.knifeToUse);
@@ -3136,7 +3151,7 @@ public class MKE_WintertodtScript extends Script {
             }
             deselectSelectedItem();
             gameState.brokenBrazier.click("fix");
-            Microbot.log("Fixing broken brazier (priority over eating)");
+            Microbot.log("Fixing broken brazier (priority)");
             resetActions = true;
             actionsPerformed++;
             return true;
@@ -3152,7 +3167,7 @@ public class MKE_WintertodtScript extends Script {
             }
             deselectSelectedItem();
             gameState.brazier.click("light");
-            Microbot.log("Relighting brazier (priority over eating)");
+            Microbot.log("Relighting brazier (priority)");
             resetActions = true;
             actionsPerformed++;
             return true;

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -1272,7 +1272,9 @@ public class MKE_WintertodtScript extends Script {
             Microbot.log("Activity: " + Rs2Antiban.getActivity().getMethod());
             Microbot.log("Play Style: " + Rs2Antiban.getPlayStyle().getName());
             Microbot.log("Micro Breaks: " + (Rs2AntibanSettings.takeMicroBreaks ? "Enabled" : "Disabled"));
-            Microbot.log("Action Cooldown: " + (Rs2AntibanSettings.usePlayStyle ? "Enabled" : "Disabled"));
+            Microbot.log("Action Cooldown: " + (Rs2AntibanSettings.usePlayStyle
+                    ? "Enabled (chance " + Rs2AntibanSettings.actionCooldownChance + ")"
+                    : "Disabled"));
             Microbot.log("Mouse Randomization: " + (Rs2AntibanSettings.moveMouseRandomly ? "Enabled" : "Disabled"));
             Microbot.log("============================");
             
@@ -2530,11 +2532,13 @@ public class MKE_WintertodtScript extends Script {
             
             /* ---------- PRIORITY BLOCK 1: FIX BROKEN BRAZIER FIRST ----------- */
             if (gameState.brokenBrazier != null && config.fixBrazier()) {
+                sleepGaussian(200, 150);
+
                 // Stop feeding temporarily to fix brazier
                 if (feedingState.isActive()) {
                     feedingState.stopFeeding(FeedingInterruptType.BRAZIER_BROKEN);
                 }
-                
+
                 gameState.brokenBrazier.click("fix");
                 Microbot.log("Fixing broken brazier");
                 resetActions = true;
@@ -2591,6 +2595,10 @@ public class MKE_WintertodtScript extends Script {
                     actionsPerformed++;
                     Microbot.log("Started feeding brazier");
                     maybeNudgeMouse();
+
+                    if (Rs2AntibanSettings.usePlayStyle) {
+                        Rs2Antiban.actionCooldown();
+                    }
                 }
             }
 
@@ -3142,6 +3150,12 @@ public class MKE_WintertodtScript extends Script {
      * if a click was issued (caller should skip the rest of the tick).
      */
     private boolean handleBrazierMaintenance(GameState gameState) {
+        // Without this guard the 60ms loop would re-issue the same click every
+        // tick while the repair/light animation runs (~30 clicks in 2s) — an
+        // obvious bot signature. resetActions is cleared once the next action
+        // begins, so a single repair click can trigger.
+        if (resetActions) return false;
+
         if (gameState.brokenBrazier != null && config.fixBrazier()) {
             if (fletchingState.isActive()) {
                 fletchingState.stopFletching(FletchingInterruptType.BRAZIER_BROKEN);
@@ -3150,6 +3164,7 @@ public class MKE_WintertodtScript extends Script {
                 feedingState.stopFeeding(FeedingInterruptType.BRAZIER_BROKEN);
             }
             deselectSelectedItem();
+            sleepGaussian(200, 150);
             gameState.brokenBrazier.click("fix");
             Microbot.log("Fixing broken brazier (priority)");
             resetActions = true;
@@ -3166,6 +3181,7 @@ public class MKE_WintertodtScript extends Script {
                 feedingState.stopFeeding(FeedingInterruptType.BRAZIER_WENT_OUT);
             }
             deselectSelectedItem();
+            sleepGaussian(200, 150);
             gameState.brazier.click("light");
             Microbot.log("Relighting brazier (priority)");
             resetActions = true;

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -2354,17 +2354,14 @@ public class MKE_WintertodtScript extends Script {
             
             /* ---------- PRIORITY BLOCK 1: FIX BROKEN BRAZIER FIRST ----------- */
             if (gameState.brokenBrazier != null && config.fixBrazier()) {
-
-                sleepGaussian(200, 150);
-
                 // Stop fletching temporarily to fix brazier
                 if (fletchingState.isActive()) {
                     fletchingState.stopFletching(FletchingInterruptType.BRAZIER_BROKEN);
                 }
-                
+
                 // Deselect any items before fixing
                 deselectSelectedItem();
-                
+
                 gameState.brokenBrazier.click("fix");
                 Microbot.log("Fixing broken brazier (priority during fletching)");
                 resetActions = true;
@@ -2374,19 +2371,16 @@ public class MKE_WintertodtScript extends Script {
             /* ----------------------------------------------------------------- */
 
             /* ---------- PRIORITY BLOCK 2: RELIGHT BRAZIER SECOND ------------ */
-            if (gameState.burningBrazier == null && gameState.brazier != null && 
+            if (gameState.burningBrazier == null && gameState.brazier != null &&
                 config.relightBrazier() && gameState.isWintertodtAlive) {
-
-                sleepGaussian(200, 150);
-                
                 // Stop fletching temporarily to relight brazier
                 if (fletchingState.isActive()) {
                     fletchingState.stopFletching(FletchingInterruptType.BRAZIER_WENT_OUT);
                 }
-                
+
                 // Deselect any items before relighting
                 deselectSelectedItem();
-                
+
                 gameState.brazier.click("light");
                 Microbot.log("Relighting brazier (priority during fletching)");
                 resetActions = true;
@@ -2532,8 +2526,6 @@ public class MKE_WintertodtScript extends Script {
             
             /* ---------- PRIORITY BLOCK 1: FIX BROKEN BRAZIER FIRST ----------- */
             if (gameState.brokenBrazier != null && config.fixBrazier()) {
-                sleepGaussian(200, 150);
-
                 // Stop feeding temporarily to fix brazier
                 if (feedingState.isActive()) {
                     feedingState.stopFeeding(FeedingInterruptType.BRAZIER_BROKEN);
@@ -2549,16 +2541,13 @@ public class MKE_WintertodtScript extends Script {
 
             /* ---------- PRIORITY BLOCK 2: RELIGHT BRAZIER SECOND ------------ */
             Rs2TileObjectModel burningBrazier = gameState.burningBrazier;  // side-specific
-            if (burningBrazier == null && gameState.brazier != null && 
+            if (burningBrazier == null && gameState.brazier != null &&
                 config.relightBrazier() && gameState.isWintertodtAlive) {
-
-                sleepGaussian(200, 150);
-                
                 // Stop feeding temporarily to relight brazier
                 if (feedingState.isActive()) {
                     feedingState.stopFeeding(FeedingInterruptType.BRAZIER_WENT_OUT);
                 }
-                
+
                 gameState.brazier.click("light");
                 Microbot.log("Relighting brazier");
                 resetActions = true;
@@ -3164,7 +3153,6 @@ public class MKE_WintertodtScript extends Script {
                 feedingState.stopFeeding(FeedingInterruptType.BRAZIER_BROKEN);
             }
             deselectSelectedItem();
-            sleepGaussian(200, 150);
             gameState.brokenBrazier.click("fix");
             Microbot.log("Fixing broken brazier (priority)");
             resetActions = true;
@@ -3181,7 +3169,6 @@ public class MKE_WintertodtScript extends Script {
                 feedingState.stopFeeding(FeedingInterruptType.BRAZIER_WENT_OUT);
             }
             deselectSelectedItem();
-            sleepGaussian(200, 150);
             gameState.brazier.click("light");
             Microbot.log("Relighting brazier (priority)");
             resetActions = true;

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -4358,7 +4358,7 @@ public class MKE_WintertodtScript extends Script {
             if (!hoveredForNextRound && !spamClickingActive && timeUntilStart > 0 && timeUntilStart <= hoverBeforeStartTime) {
                 Rs2TileObjectModel nextObject = getNextInteractiveObject(gameState);
                 if (nextObject != null) {
-                    if (nextObject.getClickbox() != null) Microbot.getMouse().move(nextObject.getClickbox().getBounds());
+                    if (nextObject.getClickbox() != null) moveCursorHumanized(nextObject.getClickbox().getBounds());
                     hoveredForNextRound = true;
                     Microbot.log("Hovering over next interactive object: " + nextObject.getId() + 
                                " (" + (timeUntilStart / 1000.0) + "s before round start)");
@@ -4578,7 +4578,7 @@ public class MKE_WintertodtScript extends Script {
             dx = Math.max(-80, Math.min(80, dx));
             dy = Math.max(-80, Math.min(80, dy));
 
-            Microbot.getMouse().move(start.x + dx, start.y + dy);
+            moveCursorHumanized(start.x + dx, start.y + dy);
 
             /* 3. ~50 % chance of a quick follow-up wobble             */
             if (random.nextBoolean())
@@ -4590,11 +4590,36 @@ public class MKE_WintertodtScript extends Script {
                 dx2 = Math.max(-30, Math.min(30, dx2));
                 dy2 = Math.max(-30, Math.min(30, dy2));
 
-                Microbot.getMouse().move(start.x + dx + dx2,
-                                          start.y + dy + dy2);
+                moveCursorHumanized(start.x + dx + dx2,
+                                    start.y + dy + dy2);
             }
         }
         catch (Exception ignored) {}
+    }
+
+    /**
+     * Routes cursor movement through NaturalMouse when available. Direct
+     * Microbot.getMouse().move(x, y) dispatches a teleport MOUSE_MOVED event
+     * with no path — visually obvious and trivially bot-detectable. Whenever
+     * we want to *move* the cursor (hover, nudge, pre-position before a spam
+     * click), use this so the move follows a smooth Bezier-style curve.
+     */
+    private static void moveCursorHumanized(int x, int y)
+    {
+        if (x <= 1 || y <= 1) return;
+        if (Microbot.naturalMouse != null) {
+            Microbot.naturalMouse.moveTo(x, y);
+        } else {
+            Microbot.getMouse().move(x, y);
+        }
+    }
+
+    private static void moveCursorHumanized(java.awt.Rectangle rect)
+    {
+        if (rect == null) return;
+        int cx = (int) (rect.getX() + rect.getWidth() / 2.0);
+        int cy = (int) (rect.getY() + rect.getHeight() / 2.0);
+        moveCursorHumanized(cx, cy);
     }
 
     /* ------------ knife selection helpers ------------------------------ */
@@ -4888,7 +4913,7 @@ public class MKE_WintertodtScript extends Script {
             }
             
             // Just hover and click without actually interacting
-            if (spamClickTarget.getClickbox() != null) Microbot.getMouse().move(spamClickTarget.getClickbox().getBounds());
+            if (spamClickTarget.getClickbox() != null) moveCursorHumanized(spamClickTarget.getClickbox().getBounds());
             
             // Small delay between hover and click for realism
             sleepGaussian(60, 40);

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -1824,12 +1824,18 @@ public class MKE_WintertodtScript extends Script {
             return;
         }
 
+        // Brazier maintenance is THE priority. When snowfall breaks the
+        // brazier, the fix window closes fast (other players race to repair),
+        // and an unlit brazier means zero points until it's relit. Both of
+        // those beat eating — we'll eat next tick once the brazier is back.
+        if (handleBrazierMaintenance(gameState)) {
+            return;
+        }
+
         // Drop unnecessary items
         dropUnnecessaryItems();
 
-        // Eat first — survival before antiban. If anything later in this method
-        // ever blocks (the dodge logic has wedged in the past), we still want
-        // warmth/HP recovery to have a chance to run this tick.
+        // Eat — survival. Runs only after brazier is fixed/lit (handled above).
         handleEating(gameState);
 
         // Dodge falling snow/damage (opt-in; most players just rely on food/potions)
@@ -2422,7 +2428,9 @@ public class MKE_WintertodtScript extends Script {
                 if (random.nextInt(100) < 10) {
                     sleepGaussian(400, 600);
                 }
-                navigateToBrazier();
+                // Fletch on a snowfall-safe tile rather than at the brazier.
+                // Feeding still walks back to the brazier-stand tile.
+                navigateToFletchSpot();
 
                 // Keep knife in slot-27 optimisation
                 Rs2ItemModel knife = Rs2Inventory.get(WintertodtInventoryManager.knifeToUse);
@@ -3112,6 +3120,47 @@ public class MKE_WintertodtScript extends Script {
      * @param gameState Current game state
      * @return true if food was consumed
      */
+    /**
+     * Top-of-loop brazier priority handler: fix a broken brazier, then relight
+     * an unlit one. Runs before {@link #handleEating} so a snowfall-induced
+     * break doesn't lose us the repair window to another player. Returns true
+     * if a click was issued (caller should skip the rest of the tick).
+     */
+    private boolean handleBrazierMaintenance(GameState gameState) {
+        if (gameState.brokenBrazier != null && config.fixBrazier()) {
+            if (fletchingState.isActive()) {
+                fletchingState.stopFletching(FletchingInterruptType.BRAZIER_BROKEN);
+            }
+            if (feedingState.isActive()) {
+                feedingState.stopFeeding(FeedingInterruptType.BRAZIER_BROKEN);
+            }
+            deselectSelectedItem();
+            gameState.brokenBrazier.click("fix");
+            Microbot.log("Fixing broken brazier (priority over eating)");
+            resetActions = true;
+            actionsPerformed++;
+            return true;
+        }
+
+        if (gameState.burningBrazier == null && gameState.brazier != null
+                && config.relightBrazier() && gameState.isWintertodtAlive) {
+            if (fletchingState.isActive()) {
+                fletchingState.stopFletching(FletchingInterruptType.BRAZIER_WENT_OUT);
+            }
+            if (feedingState.isActive()) {
+                feedingState.stopFeeding(FeedingInterruptType.BRAZIER_WENT_OUT);
+            }
+            deselectSelectedItem();
+            gameState.brazier.click("light");
+            Microbot.log("Relighting brazier (priority over eating)");
+            resetActions = true;
+            actionsPerformed++;
+            return true;
+        }
+
+        return false;
+    }
+
     private boolean handleEating(GameState gameState) {
         if (gameState.playerWarmth <= config.eatAtWarmthLevel()) {
             try {
@@ -3349,6 +3398,34 @@ public class MKE_WintertodtScript extends Script {
 
         } catch (Exception e) {
             System.err.println("Error navigating to brazier: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Navigates to the snowfall-safe fletch tile (one tile south of the
+     * brazier-stand tile). Used only while fletching so we don't tank
+     * snowfall AoE for the entire root pile.
+     */
+    private void navigateToFletchSpot() {
+        try {
+            WorldPoint fletchLocation = config.brazierLocation().getFLETCH_LOCATION();
+            double distance = Rs2Player.getWorldLocation().distanceTo(fletchLocation);
+
+            if (!BreakHandlerScript.isLockState()) {
+                BreakHandlerScript.setLockState(true);
+                Microbot.log("Locking break handler");
+            }
+
+            if (distance > 8) {
+                Rs2Walker.walkTo(fletchLocation, 1);
+                Rs2Player.waitForWalking();
+            } else if (distance >= 1) {
+                Rs2Walker.walkFastCanvas(fletchLocation);
+                sleepGaussian(400, 100);
+            }
+
+        } catch (Exception e) {
+            System.err.println("Error navigating to fletch spot: " + e.getMessage());
         }
     }
 

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -1459,13 +1459,22 @@ public class MKE_WintertodtScript extends Script {
 
             gameState.playerWarmth      = getWarmthLevel();
 
-            // Object detection
+            // Object detection. The previous filter required the brazier object's
+            // worldLocation to *exactly equal* a hardcoded constant in the Brazier
+            // enum, but the actual SW-corner of the brazier object differs by a
+            // tile from that constant (verified live: SE brazier at (1638,3997)
+            // while OBJECT_BRAZIER_LOCATION is (1639,3998)). Result: every brazier
+            // slot was permanently null → no light, no relight, no fix, NPE on
+            // feed. Switch to a tolerant within-radius filter anchored on the
+            // player-stand tile (BRAZIER_LOCATION). The two sides are 17 tiles
+            // apart, so a radius of 3 unambiguously selects the chosen side.
+            WorldPoint brazierAnchor = config.brazierLocation().getBRAZIER_LOCATION();
             gameState.brazier        = Microbot.getRs2TileObjectCache().query().withId(BRAZIER_29312)
-                                          .where(o -> o.getWorldLocation().equals(config.brazierLocation().getOBJECT_BRAZIER_LOCATION())).nearest();
+                                          .within(brazierAnchor, 3).nearest();
             gameState.brokenBrazier  = Microbot.getRs2TileObjectCache().query().withId(BRAZIER_29313)
-                                          .where(o -> o.getWorldLocation().equals(config.brazierLocation().getOBJECT_BRAZIER_LOCATION())).nearest();
+                                          .within(brazierAnchor, 3).nearest();
             gameState.burningBrazier = Microbot.getRs2TileObjectCache().query().withId(BURNING_BRAZIER_29314)
-                                          .where(o -> o.getWorldLocation().equals(config.brazierLocation().getOBJECT_BRAZIER_LOCATION())).nearest();
+                                          .within(brazierAnchor, 3).nearest();
 
             // Health and food management - determine healing strategy
             if (!autoAdjustedPotionUsage) {
@@ -1818,11 +1827,15 @@ public class MKE_WintertodtScript extends Script {
         // Drop unnecessary items
         dropUnnecessaryItems();
 
-        // Dodge falling snow/damage
-        dodgeSnowfallDamage(gameState);
-
-        // Handle eating
+        // Eat first — survival before antiban. If anything later in this method
+        // ever blocks (the dodge logic has wedged in the past), we still want
+        // warmth/HP recovery to have a chance to run this tick.
         handleEating(gameState);
+
+        // Dodge falling snow/damage (opt-in; most players just rely on food/potions)
+        if (config.dodgeSnowfall()) {
+            dodgeSnowfallDamage(gameState);
+        }
 
         // Periodic camera check (every 2 minutes during normal operation)
         if (System.currentTimeMillis() - lastCameraMovement > 120000) {
@@ -1996,10 +2009,12 @@ public class MKE_WintertodtScript extends Script {
             if (shouldLightBrazier(gameState)) {
                 Microbot.log("Prioritizing brazier lighting at round start (state: " + state + ")");
                 return; // Light the brazier first, then resume normal flow next tick
-            } else {
-                // Brazier is already lit or doesn't need lighting, reset the flag
+            } else if (gameState.burningBrazier != null) {
+                // Only consume the priority when a brazier is *definitively* burning
+                // (someone else lit it). If both burning- and unlit- slots are null,
+                // the cache may just be lagging — keep the flag and retry next tick.
                 shouldPriorizeBrazierAtStart = false;
-                Microbot.log("Brazier lighting priority completed or not needed (state: " + state + ")");
+                Microbot.log("Brazier lighting priority completed - already burning (state: " + state + ")");
             }
         }
 
@@ -2398,7 +2413,11 @@ public class MKE_WintertodtScript extends Script {
             }
 
             /* ---------- start / continue fletching ------------------- */
-            if (!isCurrentlyFletching() && gameState.burningBrazier != null) {
+            // Fletching only needs knife + roots; a burning brazier nearby isn't a
+            // precondition. Gating on burningBrazier caused silent idles when the
+            // brazier went out and the relight priority block didn't fire (e.g. the
+            // brazier object briefly fell out of the cache).
+            if (!isCurrentlyFletching()) {
                 sleepGaussian(250, 150);
                 if (random.nextInt(100) < 10) {
                     sleepGaussian(400, 600);
@@ -2452,7 +2471,7 @@ public class MKE_WintertodtScript extends Script {
             }
 
             /* Pre-select knife and hover when we have many roots */
-            if (rootCount > knifePreselectThreshold && !isKnifeSelected() && gameState.burningBrazier != null) {
+            if (rootCount > knifePreselectThreshold && !isKnifeSelected()) {
                 Rs2Inventory.interact(WintertodtInventoryManager.knifeToUse, "Use");
                 sleepGaussian(120, 40);
 
@@ -2532,14 +2551,15 @@ public class MKE_WintertodtScript extends Script {
             }
 
             /* ---------- start / continue feeding ------------------- */
-            if (!isCurrentlyFeeding() && 
-                gameState.hasItemsToBurn) {
+            if (!isCurrentlyFeeding() &&
+                gameState.hasItemsToBurn &&
+                burningBrazier != null) {
 
                 sleepGaussian(200, 150);
                 if (random.nextInt(100) < 10) {
                     sleepGaussian(400, 600);
                 }
-                
+
                 if (burningBrazier.click("feed")) {
                     feedingState.startFeeding();
                     // Initialize animation tracking for new feeding session
@@ -3260,10 +3280,14 @@ public class MKE_WintertodtScript extends Script {
 
         if (gameState.brazier == null || gameState.burningBrazier != null) {
             setLockState(State.LIGHT_BRAZIER, false);
-            // Reset priority flag if brazier is already lit or doesn't exist
-            if (shouldPriorizeBrazierAtStart) {
+            // Only consume the round-start priority when a brazier is *definitively*
+            // burning. If both are null, the cache hasn't seen the brazier yet
+            // (common right after the round-start tick) — keep the flag so we'll
+            // retry once detection catches up, instead of giving up and chopping
+            // for the rest of the round with an unlit brazier.
+            if (shouldPriorizeBrazierAtStart && gameState.burningBrazier != null) {
                 shouldPriorizeBrazierAtStart = false;
-                Microbot.log("Brazier priority reset - brazier already lit or unavailable");
+                Microbot.log("Brazier priority reset - brazier already lit");
             }
             return false;
         }
@@ -3369,29 +3393,15 @@ public class MKE_WintertodtScript extends Script {
                                 Rs2Player.waitForWalking(1500);
                                 resetActions = true;
                                 Microbot.log("Dodged snowfall damage (80% chance triggered)");
-                                Microbot.log("Waiting for burning brazier to go out after snowfall damage...");
-                                Rs2TileObjectModel hoverTarget = Microbot.getRs2TileObjectCache().query()
-                                        .where(o -> o.getName() != null && o.getName().toLowerCase().contains("brazier") && o.isReachable())
-                                        .within(4).nearest();
-                                if (hoverTarget != null && hoverTarget.getClickbox() != null) {
-                                    Microbot.getMouse().move(hoverTarget.getClickbox().getBounds());
-                                }
-
-                                boolean brazierWentOut = sleepUntilTrue(
-                                        () -> {
-                                            // Wait until burning brazier is gone OR we're no longer in burn state
-                                            Rs2TileObjectModel burningBrazier = Microbot.getRs2TileObjectCache().query().withId(BURNING_BRAZIER_29314).within(5).nearest();
-                                            return burningBrazier == null || (state != State.BURN_LOGS && state != State.FLETCH_LOGS);
-                                        },
-                                        100,  // Check every 100ms
-                                        5000 // Timeout after 5 seconds
-                                );
-
-                                if (brazierWentOut) {
-                                    Microbot.log("Brazier state changed, continuing...");
-                                } else {
-                                    Microbot.log("Timeout waiting for brazier change - continuing anyway");
-                                }
+                                // Don't block here. The previous implementation sleepUntilTrue'd
+                                // for the brazier to go out (timeout 5s, but in practice the
+                                // executor wedged for ~140s — see "avg loop time: 141100ms" in
+                                // the round logs), which starved handleEating and nearly killed
+                                // the player. The dodge already moved us out of the AoE; let
+                                // the next script tick re-analyze: the priority blocks in
+                                // handleFletchLogsState / handleBurnLogsState will detect a
+                                // broken brazier and click "fix" (auto-walks back), or relight
+                                // an unlit brazier — exactly what we want here.
                             } else {
                                 Microbot.log("Snowfall detected but purposely NOT dodging (20% chance - staying put for realism ;) )");
                             }

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/enums/Brazier.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/enums/Brazier.java
@@ -6,11 +6,15 @@ import net.runelite.api.coords.WorldPoint;
 
 @AllArgsConstructor
 public enum Brazier {
-    SOUTH_EAST(new WorldPoint(1638, 3996, 0), new WorldPoint(1639, 3998, 0)),
-    SOUTH_WEST(new WorldPoint(1621, 3996, 0), new WorldPoint(1621, 3998, 0));
+    SOUTH_EAST(new WorldPoint(1638, 3996, 0), new WorldPoint(1639, 3998, 0), new WorldPoint(1638, 3995, 0)),
+    SOUTH_WEST(new WorldPoint(1621, 3996, 0), new WorldPoint(1621, 3998, 0), new WorldPoint(1621, 3995, 0));
 
     @Getter
     public final WorldPoint BRAZIER_LOCATION;
     @Getter
     public final WorldPoint OBJECT_BRAZIER_LOCATION;
+    // One tile south of the brazier-stand tile — the same offset the dodge logic uses.
+    // Snowfall AoE around the brazier doesn't reach here, so it's safe to fletch on.
+    @Getter
+    public final WorldPoint FLETCH_LOCATION;
 }


### PR DESCRIPTION
## Summary
- Fix the root cause behind silent-fletch-idle and skipped brazier repairs/lights: `analyzeGameState` was filtering braziers by `worldLocation.equals(constant)`, but the live SE brazier sits at (1638,3997) while the constant was (1639,3998). Switched to `.within(brazierAnchor, 3)` so the cache lookup matches live state.
- Drop a 140s executor wedge in `dodgeSnowfallDamage` (a `sleepUntilTrue` masquerading as a 5s timeout) that was starving `handleEating` and nearly killing the player. Now walk + return; the next tick re-evaluates.
- Add `dodgeSnowfall` config (default **off**) — most players don't bother dodging since eating is more efficient.
- Add a snowfall-safe fletch tile (1 south of the brazier-stand tile, 2 south of the brazier object) and `navigateToFletchSpot()`. Fletching no longer tanks snowfall AoE for a full root pile. Walk fires only on fresh entry to `FLETCH_LOGS`; mid-state interruptions (eat, brazier fix/light) resume in place.
- Promote brazier fix/relight to the top of `performMaintenanceTasks`, ahead of `handleEating`. When snowfall breaks the brazier the repair window closes fast — both fix and relight beat eating, which can wait a tick.
- Antiban hardening (per code review):
  - `handleBrazierMaintenance` gated by `resetActions` + `sleepGaussian(200, 150)` so it can't re-click every 60ms tick during a repair animation.
  - `handleBurnLogsState` fix-block aligned with the relight-block (`sleepGaussian(200, 150)` before click).
  - Feed click now calls `Rs2Antiban.actionCooldown()`.
- Swap config icons from the Pictographs block (`🔪`/`🔧` — render to tofu in the JVM emoji font) to Dingbats/Misc Symbols (`➳`/`⚒️`) which match the blocks `❄️`/`🔥` already render from.
- Plugin version bumped to 2.2.0 (new feature work).

## Test plan
- [x] Compile clean (`./gradlew compileMke_wintertodtJava`).
- [x] Smoke-test live: 5 rounds, 46 fletch starts, 3 fixes, 21 lights, 39 feeds, 0 exceptions/deaths over ~24 minutes.
- [x] Post-fletch interruptions resume in place — no re-walk to safe tile mid-pile.
- [x] Maintenance fires before eating in priority order.
- [x] Zero `Damaged by Wintertodt Snowfall` events after switching to the safe fletch tile.
- [x] Reviewer: verify the `➳` and `⚒️` icons render in your JVM emoji font.