### PR TITLE
fix(MKE_Wintertodt): skip brazier maintenance while chopping roots

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
@@ -42,7 +42,7 @@ import java.time.Instant;
 )
 @Slf4j
 public class MKE_WintertodtPlugin extends Plugin {
-    static final String version = "2.2.0";
+    static final String version = "2.2.1";
 
     // Core plugin components
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -3145,6 +3145,12 @@ public class MKE_WintertodtScript extends Script {
         // begins, so a single repair click can trigger.
         if (resetActions) return false;
 
+        // Skip while chopping — the roots are several tiles from the brazier,
+        // so by the time we abandon the chop and walk over, another player
+        // has already repaired/relit. The interruption costs us a chop cycle
+        // for nothing.
+        if (state == State.CHOP_ROOTS) return false;
+
         if (gameState.brokenBrazier != null && config.fixBrazier()) {
             if (fletchingState.isActive()) {
                 fletchingState.stopFletching(FletchingInterruptType.BRAZIER_BROKEN);


### PR DESCRIPTION
## Summary
- Bail out of `handleBrazierMaintenance` when `state == CHOP_ROOTS` — roots are several tiles from the brazier, so abandoning a chop to walk over loses the repair/relight window to another player anyway. The interruption costs a chop cycle for nothing.
- Bump plugin version 2.2.0 → 2.2.1.

## Test plan
- [x] Run the plugin at Wintertodt; observe that a broken/unlit brazier event during `CHOP_ROOTS` does not abort the current chop cycle.
- [x] Confirm brazier maintenance still triggers normally outside of `CHOP_ROOTS` (e.g. during `FLETCH_LOGS`, `BURN_LOGS`, idle).