### PR TITLE
fix(auto-smelting): rewrite bail-on-transient-state checks

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingPlugin.java
@@ -29,7 +29,7 @@ import java.awt.*;
 )
 @Slf4j
 public class AutoSmeltingPlugin extends Plugin {
-    public static final String version = "1.0.3";
+    public static final String version = "1.0.4";
     @Inject
     private AutoSmeltingConfig config;
     @Provides

--- a/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/smelting/AutoSmeltingScript.java
@@ -15,7 +15,6 @@ import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 
-import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -35,8 +34,13 @@ public class AutoSmeltingScript extends Script {
             try {
                 if (!super.run()) return;
                 if (!Microbot.isLoggedIn()) return;
-                if (config.SELECTED_BAR_TYPE().getRequiredSmithingLevel() > Rs2Player.getBoostedSkillLevel(Skill.SMITHING)) {
-                    Microbot.showMessage("Your smithing level isn't high enough for " + config.SELECTED_BAR_TYPE().toString());
+                int currentSmithing = Rs2Player.getRealSkillLevel(Skill.SMITHING);
+                // Skill reads return 0 transiently during login / region load.
+                if (currentSmithing <= 0) return;
+                int requiredSmithing = config.SELECTED_BAR_TYPE().getRequiredSmithingLevel();
+                if (currentSmithing < requiredSmithing) {
+                    Microbot.log("Smithing " + currentSmithing + " is below the " + requiredSmithing
+                            + " required for " + config.SELECTED_BAR_TYPE() + ". Shutting down.");
                     super.shutdown();
                     return;
                 }
@@ -61,6 +65,10 @@ public class AutoSmeltingScript extends Script {
                     if (!Rs2Player.isInMemberWorld()) {
                         Rs2Bank.depositAll();
                     } else if (Rs2Player.isMember()) Rs2Bank.depositAllExcept(coalBag);
+                    // depositAll fires a menu click and returns before the next game tick
+                    // processes it. Wait for slots to free so the upcoming withdrawX isn't
+                    // blocked by Rs2Bank's "inventory full of the wrong item" guard.
+                    sleepUntil(() -> !Rs2Inventory.isFull(), 3000);
                     if (config.SELECTED_BAR_TYPE().getId() == ItemID.IRON_BAR && Rs2Bank.hasItem(ItemID.RING_OF_FORGING) && !Rs2Equipment.isWearing(ItemID.RING_OF_FORGING)) {
                         Rs2Bank.withdrawAndEquip(ItemID.RING_OF_FORGING);
                         return;
@@ -71,7 +79,7 @@ public class AutoSmeltingScript extends Script {
                             Rs2Bank.withdrawAndEquip(ItemID.GAUNTLETS_OF_GOLDSMITHING);
                             return;
                         }
-                        if (selectedBar != i && (Rs2Bank.hasItem(ItemID.SMITHING_UNIFORM_GLOVES) || Rs2Bank.hasItem(ItemID.SMITHING_UNIFORM_GLOVES_ICE)) && (!Rs2Equipment.isWearing(ItemID.SMITHING_UNIFORM_GLOVES_ICE) ||!Rs2Equipment.isWearing(ItemID.SMITHING_UNIFORM_GLOVES_ICE))) {
+                        if (selectedBar != i && (Rs2Bank.hasItem(ItemID.SMITHING_UNIFORM_GLOVES) || Rs2Bank.hasItem(ItemID.SMITHING_UNIFORM_GLOVES_ICE)) && !Rs2Equipment.isWearing(ItemID.SMITHING_UNIFORM_GLOVES_ICE) && !Rs2Equipment.isWearing(ItemID.SMITHING_UNIFORM_GLOVES)) {
                             if (Rs2Bank.hasItem(ItemID.SMITHING_UNIFORM_GLOVES_ICE)) {
                                 Rs2Bank.withdrawAndEquip(ItemID.SMITHING_UNIFORM_GLOVES_ICE);
                                 return;
@@ -107,52 +115,40 @@ public class AutoSmeltingScript extends Script {
                     withdrawRightAmountOfMaterials(config);
                     return;
                 }
-                Rs2TileObjectModel oneClickFurnace = Microbot.getRs2TileObjectCache().query()
-                        .where(o -> o.getName() != null && o.getName().toLowerCase().contains("furnace"))
-                        .within(initialPlayerLocation, 20)
-                        .nearest();
-                if (oneClickFurnace != null) {
-                    if (Rs2Bank.isOpen()){
-                        Rs2Bank.closeBank();
-                        sleepUntil(() -> !Rs2Bank.isOpen(), 1000);
-                    }
-                    oneClickFurnace.click("smelt");
-                    sleepUntil(Rs2Player::isMoving, 1000);
-                    sleepUntil(() -> !Rs2Player.isMoving(), 4000);
-                    Rs2Widget.sleepUntilHasWidgetText("What would you like to smelt?", 270, 5, false, 4000);
-                    Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
-                    Rs2Widget.sleepUntilHasNotWidgetText("What would you like to smelt?", 270, 5, false, 4000);
-                    Rs2Antiban.actionCooldown();
-                    Rs2Antiban.takeMicroBreakByChance();
+                if (Rs2Bank.isOpen()) {
+                    Rs2Bank.closeBank();
+                    sleepUntil(() -> !Rs2Bank.isOpen(), 1500);
                     return;
                 }
 
-                // walk to the initial position (near furnace)
-                if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
-                    if (Rs2Bank.isOpen())
-                        Rs2Bank.closeBank();
-                    Rs2Walker.walkTo(initialPlayerLocation, 4);
-                    return;
-                }
-
-                // interact with the furnace until the smelting dialogue opens in chat, click the selected bar icon
+                // Run the lookup on the client thread so each getName() resolves in-place
+                // instead of round-tripping through ClientThread.invoke per scene object.
                 Rs2TileObjectModel furnace = Microbot.getRs2TileObjectCache().query()
-                        .where(o -> o.getName() != null && o.getName().toLowerCase().contains("furnace"))
-                        .within(initialPlayerLocation, 20)
-                        .nearest();
-                if (furnace != null) {
-                    furnace.click("smelt");
-                    Rs2Widget.sleepUntilHasWidgetText("What would you like to smelt?", 270, 5, false, 4000);
-                    Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
-                    Rs2Widget.sleepUntilHasNotWidgetText("What would you like to smelt?", 270, 5, false, 4000);
-                    Rs2Antiban.actionCooldown();
-                    Rs2Antiban.takeMicroBreakByChance();
+                        .withNameContains("furnace")
+                        .nearestOnClientThread(initialPlayerLocation, 20);
+
+                if (furnace == null) {
+                    if (initialPlayerLocation.distanceTo(Rs2Player.getWorldLocation()) > 4) {
+                        Rs2Walker.walkTo(initialPlayerLocation, 4);
+                    } else {
+                        Microbot.status = "AutoSmelting: no furnace within 20 tiles of start — stand near a furnace and restart";
+                    }
+                    return;
                 }
+
+                furnace.click("smelt");
+                sleepUntil(Rs2Player::isMoving, 1000);
+                sleepUntil(() -> !Rs2Player.isMoving(), 6000);
+                Rs2Widget.sleepUntilHasWidgetText("What would you like to smelt?", 270, 5, false, 4000);
+                Rs2Widget.clickWidget(config.SELECTED_BAR_TYPE().getName());
+                Rs2Widget.sleepUntilHasNotWidgetText("What would you like to smelt?", 270, 5, false, 4000);
+                Rs2Antiban.actionCooldown();
+                Rs2Antiban.takeMicroBreakByChance();
 
             } catch (Exception ex) {
-                System.out.println(ex.getMessage());
+                Microbot.logStackTrace("AutoSmeltingScript", ex);
             }
-        }, 0, 100, TimeUnit.MILLISECONDS);
+        }, 0, 600, TimeUnit.MILLISECONDS);
         return true;
     }
 
@@ -185,16 +181,16 @@ public class AutoSmeltingScript extends Script {
                     ? config.SELECTED_BAR_TYPE().getWithdrawalsWithCoalBag(Rs2Inventory.capacity()).get(requiredMaterials.getKey())
                     : config.SELECTED_BAR_TYPE().maxBarsForFullInventory() * amountForOne;
             if (!Rs2Bank.hasBankItem(name, totalAmount, true)) {
-                Microbot.showMessage(MessageFormat.format("Required Materials not in bank. You need {1} {0}.", name, totalAmount));
-                super.shutdown();
+                Microbot.log("Bank lacks " + totalAmount + " " + name + ". Shutting down.");
+                shutdown();
+                return;
             }
             Rs2Bank.withdrawX(name, totalAmount, true);
             sleepUntil(() -> Rs2Inventory.hasItemAmount(name, totalAmount, false, true), 3500);
-
-            // Exit if we did not end up finding it.
+            // Withdraw missed the verify window — let the next tick retry instead of bailing.
             if (!Rs2Inventory.hasItemAmount(name, totalAmount, false, true)) {
-                Microbot.showMessage("Could not find item in bank.");
-                shutdown();
+                Microbot.log("Withdraw of " + totalAmount + " " + name + " didn't settle in 3.5s; retrying next tick.");
+                return;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Rewrites the bail-on-transient-state error checks that fired spurious popups ("smithing level isn't high enough", "Could not find item in bank") mid-run and shut the plugin down on transient game-state reads.
- Replaces a per-scene-object ClientThread furnace lookup (the previously-reported "opens bank, grabs ore, then stalls" bug) with `withNameContains` + `nearestOnClientThread`.
- Adds a post-deposit settle wait so Rs2Bank's full-inventory guard doesn't silently skip the cycle-2 withdraw.
- Bumps version 1.0.3 → 1.0.4. See the commit message for the per-fix breakdown.

## Test plan
- [x] `./gradlew build -PpluginList=AutoSmeltingPlugin` → BUILD SUCCESSFUL
- [x] In-client at Edgeville with silver: 2+ full cycles (28 ore → 28 bars → bank → withdraw → repeat) with no popups, no unexpected shutdowns, plugin status stays RUNNING across the deposit→withdraw transition (the previous bug's failure point)