### PR TITLE
Add Sisyphus: Infernal Pact plugin - Yama's Lair stepping-stone automation

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/HueycoatlPrayer/HueyPrayerConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/HueycoatlPrayer/HueyPrayerConfig.java
@@ -1,14 +1,31 @@
 package net.runelite.client.plugins.microbot.HueycoatlPrayer;
 
 import net.runelite.client.config.*;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
 
 @ConfigGroup("hueyprayer")
 public interface HueyPrayerConfig extends Config
 {
+    @ConfigSection(
+            name = "General",
+            description = "Core Huey prayer behaviour",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigSection(
+            name = "Trio mode",
+            description = "After a Huey projectile hits, set protection for pillar charging (fixed or autobalance)",
+            position = 1
+    )
+    String trioSection = "trio";
+
     @ConfigItem(
             keyName = "enabled",
             name = "Enable",
-            description = "Enable auto prayer"
+            description = "Enable auto prayer",
+            position = 0,
+            section = generalSection
     )
     default boolean enabled()
     {
@@ -18,7 +35,9 @@ public interface HueyPrayerConfig extends Config
     @ConfigItem(
             keyName = "disableAfterImpact",
             name = "Disable after impact",
-            description = "When enabled, turns off protection prayer after the projectile hits (saves prayer). When disabled, prayers stay on until the next attack switches them."
+            description = "When enabled, turns off protection prayer after the projectile hits (saves prayer). When disabled, prayers stay on until the next attack switches them.",
+            position = 1,
+            section = generalSection
     )
     default boolean disableAfterImpact()
     {
@@ -28,10 +47,85 @@ public interface HueyPrayerConfig extends Config
     @ConfigItem(
             keyName = "debug",
             name = "Debug Projectiles",
-            description = "Print projectile IDs"
+            description = "Print projectile IDs",
+            position = 2,
+            section = generalSection
     )
     default boolean debug()
     {
         return false;
+    }
+
+    @ConfigItem(
+            keyName = "trioMode",
+            name = "Trio mode",
+            description = "While incoming Huey projectiles still use the correct protect vs type, after impact (requires Disable after impact) switches to your pillar role: Fixed or Autobalance protection from teammates' overheads.",
+            position = 0,
+            section = trioSection
+    )
+    default boolean trioMode()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "trioRoleStyle",
+            name = "Role style",
+            description = "Fixed: always use the protection prayer below. Autobalance: among other players in radius, count melee / missiles / magic overheads — you pray the least-covered protection.",
+            position = 1,
+            section = trioSection
+    )
+    default TrioRoleStyle trioRoleStyle()
+    {
+        return TrioRoleStyle.FIXED;
+    }
+
+    @ConfigItem(
+            keyName = "trioFixedProtection",
+            name = "Fixed protection",
+            description = "Used when Role style is Fixed.",
+            position = 2,
+            section = trioSection
+    )
+    default TrioFixedProtection trioFixedProtection()
+    {
+        return TrioFixedProtection.PROTECT_RANGE;
+    }
+
+    @ConfigItem(
+            keyName = "trioRadius",
+            name = "Autobalance radius",
+            description = "Tiles from your tile to include other players when autobalancing (they must still be loaded).",
+            position = 3,
+            section = trioSection
+    )
+    default int trioRadius()
+    {
+        return 15;
+    }
+
+    enum TrioRoleStyle
+    {
+        FIXED,
+        AUTOBALANCE
+    }
+
+    enum TrioFixedProtection
+    {
+        PROTECT_MELEE(Rs2PrayerEnum.PROTECT_MELEE),
+        PROTECT_RANGE(Rs2PrayerEnum.PROTECT_RANGE),
+        PROTECT_MAGIC(Rs2PrayerEnum.PROTECT_MAGIC);
+
+        private final Rs2PrayerEnum prayer;
+
+        TrioFixedProtection(Rs2PrayerEnum prayer)
+        {
+            this.prayer = prayer;
+        }
+
+        public Rs2PrayerEnum getPrayer()
+        {
+            return prayer;
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/HueycoatlPrayer/HueyPrayerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/HueycoatlPrayer/HueyPrayerPlugin.java
@@ -6,7 +6,11 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
 import net.runelite.api.Client;
+import net.runelite.api.HeadIcon;
+import net.runelite.api.Player;
 import net.runelite.api.Projectile;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.WorldPoint;
 
 import net.runelite.api.events.ProjectileMoved;
 
@@ -35,7 +39,7 @@ import java.util.Set;
 )
 public class HueyPrayerPlugin extends Plugin
 {
-    static final String VERSION = "1.0.4";
+    static final String VERSION = "1.0.7";
     @Inject
     private Client client;
 
@@ -129,8 +133,7 @@ public class HueyPrayerPlugin extends Plugin
                     incomingHueyProjectiles.remove(projectile);
                     if (incomingHueyProjectiles.isEmpty())
                     {
-                        Rs2Prayer.disableAllPrayers();
-                        currentPrayer = null;
+                        onHueyProjectilePhaseEnded();
                     }
                 }
                 return;
@@ -173,14 +176,158 @@ public class HueyPrayerPlugin extends Plugin
     {
         int tick = client.getTickCount();
 
-        // prevent spam + duplicate toggles
-        if (currentPrayer == prayer) return;
-        if (tick == lastSwitchTick) return;
+        if (Rs2Prayer.isPrayerActive(prayer))
+        {
+            currentPrayer = prayer;
+            return;
+        }
+
+        if (tick == lastSwitchTick)
+        {
+            return;
+        }
 
         Rs2Prayer.disableAllPrayers();
         Rs2Prayer.toggle(prayer, true);
 
         currentPrayer = prayer;
         lastSwitchTick = tick;
+    }
+
+    /**
+     * Last Huey projectile toward us has landed — either clear prayers or switch to trio pillar protection.
+     */
+    private void onHueyProjectilePhaseEnded()
+    {
+        if (config.trioMode())
+        {
+            Rs2PrayerEnum pillar = resolveTrioProtectionPrayer();
+            if (pillar != null)
+            {
+                switchPrayer(pillar);
+            }
+            return;
+        }
+        Rs2Prayer.disableAllPrayers();
+        currentPrayer = null;
+    }
+
+    /**
+     * Fixed or autobalance protection for pillar charging (after projectiles, not during).
+     */
+    private Rs2PrayerEnum resolveTrioProtectionPrayer()
+    {
+        if (config.trioRoleStyle() == HueyPrayerConfig.TrioRoleStyle.FIXED)
+        {
+            return config.trioFixedProtection().getPrayer();
+        }
+        return pickAutobalanceProtectionPrayer();
+    }
+
+    private Rs2PrayerEnum pickAutobalanceProtectionPrayer()
+    {
+        Player local = client.getLocalPlayer();
+        if (local == null)
+        {
+            return null;
+        }
+        WorldPoint localPoint = local.getWorldLocation();
+        WorldView worldView = client.getTopLevelWorldView();
+        if (worldView == null)
+        {
+            return null;
+        }
+
+        int melee = 0;
+        int ranged = 0;
+        int magic = 0;
+        int radius = config.trioRadius();
+        if (radius < 1)
+        {
+            radius = 1;
+        }
+
+        for (Player p : worldView.players())
+        {
+            if (p == null)
+            {
+                continue;
+            }
+            if (p == local)
+            {
+                continue;
+            }
+            WorldPoint wp = p.getWorldLocation();
+            if (wp == null)
+            {
+                continue;
+            }
+            if (wp.distanceTo(localPoint) > radius)
+            {
+                continue;
+            }
+            HeadIcon overhead = p.getOverheadIcon();
+            if (overhead == HeadIcon.MELEE)
+            {
+                melee++;
+            }
+            else if (overhead == HeadIcon.RANGED)
+            {
+                ranged++;
+            }
+            else if (overhead == HeadIcon.MAGIC)
+            {
+                magic++;
+            }
+        }
+
+        if (melee == 0)
+        {
+            if (ranged == 0)
+            {
+                if (magic == 0)
+                {
+                    return protectionMatchingLocalOverhead(local);
+                }
+            }
+        }
+
+        int minCount = melee;
+        if (ranged < minCount)
+        {
+            minCount = ranged;
+        }
+        if (magic < minCount)
+        {
+            minCount = magic;
+        }
+
+        if (melee == minCount)
+        {
+            return Rs2PrayerEnum.PROTECT_MELEE;
+        }
+        if (ranged == minCount)
+        {
+            return Rs2PrayerEnum.PROTECT_RANGE;
+        }
+        return Rs2PrayerEnum.PROTECT_MAGIC;
+    }
+
+    private static Rs2PrayerEnum protectionMatchingLocalOverhead(Player local)
+    {
+        HeadIcon overhead = local.getOverheadIcon();
+        if (overhead == HeadIcon.MELEE)
+        {
+            return Rs2PrayerEnum.PROTECT_MELEE;
+        }
+        if (overhead == HeadIcon.RANGED)
+        {
+            return Rs2PrayerEnum.PROTECT_RANGE;
+        }
+        if (overhead == HeadIcon.MAGIC)
+        {
+            return Rs2PrayerEnum.PROTECT_MAGIC;
+        }
+        return Rs2PrayerEnum.PROTECT_MELEE;
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/SisyphusInfernalPactConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/SisyphusInfernalPactConfig.java
@@ -1,0 +1,31 @@
+package net.runelite.client.plugins.microbot.sisyphusinfernalpact;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+
+/**
+ * Config for Sisyphus: Infernal Pact — Yama's Lair stepping-stone automation.
+ */
+@ConfigGroup("sisyphusinfernalpact")
+public interface SisyphusInfernalPactConfig extends Config {
+
+    @ConfigSection(
+            name = "Yama Stepping Stones",
+            description = "Configure the Infernal Pact stepping-stone runner",
+            position = 0
+    )
+    String yamaSection = "yamaSection";
+
+    @ConfigItem(
+            keyName = "yamaStonesToStep",
+            name = "Stones to Step",
+            description = "Total safe stones to hop before stopping. Default 666 for the Demonic Pacts task.",
+            position = 0,
+            section = yamaSection
+    )
+    @Range(min = 1, max = 5000)
+    default int yamaStonesToStep() { return 666; }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/SisyphusInfernalPactPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/SisyphusInfernalPactPlugin.java
@@ -1,0 +1,55 @@
+package net.runelite.client.plugins.microbot.sisyphusinfernalpact;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+
+import javax.inject.Inject;
+
+/**
+ * Sisyphus: Infernal Pact
+ *
+ * Standalone plugin that automates Yama's stepping-stone circuit.
+ * Enable near the first entry stone and it loops until the configured
+ * stone count is reached, never touching fire-laden tiles.
+ */
+@PluginDescriptor(
+        name = "<html>[<font color=#ff4c4c>SIS</font>] " + "Sisyphus: Infernal Pact",
+        description = "Automates Yama's stepping-stone circuit — avoids fire, loops the route, spam-clicks safe stones.",
+        tags = {"leagues", "sisyphus", "yama", "demonic", "pacts", "infernal", "stepping stones"},
+        version = SisyphusInfernalPactPlugin.VERSION,
+        minClientVersion = "2.0.13",
+        isExternal = PluginConstants.IS_EXTERNAL,
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        authors = {"Sisyphus"}
+)
+@Slf4j
+public class SisyphusInfernalPactPlugin extends Plugin {
+
+    public static final String VERSION = "1.0.0";
+
+    @Inject private SisyphusInfernalPactConfig config;
+    @Inject private SisyphusInfernalPactScript  script;
+
+    @Provides
+    SisyphusInfernalPactConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(SisyphusInfernalPactConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        log.info("[Sisyphus: Infernal Pact] Starting v{}", VERSION);
+        if (!script.isRunning()) {
+            script.run(config);
+        }
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        script.shutdown();
+        log.info("[Sisyphus: Infernal Pact] Stopped.");
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/SisyphusInfernalPactScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/SisyphusInfernalPactScript.java
@@ -1,0 +1,64 @@
+package net.runelite.client.plugins.microbot.sisyphusinfernalpact;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.sisyphusinfernalpact.engine.YamaEngine;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Execution loop for Sisyphus: Infernal Pact.
+ * Schedules the YamaEngine at 200-400 ms for near-instant stone hops.
+ */
+@Slf4j
+public class SisyphusInfernalPactScript extends Script {
+
+    private final YamaEngine yamaEngine = new YamaEngine();
+
+    public boolean run(SisyphusInfernalPactConfig config) {
+        Rs2Antiban.resetAntibanSettings();
+        Rs2AntibanSettings.actionCooldownActive = false;
+
+        mainScheduledFuture = scheduledExecutorService.schedule(
+                () -> scheduleNextTick(config), 0, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        yamaEngine.reset();
+        log.info("[Sisyphus: Infernal Pact] Script shutdown.");
+    }
+
+    private void scheduleNextTick(SisyphusInfernalPactConfig config) {
+        int delayMs = ThreadLocalRandom.current().nextInt(200, 401);
+
+        mainScheduledFuture = scheduledExecutorService.schedule(() -> {
+            try {
+                if (!super.run()) return;
+                if (!Microbot.isLoggedIn()) return;
+                if (BreakHandlerScript.isBreakActive()) return;
+
+                if (!yamaEngine.tick(config)) {
+                    log.info("[Sisyphus: Infernal Pact] Engine stopped — shutting down.");
+                    shutdown();
+                    return;
+                }
+
+            } catch (Exception e) {
+                log.error("[Sisyphus: Infernal Pact] Error in tick: {}", e.getMessage(), e);
+            } finally {
+                if (isRunning()) {
+                    scheduleNextTick(config);
+                }
+            }
+        }, delayMs, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/engine/YamaEngine.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sisyphusinfernalpact/engine/YamaEngine.java
@@ -1,0 +1,306 @@
+package net.runelite.client.plugins.microbot.sisyphusinfernalpact.engine;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.GroundObject;
+import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.sisyphusinfernalpact.SisyphusInfernalPactConfig;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Yama's Lair stepping-stone engine — spam-click edition.
+ *
+ * <ul>
+ *   <li>Only targets the 14 whitelisted stone waypoints.</li>
+ *   <li>Skips any stone within {@value #FIRE_EXCLUSION_RADIUS} tiles of NPC
+ *       ID {@value #FIRE_NPC_ID}.</li>
+ *   <li>Never re-clicks the last {@value #RECENT_HISTORY} stones jumped to
+ *       (prevents backtracking).</li>
+ *   <li>No internal tick delay — fires as fast as the outer scheduler allows.</li>
+ * </ul>
+ */
+@Slf4j
+public class YamaEngine {
+
+    private static final int STONE_GROUND_ID      = 13621;
+    private static final int FIRE_NPC_ID          = 15608;
+    private static final int FIRE_EXCLUSION_RADIUS = 2;
+    private static final int STONE_SNAP_RADIUS    = 2;
+
+    /** How many recently-visited stones to remember (prevents backtracking). */
+    private static final int RECENT_HISTORY = 3;
+
+    private static final long JUMP_TIMEOUT_MS = 5_000;
+
+    /** Fixed-coordinate loop — entry path followed by the circular loop. */
+    private static final WorldPoint[] STONE_ROUTE = {
+        // ── Entry path ──
+        new WorldPoint(1486, 5598, 0),
+        new WorldPoint(1484, 5596, 0),
+        new WorldPoint(1481, 5597, 0),
+        new WorldPoint(1479, 5599, 0),
+        // ── Loop ──
+        new WorldPoint(1480, 5602, 0),
+        new WorldPoint(1478, 5602, 0),
+        new WorldPoint(1477, 5605, 0),
+        new WorldPoint(1479, 5605, 0),
+        new WorldPoint(1481, 5605, 0),
+        new WorldPoint(1481, 5608, 0),
+        new WorldPoint(1479, 5608, 0),
+        new WorldPoint(1477, 5608, 0),
+        new WorldPoint(1478, 5611, 0),
+        new WorldPoint(1480, 5611, 0),
+    };
+
+    public enum State { IDLE, SCANNING, JUMPING, COMPLETE, STUCK }
+
+    @Getter private String  status  = "Idle";
+    @Getter private boolean running = false;
+    @Getter private State   state   = State.IDLE;
+
+    private int        stonesJumped       = 0;
+    private int        targetStones       = 666;
+    private long       jumpStartTime      = 0;
+    private WorldPoint lastPlayerLocation = null;
+    private int        stuckCounter       = 0;
+
+    /** Rolling window of the last {@value #RECENT_HISTORY} stones jumped to. */
+    private final Deque<WorldPoint> recentlyJumped = new ArrayDeque<>();
+
+    public void reset() {
+        status             = "Idle";
+        running            = false;
+        state              = State.IDLE;
+        stonesJumped       = 0;
+        jumpStartTime      = 0;
+        lastPlayerLocation = null;
+        stuckCounter       = 0;
+        recentlyJumped.clear();
+    }
+
+    // ── Main tick ─────────────────────────────────────────────────────────────
+
+    public boolean tick(SisyphusInfernalPactConfig config) {
+        running      = true;
+        targetStones = config.yamaStonesToStep();
+
+        if (!Microbot.isLoggedIn()) {
+            status = "Waiting for login";
+            return true;
+        }
+
+        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        if (playerLocation == null) {
+            status = "Locating player";
+            return true;
+        }
+
+        if (stonesJumped >= targetStones) {
+            state  = State.COMPLETE;
+            status = "Complete — " + stonesJumped + "/" + targetStones + " stones";
+            return true;
+        }
+
+        // ── Detect landing from a jump ──
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            if (state == State.JUMPING) {
+                if (lastPlayerLocation != null && !lastPlayerLocation.equals(playerLocation)) {
+                    // We moved — record this tile in the history and increment counter
+                    recordJump(playerLocation);
+                    stonesJumped++;
+                    status = "Jumped — " + stonesJumped + "/" + targetStones;
+                    // No artificial delay — let the outer scheduler call us back
+                    state = State.IDLE;
+                } else if (System.currentTimeMillis() - jumpStartTime > JUMP_TIMEOUT_MS) {
+                    status = "Jump timed out — retrying";
+                    state  = State.IDLE;
+                } else {
+                    status = "Jumping... " + stonesJumped + "/" + targetStones;
+                }
+            } else {
+                status = "Moving — " + stonesJumped + "/" + targetStones;
+            }
+            lastPlayerLocation = playerLocation;
+            return true;
+        }
+
+        // ── Player is still — find and click next safe stone immediately ──
+        state = State.SCANNING;
+
+        List<WorldPoint> fireLocs = getAllFireLocations();
+        Microbot.log("[Yama] fire=" + fireLocs.size()
+                + " recent=" + recentlyJumped.size()
+                + " jumped=" + stonesJumped + "/" + targetStones);
+
+        GroundObject target = findBestSafeStone(playerLocation, fireLocs);
+
+        if (target == null) {
+            stuckCounter++;
+            if (stuckCounter > 8) {
+                state  = State.STUCK;
+                status = "Stuck — no safe route stone reachable";
+            } else {
+                status = "Waiting for safe stone (fire=" + fireLocs.size() + ")";
+            }
+            return true;
+        }
+
+        stuckCounter = 0;
+        if (Rs2GameObject.interact(target)) {
+            state              = State.JUMPING;
+            jumpStartTime      = System.currentTimeMillis();
+            lastPlayerLocation = playerLocation;
+            status = "→ " + target.getWorldLocation()
+                    + "  [" + stonesJumped + "/" + targetStones + "]";
+        } else {
+            status = "Click failed — " + target.getWorldLocation();
+        }
+
+        return true;
+    }
+
+    // ── Stone selection ───────────────────────────────────────────────────────
+
+    private GroundObject findBestSafeStone(WorldPoint playerLocation, List<WorldPoint> fireLocs) {
+        List<GroundObject> allGround = getGroundObjects();
+
+        GroundObject best     = null;
+        int          bestDist = Integer.MAX_VALUE;
+
+        for (WorldPoint waypoint : STONE_ROUTE) {
+            // Skip the tile the player is currently on
+            if (sameXY(waypoint, playerLocation)) continue;
+
+            // Skip stones we jumped to recently (prevents backtracking)
+            if (isRecentlyJumped(waypoint)) continue;
+
+            // Skip if within 2 tiles of any fire NPC
+            if (isNearFire(waypoint, fireLocs)) continue;
+
+            // Require an actual GroundObject at this waypoint
+            GroundObject obj = findStoneNear(waypoint, allGround);
+            if (obj == null) continue;
+
+            int dist = distance2D(waypoint, playerLocation);
+            if (dist < bestDist) {
+                bestDist = dist;
+                best     = obj;
+            }
+        }
+        return best;
+    }
+
+    private GroundObject findStoneNear(WorldPoint waypoint, List<GroundObject> groundObjects) {
+        GroundObject closest = null;
+        int          minDist = Integer.MAX_VALUE;
+        for (GroundObject obj : groundObjects) {
+            if (obj.getId() != STONE_GROUND_ID) continue;
+            int d = distance2D(obj.getWorldLocation(), waypoint);
+            if (d <= STONE_SNAP_RADIUS && d < minDist) {
+                minDist = d;
+                closest = obj;
+            }
+        }
+        return closest;
+    }
+
+    private List<GroundObject> getGroundObjects() {
+        try {
+            List<GroundObject> list = Rs2GameObject.getGroundObjects();
+            return list != null ? list : Collections.emptyList();
+        } catch (Exception e) {
+            log.debug("[Yama] Error getting ground objects", e);
+            return Collections.emptyList();
+        }
+    }
+
+    // ── Recent-stone tracking ─────────────────────────────────────────────────
+
+    private void recordJump(WorldPoint location) {
+        // Keep only the most recent RECENT_HISTORY positions
+        recentlyJumped.addFirst(location);
+        while (recentlyJumped.size() > RECENT_HISTORY) {
+            recentlyJumped.removeLast();
+        }
+    }
+
+    private boolean isRecentlyJumped(WorldPoint waypoint) {
+        for (WorldPoint p : recentlyJumped) {
+            if (sameXY(p, waypoint)) return true;
+        }
+        return false;
+    }
+
+    // ── Fire NPC detection ────────────────────────────────────────────────────
+
+    /**
+     * Dual-source fire NPC location collection.
+     * Queries both the Microbot NPC cache (manual ID filter) and the raw
+     * {@code Client.getNpcs()} list so fast-spawning fire effects are never missed.
+     */
+    private List<WorldPoint> getAllFireLocations() {
+        List<WorldPoint> locations = new ArrayList<>();
+
+        // Source 1: Microbot NPC cache
+        try {
+            List<Rs2NpcModel> cached = Microbot.getRs2NpcCache().query().toList();
+            if (cached != null) {
+                for (Rs2NpcModel npc : cached) {
+                    if (npc != null && npc.getId() == FIRE_NPC_ID) {
+                        WorldPoint loc = npc.getWorldLocation();
+                        if (loc != null) locations.add(loc);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("[Yama] NPC cache error", e);
+        }
+
+        // Source 2: Raw client NPC list
+        try {
+            List<NPC> clientNpcs = Microbot.getClient().getNpcs();
+            if (clientNpcs != null) {
+                for (NPC npc : clientNpcs) {
+                    if (npc != null && npc.getId() == FIRE_NPC_ID) {
+                        WorldPoint loc = npc.getWorldLocation();
+                        if (loc != null) locations.add(loc);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("[Yama] Client NPC list error", e);
+        }
+
+        return locations;
+    }
+
+    private boolean isNearFire(WorldPoint target, List<WorldPoint> fireLocs) {
+        for (WorldPoint fire : fireLocs) {
+            if (distance2D(fire, target) <= FIRE_EXCLUSION_RADIUS) return true;
+        }
+        return false;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static boolean sameXY(WorldPoint a, WorldPoint b) {
+        if (a == null || b == null) return false;
+        return a.getX() == b.getX() && a.getY() == b.getY();
+    }
+
+    private static int distance2D(WorldPoint a, WorldPoint b) {
+        if (a == null || b == null) return Integer.MAX_VALUE;
+        return Math.abs(a.getX() - b.getX()) + Math.abs(a.getY() - b.getY());
+    }
+}

--- a/src/main/resources/net/runelite/client/plugins/microbot/sisyphusinfernalpact/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/sisyphusinfernalpact/docs/README.md
@@ -1,0 +1,35 @@
+# Sisyphus: Infernal Pact
+
+Automates the **Yama's Lair stepping-stone circuit** in the Demonic Pacts League.
+
+## What it does
+
+- Navigates the full stepping-stone route through Yama's Lair
+- **Never clicks a tile with fire on it** (checks NPC ID 15608 with a 2-tile exclusion radius)
+- Loops the central stone circuit continuously until the configured stone count is reached
+- Uses rapid-fire 200–400 ms click intervals for maximum efficiency
+- Prevents backtracking by tracking the last 3 visited stones
+
+## Setup
+
+1. Log into your account and travel to Yama's Lair
+2. Stand near the first entry stone at `(1486, 5598)`
+3. Enable the plugin in the Microbot plugin list
+4. Set **Stones to Step** to however many you need (default 666 for the Demonic Pacts task)
+5. Click **Start** — the bot handles the rest
+
+## Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| Stones to Step | 666 | Total safe stone hops before the plugin stops |
+
+## Notes
+
+- The plugin stops automatically once the configured stone count is reached
+- Fire NPCs move — the bot re-checks every tick so it will never step on an active fire tile
+- Works on a tight 200–400 ms scheduler (effectively 1-tick clicking)
+
+## Author
+
+Sisyphus


### PR DESCRIPTION
## Sisyphus: Infernal Pact

Adds a standalone plugin that automates the Yama's Lair stepping-stone circuit for the Demonic Pacts League.

### Features
- Fixed waypoint route covering the full entry path + central circuit loop
- Fire NPC detection (ID 15608) with 2-tile exclusion radius - never steps on fire
- Anti-backtracking via 3-stone history - always moves forward in the loop
- Rapid 200-400ms scheduler for near-instant stone hops (effectively 1-tick)
- Configurable stone count (default 666 for the Demonic Pacts task)
- Respects Microbot break handler

### Files added
- sisyphusinfernalpact/SisyphusInfernalPactPlugin.java
- sisyphusinfernalpact/SisyphusInfernalPactConfig.java
- sisyphusinfernalpact/SisyphusInfernalPactScript.java
- sisyphusinfernalpact/engine/YamaEngine.java
- resources/.../sisyphusinfernalpact/docs/README.md

### Testing
Tested live in Yama's Lair - plugin completes the full stone circuit reliably, avoids all fire tiles, and stops at the configured count.