### PR TITLE
Butterfly Catcher

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherConfig.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigInformation(
+        "<b>Butterfly Catcher</b> — by StonksCode<br/><br/>" +
+        "<b>Species (net / barehanded):</b><br/>" +
+        "Ruby Harvest 5/15 &nbsp;|&nbsp; Sapphire Glacialis 25/35 &nbsp;|&nbsp; Snowy Knight 35/45<br/>" +
+        "Black Warlock 45/55 &nbsp;|&nbsp; Sunlight Moth 65/75 &nbsp;|&nbsp; Moonlight Moth 75/85<br/><br/>" +
+        "<b>Barehanded</b> — XP only, nothing in inventory<br/>" +
+        "<b>Butterfly Net</b> — equip net first, 10 levels lower requirement"
+)
+@ConfigGroup("ButterflyCatcher")
+public interface ButterflyCatcherConfig extends Config {
+
+    @ConfigItem(
+            keyName = "butterflyType",
+            name = "Butterfly / Moth",
+            description = "<html>Which creature to hunt.<br>"
+                    + "<b>Classic:</b> Ruby Harvest, Sapphire Glacialis, Snowy Knight, Black Warlock.<br>"
+                    + "<b>Varlamore:</b> Sunlight Moth, Moonlight Moth.<br>"
+                    + "Net level shown in parentheses; barehanded = net + 10.</html>",
+            position = 0
+    )
+    default ButterflyType butterflyType() {
+        return ButterflyType.BLACK_WARLOCK;
+    }
+
+    @ConfigItem(
+            keyName = "catchMode",
+            name = "Catch Mode",
+            description = "<html><b>BAREHANDED:</b> catch and release for XP — nothing enters inventory.<br>"
+                    + "<b>BUTTERFLY_NET:</b> use an equipped butterfly net (lower level requirement).</html>",
+            position = 1
+    )
+    default CatchMode catchMode() {
+        return CatchMode.BAREHANDED;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherPlugin.java
@@ -1,0 +1,73 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+import javax.inject.Inject;
+
+/**
+ * =====================================================================
+ *  Butterfly Catcher
+ *  Author: StonksCode
+ * =====================================================================
+ *
+ *  Automates butterfly and moth catching for Hunter XP training.
+ *
+ *  Supported species:
+ *    - Ruby Harvest       (net lvl 5  / bare lvl 15)
+ *    - Sapphire Glacialis (net lvl 25 / bare lvl 35)
+ *    - Snowy Knight       (net lvl 35 / bare lvl 45)
+ *    - Black Warlock      (net lvl 45 / bare lvl 55)
+ *    - Sunlight Moth      (net lvl 65 / bare lvl 75)
+ *    - Moonlight Moth     (net lvl 75 / bare lvl 85)
+ *
+ *  Catch modes:
+ *    BAREHANDED    — catch and release for XP; nothing enters inventory.
+ *    BUTTERFLY_NET — equip a butterfly net or magic butterfly net before
+ *                    starting; allows catching at 10 levels lower than
+ *                    the barehanded requirement.
+ *
+ *  Usage:
+ *    1. Stand near a spawn of your chosen species.
+ *    2. If using Butterfly Net mode, equip your net first.
+ *    3. Select your species and catch mode in the config panel.
+ *    4. Start the plugin — it will run indefinitely with no banking.
+ * =====================================================================
+ */
+@PluginDescriptor(
+        name = "Butterfly Catcher",
+        description = "By StonksCode. Automates butterfly and moth catching for Hunter XP. See the config panel for full setup instructions.",
+        tags = {"hunter", "butterfly", "moth", "sunlight", "moonlight", "net", "microbot", "stonkscode"},
+        enabledByDefault = false
+)
+@Slf4j
+public class ButterflyCatcherPlugin extends Plugin {
+
+    @Inject
+    private ButterflyCatcherConfig config;
+
+    @Inject
+    private ButterflyCatcherScript script;
+
+    @Provides
+    ButterflyCatcherConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(ButterflyCatcherConfig.class);
+    }
+
+    @Override
+    protected void startUp() {
+        script.run(config);
+        log.info("Butterfly Catcher started — target: {}", config.butterflyType().getDisplayName());
+    }
+
+    @Override
+    protected void shutDown() {
+        if (script != null) {
+            script.shutdown();
+        }
+        log.info("Butterfly Catcher stopped.");
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherScript.java
@@ -1,0 +1,204 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.api.npc.Rs2NpcCache;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ButterflyCatcherScript
+ *
+ * Two modes — both run indefinitely with no banking:
+ *
+ *   BAREHANDED:
+ *     Click catch, wait for animation/movement to resolve, repeat.
+ *     Requires Hunter level >= target.getBarehandedLevelRequired().
+ *
+ *   BUTTERFLY_NET:
+ *     Same loop, but requires a butterfly net or magic butterfly net to be
+ *     equipped. Verified once on startup. Requires Hunter level >=
+ *     target.getNetLevelRequired() (10 levels lower than barehanded).
+ *
+ * Item IDs for nets:
+ *   Butterfly net       : 10010
+ *   Magic butterfly net : 11259
+ */
+@Slf4j
+public class ButterflyCatcherScript extends Script {
+
+    // Item IDs for butterfly nets
+    private static final int NET_ITEM_ID       = 10010;
+    private static final int MAGIC_NET_ITEM_ID = 11259;
+
+    @Inject
+    private Rs2NpcCache npcCache;
+
+    private static final String TAG  = "[ButterflyCatcher]";
+    private static final int    TICK = 600;
+
+    // -------------------------------------------------------------------------
+    // Internal state
+    // -------------------------------------------------------------------------
+
+    private ButterflyType targetButterfly;
+    private CatchMode     catchMode;
+    private boolean       catchCommitted = false;
+
+    // -------------------------------------------------------------------------
+    // Entry point
+    // -------------------------------------------------------------------------
+
+    public boolean run(ButterflyCatcherConfig config) {
+        this.targetButterfly = config.butterflyType();
+        this.catchMode       = config.catchMode();
+
+        int requiredLevel = effectiveLevel();
+        Microbot.log(TAG + " Starting — target: " + targetButterfly.getDisplayName()
+                + " | mode: " + catchMode
+                + " | Required Hunter level: " + requiredLevel);
+
+        // --- Net equipment check (BUTTERFLY_NET mode only) ---
+        if (catchMode == CatchMode.BUTTERFLY_NET) {
+            if (!isNetEquipped()) {
+                Microbot.log(TAG + " ⚠ No butterfly net equipped! "
+                        + "Please equip a Butterfly Net (10010) or Magic Butterfly Net (11259) "
+                        + "before starting. Stopping.");
+                Microbot.showMessage("Butterfly Catcher stopped: no butterfly net equipped. "
+                        + "Equip a net and restart.");
+                return false;
+            }
+            Microbot.log(TAG + " Butterfly net verified — equipment check passed.");
+        }
+
+        // --- Hunter level check ---
+        int hunterLevel = Microbot.getClient().getRealSkillLevel(Skill.HUNTER);
+        if (hunterLevel < requiredLevel) {
+            Microbot.log(TAG + " ⚠ Hunter level too low ("
+                    + hunterLevel + " / " + requiredLevel
+                    + ") for " + targetButterfly.getDisplayName()
+                    + " in " + catchMode + " mode. Stopping.");
+            Microbot.showMessage("Butterfly Catcher stopped: Hunter level too low ("
+                    + hunterLevel + " / " + requiredLevel + ").");
+            return false;
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(
+                this::tick, 0, TICK, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Main tick
+    // -------------------------------------------------------------------------
+
+    private void tick() {
+        try {
+            if (!Microbot.isLoggedIn()) return;
+            if (!super.run()) return;
+
+            // Re-check level every tick in case boosted level drops below threshold
+            int hunterLevel = Microbot.getClient().getRealSkillLevel(Skill.HUNTER);
+            if (hunterLevel < effectiveLevel()) {
+                Microbot.log(TAG + " Hunter level too low ("
+                        + hunterLevel + " / " + effectiveLevel()
+                        + ") — stopping.");
+                shutdown();
+                return;
+            }
+
+            tickCatching();
+
+        } catch (Exception e) {
+            log.error(TAG + " Unexpected error in tick: {}", e.getMessage(), e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // CATCHING
+    // -------------------------------------------------------------------------
+
+    private void tickCatching() {
+        // Idle guard — don't spam-click while already committed to a catch attempt
+        if (catchCommitted) {
+            if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+                return;
+            }
+            catchCommitted = false;
+        }
+
+        if (Rs2Player.isAnimating()) return;
+
+        // Find nearest target NPC
+        Rs2NpcModel target = findNearestTarget();
+
+        if (target == null) {
+            Microbot.log(TAG + " No " + targetButterfly.getDisplayName()
+                    + " found nearby (IDs: " + Arrays.toString(targetButterfly.getNpcIds()) + ") — waiting.");
+            return;
+        }
+
+        boolean clicked = target.click("Catch");
+        if (!clicked) {
+            log.warn(TAG + " click(Catch) failed on {} at {}",
+                    targetButterfly.getDisplayName(), target.getWorldLocation());
+            return;
+        }
+
+        catchCommitted = true;
+        log.debug(TAG + " Clicked Catch on {} at {}",
+                targetButterfly.getDisplayName(), target.getWorldLocation());
+        sleepUntil(() -> Rs2Player.isAnimating() || Rs2Player.isMoving(), 1500);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the Hunter level required for the current catch mode.
+     * BUTTERFLY_NET uses the lower net threshold; BAREHANDED adds 10.
+     */
+    private int effectiveLevel() {
+        return catchMode == CatchMode.BUTTERFLY_NET
+                ? targetButterfly.getNetLevelRequired()
+                : targetButterfly.getBarehandedLevelRequired();
+    }
+
+    /**
+     * Returns true if a butterfly net or magic butterfly net is currently equipped.
+     */
+    private boolean isNetEquipped() {
+        return Rs2Equipment.isWearing(NET_ITEM_ID) || Rs2Equipment.isWearing(MAGIC_NET_ITEM_ID);
+    }
+
+    private Rs2NpcModel findNearestTarget() {
+        Rs2NpcModel best = null;
+        int bestDist     = Integer.MAX_VALUE;
+        WorldPoint myPos = Rs2Player.getWorldLocation();
+
+        for (int npcId : targetButterfly.getNpcIds()) {
+            Rs2NpcModel candidate = npcCache.query().withId(npcId).nearest();
+            if (candidate == null) continue;
+            int dist = candidate.getWorldLocation().distanceTo(myPos);
+            if (dist < bestDist) {
+                bestDist = dist;
+                best     = candidate;
+            }
+        }
+        return best;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyType.java
@@ -1,0 +1,139 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import lombok.Getter;
+
+/**
+ * ButterflyType
+ *
+ * Defines all catchable butterflies and moths from the Hunter skill.
+ * Data sourced from: https://oldschool.runescape.wiki/w/Butterfly_(Hunter)
+ *
+ * Level requirements:
+ *   The game requires a Hunter level 10 ABOVE the net level for barehanded catching.
+ *   This enum stores the NET level as the baseline; the script derives the
+ *   barehanded level by adding 10.
+ *
+ *   Species              Net   Barehanded
+ *   ─────────────────── ────  ──────────
+ *   Ruby Harvest          5       15
+ *   Sapphire Glacialis   25       35
+ *   Snowy Knight         35       45
+ *   Black Warlock        45       55
+ *   Sunlight Moth        65       75
+ *   Moonlight Moth       75       85
+ *
+ * Item IDs:
+ *   Butterfly net      : 10010
+ *   Magic butterfly net: 11259
+ *   Butterfly jar      : 10012  (same for all species)
+ */
+@Getter
+public enum ButterflyType {
+
+    RUBY_HARVEST(
+            "Ruby Harvest",
+            new int[]{ 5525 },
+            5,
+            10012,
+            10009
+    ),
+    SAPPHIRE_GLACIALIS(
+            "Sapphire Glacialis",
+            new int[]{ 5526 },
+            25,
+            10012,
+            10011
+    ),
+    SNOWY_KNIGHT(
+            "Snowy Knight",
+            new int[]{ 5527 },
+            35,
+            10012,
+            10013
+    ),
+    BLACK_WARLOCK(
+            "Black Warlock",
+            new int[]{ 5553 },
+            45,
+            10012,
+            10010
+    ),
+
+    /**
+     * Sunlight Moth — Avium Savannah south of the Hunter Guild.
+     * Net: 65 | Barehanded: 75
+     */
+    SUNLIGHT_MOTH(
+            "Sunlight Moth",
+            new int[]{ 12770 },
+            65,
+            10012,
+            28890
+    ),
+
+    /**
+     * Moonlight Moth — Neypotzli / Hunter Guild basement / Tonali Cavern.
+     * Net: 75 | Barehanded: 85
+     * NPC IDs: 12771, 12772, 12773 (variants per location).
+     */
+    MOONLIGHT_MOTH(
+            "Moonlight Moth",
+            new int[]{ 12771, 12772, 12773 },
+            75,
+            10012,
+            28893
+    );
+
+    // -------------------------------------------------------------------------
+
+    /** Human-readable name shown in the config dropdown. */
+    private final String displayName;
+
+    /**
+     * All NPC IDs for this creature.
+     * Most species have exactly one. Moonlight Moth has three location variants.
+     */
+    private final int[] npcIds;
+
+    /**
+     * Hunter level required to catch with a butterfly net (or magic butterfly net).
+     */
+    private final int netLevelRequired;
+
+    /** Item ID of the empty butterfly jar (always 10012). */
+    private final int jarItemId;
+
+    /** Item ID placed in the inventory after a successful jar catch. */
+    private final int caughtItemId;
+
+    // -------------------------------------------------------------------------
+
+    ButterflyType(String displayName, int[] npcIds, int netLevelRequired,
+                  int jarItemId, int caughtItemId) {
+        this.displayName      = displayName;
+        this.npcIds           = npcIds;
+        this.netLevelRequired = netLevelRequired;
+        this.jarItemId        = jarItemId;
+        this.caughtItemId     = caughtItemId;
+    }
+
+    /**
+     * Hunter level required to catch bare-handed (always netLevelRequired + 10).
+     */
+    public int getBarehandedLevelRequired() {
+        return netLevelRequired + 10;
+    }
+
+    /**
+     * Returns the primary NPC ID (first in the array). Used for logging.
+     * The script always iterates all IDs in the array when searching.
+     */
+    public int getNpcId() {
+        return npcIds[0];
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/CatchMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/CatchMode.java
@@ -1,0 +1,37 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+/**
+ * CatchMode
+ *
+ * Controls whether the plugin catches bare-handed (XP only) or uses a
+ * butterfly net / magic butterfly net.
+ *
+ * Banking has been intentionally removed — the script runs indefinitely
+ * without ever needing to visit a bank.
+ */
+public enum CatchMode {
+
+    /**
+     * Catch the butterfly/moth bare-handed.
+     * The creature is instantly released on catch, so nothing enters the
+     * inventory. Requires Hunter level = netLevelRequired + 10.
+     */
+    BAREHANDED,
+
+    /**
+     * Catch using a butterfly net (or magic butterfly net).
+     * The net must be equipped before the script starts — the script will
+     * verify this on startup and stop with a message if not equipped.
+     * Requires Hunter level = netLevelRequired (the lower threshold).
+     */
+    BUTTERFLY_NET;
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case BAREHANDED:    return "Barehanded";
+            case BUTTERFLY_NET: return "Butterfly Net";
+            default:            return name();
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherConfig.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigInformation(
+        "<b>Butterfly Catcher</b> — by StonksCode<br/><br/>" +
+        "<b>Species (net / barehanded):</b><br/>" +
+        "Ruby Harvest 5/15 &nbsp;|&nbsp; Sapphire Glacialis 25/35 &nbsp;|&nbsp; Snowy Knight 35/45<br/>" +
+        "Black Warlock 45/55 &nbsp;|&nbsp; Sunlight Moth 65/75 &nbsp;|&nbsp; Moonlight Moth 75/85<br/><br/>" +
+        "<b>Barehanded</b> — XP only, nothing in inventory<br/>" +
+        "<b>Butterfly Net</b> — equip net first, 10 levels lower requirement"
+)
+@ConfigGroup("ButterflyCatcher")
+public interface ButterflyCatcherConfig extends Config {
+
+    @ConfigItem(
+            keyName = "butterflyType",
+            name = "Butterfly / Moth",
+            description = "<html>Which creature to hunt.<br>"
+                    + "<b>Classic:</b> Ruby Harvest, Sapphire Glacialis, Snowy Knight, Black Warlock.<br>"
+                    + "<b>Varlamore:</b> Sunlight Moth, Moonlight Moth.<br>"
+                    + "Net level shown in parentheses; barehanded = net + 10.</html>",
+            position = 0
+    )
+    default ButterflyType butterflyType() {
+        return ButterflyType.BLACK_WARLOCK;
+    }
+
+    @ConfigItem(
+            keyName = "catchMode",
+            name = "Catch Mode",
+            description = "<html><b>BAREHANDED:</b> catch and release for XP — nothing enters inventory.<br>"
+                    + "<b>BUTTERFLY_NET:</b> use an equipped butterfly net (lower level requirement).</html>",
+            position = 1
+    )
+    default CatchMode catchMode() {
+        return CatchMode.BAREHANDED;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherPlugin.java
@@ -1,0 +1,73 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+import javax.inject.Inject;
+
+/**
+ * =====================================================================
+ *  Butterfly Catcher
+ *  Author: StonksCode
+ * =====================================================================
+ *
+ *  Automates butterfly and moth catching for Hunter XP training.
+ *
+ *  Supported species:
+ *    - Ruby Harvest       (net lvl 5  / bare lvl 15)
+ *    - Sapphire Glacialis (net lvl 25 / bare lvl 35)
+ *    - Snowy Knight       (net lvl 35 / bare lvl 45)
+ *    - Black Warlock      (net lvl 45 / bare lvl 55)
+ *    - Sunlight Moth      (net lvl 65 / bare lvl 75)
+ *    - Moonlight Moth     (net lvl 75 / bare lvl 85)
+ *
+ *  Catch modes:
+ *    BAREHANDED    — catch and release for XP; nothing enters inventory.
+ *    BUTTERFLY_NET — equip a butterfly net or magic butterfly net before
+ *                    starting; allows catching at 10 levels lower than
+ *                    the barehanded requirement.
+ *
+ *  Usage:
+ *    1. Stand near a spawn of your chosen species.
+ *    2. If using Butterfly Net mode, equip your net first.
+ *    3. Select your species and catch mode in the config panel.
+ *    4. Start the plugin — it will run indefinitely with no banking.
+ * =====================================================================
+ */
+@PluginDescriptor(
+        name = "Butterfly Catcher",
+        description = "By StonksCode. Automates butterfly and moth catching for Hunter XP. See the config panel for full setup instructions.",
+        tags = {"hunter", "butterfly", "moth", "sunlight", "moonlight", "net", "microbot", "stonkscode"},
+        enabledByDefault = false
+)
+@Slf4j
+public class ButterflyCatcherPlugin extends Plugin {
+
+    @Inject
+    private ButterflyCatcherConfig config;
+
+    @Inject
+    private ButterflyCatcherScript script;
+
+    @Provides
+    ButterflyCatcherConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(ButterflyCatcherConfig.class);
+    }
+
+    @Override
+    protected void startUp() {
+        script.run(config);
+        log.info("Butterfly Catcher started — target: {}", config.butterflyType().getDisplayName());
+    }
+
+    @Override
+    protected void shutDown() {
+        if (script != null) {
+            script.shutdown();
+        }
+        log.info("Butterfly Catcher stopped.");
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyCatcherScript.java
@@ -1,0 +1,204 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.api.npc.Rs2NpcCache;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ButterflyCatcherScript
+ *
+ * Two modes — both run indefinitely with no banking:
+ *
+ *   BAREHANDED:
+ *     Click catch, wait for animation/movement to resolve, repeat.
+ *     Requires Hunter level >= target.getBarehandedLevelRequired().
+ *
+ *   BUTTERFLY_NET:
+ *     Same loop, but requires a butterfly net or magic butterfly net to be
+ *     equipped. Verified once on startup. Requires Hunter level >=
+ *     target.getNetLevelRequired() (10 levels lower than barehanded).
+ *
+ * Item IDs for nets:
+ *   Butterfly net       : 10010
+ *   Magic butterfly net : 11259
+ */
+@Slf4j
+public class ButterflyCatcherScript extends Script {
+
+    // Item IDs for butterfly nets
+    private static final int NET_ITEM_ID       = 10010;
+    private static final int MAGIC_NET_ITEM_ID = 11259;
+
+    @Inject
+    private Rs2NpcCache npcCache;
+
+    private static final String TAG  = "[ButterflyCatcher]";
+    private static final int    TICK = 600;
+
+    // -------------------------------------------------------------------------
+    // Internal state
+    // -------------------------------------------------------------------------
+
+    private ButterflyType targetButterfly;
+    private CatchMode     catchMode;
+    private boolean       catchCommitted = false;
+
+    // -------------------------------------------------------------------------
+    // Entry point
+    // -------------------------------------------------------------------------
+
+    public boolean run(ButterflyCatcherConfig config) {
+        this.targetButterfly = config.butterflyType();
+        this.catchMode       = config.catchMode();
+
+        int requiredLevel = effectiveLevel();
+        Microbot.log(TAG + " Starting — target: " + targetButterfly.getDisplayName()
+                + " | mode: " + catchMode
+                + " | Required Hunter level: " + requiredLevel);
+
+        // --- Net equipment check (BUTTERFLY_NET mode only) ---
+        if (catchMode == CatchMode.BUTTERFLY_NET) {
+            if (!isNetEquipped()) {
+                Microbot.log(TAG + " ⚠ No butterfly net equipped! "
+                        + "Please equip a Butterfly Net (10010) or Magic Butterfly Net (11259) "
+                        + "before starting. Stopping.");
+                Microbot.showMessage("Butterfly Catcher stopped: no butterfly net equipped. "
+                        + "Equip a net and restart.");
+                return false;
+            }
+            Microbot.log(TAG + " Butterfly net verified — equipment check passed.");
+        }
+
+        // --- Hunter level check ---
+        int hunterLevel = Microbot.getClient().getRealSkillLevel(Skill.HUNTER);
+        if (hunterLevel < requiredLevel) {
+            Microbot.log(TAG + " ⚠ Hunter level too low ("
+                    + hunterLevel + " / " + requiredLevel
+                    + ") for " + targetButterfly.getDisplayName()
+                    + " in " + catchMode + " mode. Stopping.");
+            Microbot.showMessage("Butterfly Catcher stopped: Hunter level too low ("
+                    + hunterLevel + " / " + requiredLevel + ").");
+            return false;
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(
+                this::tick, 0, TICK, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Main tick
+    // -------------------------------------------------------------------------
+
+    private void tick() {
+        try {
+            if (!Microbot.isLoggedIn()) return;
+            if (!super.run()) return;
+
+            // Re-check level every tick in case boosted level drops below threshold
+            int hunterLevel = Microbot.getClient().getRealSkillLevel(Skill.HUNTER);
+            if (hunterLevel < effectiveLevel()) {
+                Microbot.log(TAG + " Hunter level too low ("
+                        + hunterLevel + " / " + effectiveLevel()
+                        + ") — stopping.");
+                shutdown();
+                return;
+            }
+
+            tickCatching();
+
+        } catch (Exception e) {
+            log.error(TAG + " Unexpected error in tick: {}", e.getMessage(), e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // CATCHING
+    // -------------------------------------------------------------------------
+
+    private void tickCatching() {
+        // Idle guard — don't spam-click while already committed to a catch attempt
+        if (catchCommitted) {
+            if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+                return;
+            }
+            catchCommitted = false;
+        }
+
+        if (Rs2Player.isAnimating()) return;
+
+        // Find nearest target NPC
+        Rs2NpcModel target = findNearestTarget();
+
+        if (target == null) {
+            Microbot.log(TAG + " No " + targetButterfly.getDisplayName()
+                    + " found nearby (IDs: " + Arrays.toString(targetButterfly.getNpcIds()) + ") — waiting.");
+            return;
+        }
+
+        boolean clicked = target.click("Catch");
+        if (!clicked) {
+            log.warn(TAG + " click(Catch) failed on {} at {}",
+                    targetButterfly.getDisplayName(), target.getWorldLocation());
+            return;
+        }
+
+        catchCommitted = true;
+        log.debug(TAG + " Clicked Catch on {} at {}",
+                targetButterfly.getDisplayName(), target.getWorldLocation());
+        sleepUntil(() -> Rs2Player.isAnimating() || Rs2Player.isMoving(), 1500);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the Hunter level required for the current catch mode.
+     * BUTTERFLY_NET uses the lower net threshold; BAREHANDED adds 10.
+     */
+    private int effectiveLevel() {
+        return catchMode == CatchMode.BUTTERFLY_NET
+                ? targetButterfly.getNetLevelRequired()
+                : targetButterfly.getBarehandedLevelRequired();
+    }
+
+    /**
+     * Returns true if a butterfly net or magic butterfly net is currently equipped.
+     */
+    private boolean isNetEquipped() {
+        return Rs2Equipment.isWearing(NET_ITEM_ID) || Rs2Equipment.isWearing(MAGIC_NET_ITEM_ID);
+    }
+
+    private Rs2NpcModel findNearestTarget() {
+        Rs2NpcModel best = null;
+        int bestDist     = Integer.MAX_VALUE;
+        WorldPoint myPos = Rs2Player.getWorldLocation();
+
+        for (int npcId : targetButterfly.getNpcIds()) {
+            Rs2NpcModel candidate = npcCache.query().withId(npcId).nearest();
+            if (candidate == null) continue;
+            int dist = candidate.getWorldLocation().distanceTo(myPos);
+            if (dist < bestDist) {
+                bestDist = dist;
+                best     = candidate;
+            }
+        }
+        return best;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyType.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/ButterflyType.java
@@ -1,0 +1,139 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+import lombok.Getter;
+
+/**
+ * ButterflyType
+ *
+ * Defines all catchable butterflies and moths from the Hunter skill.
+ * Data sourced from: https://oldschool.runescape.wiki/w/Butterfly_(Hunter)
+ *
+ * Level requirements:
+ *   The game requires a Hunter level 10 ABOVE the net level for barehanded catching.
+ *   This enum stores the NET level as the baseline; the script derives the
+ *   barehanded level by adding 10.
+ *
+ *   Species              Net   Barehanded
+ *   ─────────────────── ────  ──────────
+ *   Ruby Harvest          5       15
+ *   Sapphire Glacialis   25       35
+ *   Snowy Knight         35       45
+ *   Black Warlock        45       55
+ *   Sunlight Moth        65       75
+ *   Moonlight Moth       75       85
+ *
+ * Item IDs:
+ *   Butterfly net      : 10010
+ *   Magic butterfly net: 11259
+ *   Butterfly jar      : 10012  (same for all species)
+ */
+@Getter
+public enum ButterflyType {
+
+    RUBY_HARVEST(
+            "Ruby Harvest",
+            new int[]{ 5525 },
+            5,
+            10012,
+            10009
+    ),
+    SAPPHIRE_GLACIALIS(
+            "Sapphire Glacialis",
+            new int[]{ 5526 },
+            25,
+            10012,
+            10011
+    ),
+    SNOWY_KNIGHT(
+            "Snowy Knight",
+            new int[]{ 5527 },
+            35,
+            10012,
+            10013
+    ),
+    BLACK_WARLOCK(
+            "Black Warlock",
+            new int[]{ 5553 },
+            45,
+            10012,
+            10010
+    ),
+
+    /**
+     * Sunlight Moth — Avium Savannah south of the Hunter Guild.
+     * Net: 65 | Barehanded: 75
+     */
+    SUNLIGHT_MOTH(
+            "Sunlight Moth",
+            new int[]{ 12770 },
+            65,
+            10012,
+            28890
+    ),
+
+    /**
+     * Moonlight Moth — Neypotzli / Hunter Guild basement / Tonali Cavern.
+     * Net: 75 | Barehanded: 85
+     * NPC IDs: 12771, 12772, 12773 (variants per location).
+     */
+    MOONLIGHT_MOTH(
+            "Moonlight Moth",
+            new int[]{ 12771, 12772, 12773 },
+            75,
+            10012,
+            28893
+    );
+
+    // -------------------------------------------------------------------------
+
+    /** Human-readable name shown in the config dropdown. */
+    private final String displayName;
+
+    /**
+     * All NPC IDs for this creature.
+     * Most species have exactly one. Moonlight Moth has three location variants.
+     */
+    private final int[] npcIds;
+
+    /**
+     * Hunter level required to catch with a butterfly net (or magic butterfly net).
+     */
+    private final int netLevelRequired;
+
+    /** Item ID of the empty butterfly jar (always 10012). */
+    private final int jarItemId;
+
+    /** Item ID placed in the inventory after a successful jar catch. */
+    private final int caughtItemId;
+
+    // -------------------------------------------------------------------------
+
+    ButterflyType(String displayName, int[] npcIds, int netLevelRequired,
+                  int jarItemId, int caughtItemId) {
+        this.displayName      = displayName;
+        this.npcIds           = npcIds;
+        this.netLevelRequired = netLevelRequired;
+        this.jarItemId        = jarItemId;
+        this.caughtItemId     = caughtItemId;
+    }
+
+    /**
+     * Hunter level required to catch bare-handed (always netLevelRequired + 10).
+     */
+    public int getBarehandedLevelRequired() {
+        return netLevelRequired + 10;
+    }
+
+    /**
+     * Returns the primary NPC ID (first in the array). Used for logging.
+     * The script always iterates all IDs in the array when searching.
+     */
+    public int getNpcId() {
+        return npcIds[0];
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/CatchMode.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/butterflycatcher/CatchMode.java
@@ -1,0 +1,37 @@
+package net.runelite.client.plugins.microbot.butterflycatcher;
+
+/**
+ * CatchMode
+ *
+ * Controls whether the plugin catches bare-handed (XP only) or uses a
+ * butterfly net / magic butterfly net.
+ *
+ * Banking has been intentionally removed — the script runs indefinitely
+ * without ever needing to visit a bank.
+ */
+public enum CatchMode {
+
+    /**
+     * Catch the butterfly/moth bare-handed.
+     * The creature is instantly released on catch, so nothing enters the
+     * inventory. Requires Hunter level = netLevelRequired + 10.
+     */
+    BAREHANDED,
+
+    /**
+     * Catch using a butterfly net (or magic butterfly net).
+     * The net must be equipped before the script starts — the script will
+     * verify this on startup and stop with a message if not equipped.
+     * Requires Hunter level = netLevelRequired (the lower threshold).
+     */
+    BUTTERFLY_NET;
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case BAREHANDED:    return "Barehanded";
+            case BUTTERFLY_NET: return "Butterfly Net";
+            default:            return name();
+        }
+    }
+}


### PR DESCRIPTION
Adds an automated Hunter skill plugin for catching butterflies and moths. Runs indefinitely with no banking required.
Supported species:
Ruby Harvest (5/15), Sapphire Glacialis (25/35), Snowy Knight (35/45), Black Warlock (45/55), Sunlight Moth (65/75), Moonlight Moth (75/85) — levels shown as net/barehanded.
Catch modes:

Barehanded — catches and releases for XP, nothing enters inventory. Requires the higher Hunter level.
Butterfly Net — equip a butterfly net or magic butterfly net before starting. Allows catching 10 levels lower than barehanded. Plugin verifies the net is equipped on startup and halts with a message if not found.