### PR TITLE
fix(leftclickcast): dropdown sync + preserve Attack on right-click

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastConfig.java
@@ -20,11 +20,10 @@ public interface LeftClickCastConfig extends Config
 		return true;
 	}
 
-	// Retained so existing stored config is not invalidated. Read once at startUp for migration into slot1Spell.
 	@ConfigItem(
 		keyName = "spell",
 		name = "Spell",
-		description = "Legacy single-spell setting — migrated into Slot 1 on startup.",
+		description = "The currently active spell. Synced with the active slot — pressing a slot hotkey updates this, and editing this updates the active slot's spell.",
 		position = 1
 	)
 	default PertTargetSpell spell()

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -49,7 +49,7 @@ import net.runelite.client.util.HotkeyListener;
 )
 public class LeftClickCastPlugin extends Plugin
 {
-	static final String version = "1.3.0";
+	static final String version = "1.3.1";
 
 	private static final int SLOT_COUNT = 5;
 
@@ -114,6 +114,7 @@ public class LeftClickCastPlugin extends Plugin
 		};
 		keyManager.registerKeyListener(enabledToggleListener);
 		migrateLegacySpellKey();
+		syncTopSpellToActiveSlot();
 	}
 
 	@Override
@@ -242,12 +243,57 @@ public class LeftClickCastPlugin extends Plugin
 		}
 	}
 
