### PR TITLE
fix(build): restore development branch compilation

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnacePlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnacePlugin.java
@@ -35,7 +35,7 @@ import static net.runelite.client.plugins.microbot.blastoisefurnace.BlastoiseFur
 )
 @Slf4j
 public class BlastoiseFurnacePlugin extends Plugin {
-    final static String version = "1.2.1";
+    final static String version = "1.2.2";
     @Inject
     private BlastoiseFurnaceConfig config;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/blastoisefurnace/BlastoiseFurnaceScript.java
@@ -29,14 +29,15 @@ import java.awt.event.KeyEvent;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static net.runelite.api.gameval.ItemID.*;
 import static net.runelite.api.gameval.ObjectID.*;
 import static net.runelite.api.gameval.VarbitID.*;
-import static net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper.ITEM_NAME_SUFFIX_PATTERN;
 
 @Slf4j
 public class BlastoiseFurnaceScript extends Script {
+    private static final Pattern ITEM_NAME_SUFFIX_PATTERN = Pattern.compile("^(.*?)(?:\\s*\\((\\d+)\\))?$");
     static final int coalBag = 12019;
     private static final int MAX_ORE_PER_INTERACTION = 27;
     private static final int MAX_ORE_PER_HYBRID_INTERACTION = 26;


### PR DESCRIPTION
## Summary

Every open PR's CI is currently red with ~100 javac errors across
`motherloadmine`, `jewelleryenchant`, `kittentracker`, `sisyphusinfernalpact`,
`thievingstalls`, `driftnet`, `herbiboar`, and `blastoisefurnace`. The
`Development Build` push CI on `development` is still listed as green
only because no push has landed since 2026-05-11 (`5df19c4`); the two
workflows run an identical `./gradlew clean build`, so the next push to
`development` would fail the same way.

## Root cause

The Microbot client jar at version `2.6.0` (currently resolved as
`latest` by `gradle/project-config.gradle#fetchLatestMicrobotClientVersion`)
no longer exposes the `ITEM_NAME_SUFFIX_PATTERN` constant on
`Rs2UiHelper`. `BlastoiseFurnaceScript.java` had a `import static …
Rs2UiHelper.ITEM_NAME_SUFFIX_PATTERN;`, so `:compileJava` failed early
on that one symbol.

That single failed import cascaded through Lombok's javac patch and
silently disabled annotation processing for the rest of the main source
set, surfacing as 100 unrelated "cannot find symbol" errors:

- `@Slf4j` no longer generated `log` -> `cannot find symbol: log` and
  `log has private access in Script` (since the parent `Script`'s
  shaded `log` field is now `private`).
- `@Getter` no longer generated accessors -> `getX()` / `getY()` not
  found across `MLMMiningSpot`, `Pickaxe`, `Jewellery`, `Staff`, etc.
- `@AllArgsConstructor(onConstructor_ = @Inject)` and
  `@Getter(onMethod_ = {@Varbit})` -> `cannot find symbol:
  onConstructor_()` / `onMethod_()` because Lombok's javac-internal
  rewrite that maps `onConstructor_` -> `onConstructor` (the actual
  bytecode attribute) never ran.

The bisection proof: excluding only `blastoisefurnace/**` from the main
source set's compile takes the error count from 100 to 0 with no other
changes — every other reported failure is a downstream cascade, not an
independent bug.

## Plugins / files touched

| Plugin | File | Fix |
| --- | --- | --- |
| BlastoiseFurnace | `BlastoiseFurnaceScript.java` | Drop the static import; inline a private `ITEM_NAME_SUFFIX_PATTERN` constant with the same regex `BankTabSorterScript` already uses (`^(.*?)(?:\s*\((\d+)\))?$`). |
| BlastoiseFurnace | `BlastoiseFurnacePlugin.java` | Bump version `1.2.1` -> `1.2.2`. |

No other plugins are modified — they all compile cleanly once the
cascade trigger is gone. Build verification: `./gradlew clean build`
locally on JDK 11 (Adoptium 11.0.30+7) finishes with `BUILD SUCCESSFUL`
in ~1m and produces 158 plugin jars.

## Test plan

- [x] `./gradlew clean build` succeeds locally on JDK 11 (Adoptium)
- [x] Zero javac errors in the build log
- [x] 158 plugin jars produced in `build/libs/`
- [x] Only one plugin (`BlastoiseFurnace`) has a version bump; no other
      plugin's version changed