+	private static String slotSpellKeyFor(int index)
+	{
+		switch (index)
+		{
+			case 0:
+				return "slot1Spell";
+			case 1:
+				return "slot2Spell";
+			case 2:
+				return "slot3Spell";
+			case 3:
+				return "slot4Spell";
+			case 4:
+				return "slot5Spell";
+			default:
+				return "slot1Spell";
+		}
+	}
+
+	private static int slotIndexForKey(String key)
+	{
+		switch (key)
+		{
+			case "slot1Spell":
+				return 0;
+			case "slot2Spell":
+				return 1;
+			case "slot3Spell":
+				return 2;
+			case "slot4Spell":
+				return 3;
+			case "slot5Spell":
+				return 4;
+			default:
+				return -1;
+		}
+	}
+
 	private void onSlotHotkey(int index)
 	{
 		activeSlot = index;
+		PertTargetSpell spell = slotSpellFor(index);
+		if (spell != null && config.spell() != spell)
+		{
+			configManager.setConfiguration("leftclickcast", "spell", spell);
+			// MicrobotConfigPanel doesn't refresh individual widgets on ConfigChanged — force a rebuild
+			// so the top dropdown visibly matches the newly active slot.
+			eventBus.post(new ExternalPluginsChanged());
+		}
 		if (config.chatFeedback())
 		{
-			PertTargetSpell spell = slotSpellFor(index);
 			String display = spell != null ? spell.getDisplayName() : "(no spell)";
 			chatMessageManager.queue(QueuedMessage.builder()
 				.type(ChatMessageType.GAMEMESSAGE)
@@ -270,19 +316,57 @@ public class LeftClickCastPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (!"leftclickcast".equals(event.getGroup()) || !"enabled".equals(event.getKey()))
+		if (!"leftclickcast".equals(event.getGroup()))
 		{
 			return;
 		}
-		if (!config.chatFeedback())
+		String key = event.getKey();
+		if ("enabled".equals(key))
 		{
+			if (!config.chatFeedback())
+			{
+				return;
+			}
+			boolean enabled = "true".equals(event.getNewValue());
+			chatMessageManager.queue(QueuedMessage.builder()
+				.type(ChatMessageType.GAMEMESSAGE)
+				.value("Left-Click Cast: " + (enabled ? "enabled" : "disabled"))
+				.build());
 			return;
 		}
-		boolean enabled = "true".equals(event.getNewValue());
-		chatMessageManager.queue(QueuedMessage.builder()
-			.type(ChatMessageType.GAMEMESSAGE)
-			.value("Left-Click Cast: " + (enabled ? "enabled" : "disabled"))
-			.build());
+		if ("spell".equals(key))
+		{
+			// User edited the top dropdown — mirror the value into the currently active slot's config.
+			// The equality guard stops the ConfigChanged→write→ConfigChanged loop.
+			PertTargetSpell newSpell = config.spell();
+			PertTargetSpell activeSpell = slotSpellFor(activeSlot);
+			if (newSpell != null && newSpell != activeSpell)
+			{
+				configManager.setConfiguration("leftclickcast", slotSpellKeyFor(activeSlot), newSpell);
+				eventBus.post(new ExternalPluginsChanged());
+			}
+			return;
+		}
+		int slot = slotIndexForKey(key);
+		if (slot == activeSlot && slot >= 0)
+		{
+			// User edited the spell for the currently active slot — mirror into the top dropdown.
+			PertTargetSpell newSpell = slotSpellFor(slot);
+			if (newSpell != null && newSpell != config.spell())
+			{
+				configManager.setConfiguration("leftclickcast", "spell", newSpell);
+				eventBus.post(new ExternalPluginsChanged());
+			}
+		}
+	}
+
+	private void syncTopSpellToActiveSlot()
+	{
+		PertTargetSpell active = slotSpellFor(activeSlot);
+		if (active != null && config.spell() != active)
+		{
+			configManager.setConfiguration("leftclickcast", "spell", active);
+		}
 	}
 
 	// Fast-path cast: fire two synchronous client.menuAction packets back-to-back so the server processes

--- a/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leftclickcast/LeftClickCastPlugin.java
@@ -49,7 +49,7 @@ import net.runelite.client.util.HotkeyListener;
 )
 public class LeftClickCastPlugin extends Plugin
 {
-	static final String version = "1.3.1";
+	static final String version = "1.3.2";
 
 	private static final int SLOT_COUNT = 5;
 
@@ -192,17 +192,20 @@ public class LeftClickCastPlugin extends Plugin
 		MenuEntry attack = entries[attackIdx];
 		final Actor dispatchTarget = targetActor;
 		final PertTargetSpell dispatchSpell = spell;
-		attack.setOption("Cast " + dispatchSpell.getDisplayName());
-		attack.setType(MenuAction.RUNELITE);
-		attack.onClick(e -> castOnTargetFast(dispatchSpell, dispatchTarget));
 
-		// Move to the tail of the array — that slot is the left-click action in RuneLite's menu model.
-		if (attackIdx != entries.length - 1)
-		{
-			entries[attackIdx] = entries[entries.length - 1];
-			entries[entries.length - 1] = attack;
-			menu.setMenuEntries(entries);
-		}
+		// Append a new RUNELITE-type "Cast X" entry at the tail. The tail is the left-click action in
+		// RuneLite's menu model, so Cast becomes left-click while the original Attack entry stays in the
+		// list — preserving right-click "Attack" access. Identifier/param0/param1/worldViewId are copied
+		// from the original so target highlighting behaves the same as a real Attack hover.
+		MenuEntry cast = menu.createMenuEntry(-1)
+			.setOption("Cast " + dispatchSpell.getDisplayName())
+			.setTarget(attack.getTarget())
+			.setType(MenuAction.RUNELITE)
+			.setIdentifier(attack.getIdentifier())
+			.setParam0(attack.getParam0())
+			.setParam1(attack.getParam1())
+			.onClick(e -> castOnTargetFast(dispatchSpell, dispatchTarget));
+		cast.setWorldViewId(attack.getWorldViewId());
 	}
 
 	private Keybind slotHotkeyFor(int index)


### PR DESCRIPTION
## Summary
- Top spell dropdown is now two-way synced with the active slot — editing the dropdown updates the active slot's spell, and pressing a slot hotkey updates the dropdown to that slot's spell.
- Left-click "Cast X" is added as a new menu entry rather than mutating the game's Attack entry — right-clicking an NPC still offers plain Attack.

## Test plan
- [x] `./gradlew :LeftClickCastPluginJar -PpluginList=LeftClickCastPlugin` against Microbot client 2.6.0
- [x] Top dropdown edit updates the active slot's spell config (verified live)
- [x] Pressing a slot hotkey updates the top dropdown and selects that slot's spell
- [x] Right-click on NPC still shows Attack option; left-click fires Cast