### PR TITLE
feat(LeaguesToolkit): Demonic Gorilla, Hespori, Kraken helpers + Ourania runner

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/DemonicGorillaPrayerHelper.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/DemonicGorillaPrayerHelper.java
@@ -1,0 +1,178 @@
+package net.runelite.client.plugins.microbot.leaguestoolkit;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.OverheadTextChanged;
+import net.runelite.api.gameval.AnimationID;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
+
+import java.util.Set;
+
+/**
+ * Event-driven demonic gorilla prayer helper.
+ * Uses onAnimationChanged for instant prayer switching and
+ * onHitsplatApplied for hit counting to predict style switches.
+ */
+@Slf4j
+public class DemonicGorillaPrayerHelper {
+
+    private static final Set<Integer> ALL_GORILLA_IDS = Set.of(
+            NpcID.MM2_DEMON_GORILLA_1_MELEE, NpcID.MM2_DEMON_GORILLA_1_RANGED, NpcID.MM2_DEMON_GORILLA_1_MAGIC,
+            NpcID.MM2_DEMON_GORILLA_2_MELEE, NpcID.MM2_DEMON_GORILLA_2_RANGED, NpcID.MM2_DEMON_GORILLA_2_MAGIC
+    );
+
+    private static final int ANIM_MAGIC = AnimationID.DEMONIC_GORILLA_MAGIC;   // 7225
+    private static final int ANIM_MELEE = AnimationID.DEMONIC_GORILLA_PUNCH;   // 7226
+    private static final int ANIM_RANGED = AnimationID.DEMONIC_GORILLA_RANGE;  // 7227
+
+    @Getter
+    private String status = "Idle";
+    @Getter
+    private String currentStyle = "Unknown";
+    @Getter
+    private int blockedHitCount = 0;
+
+    private int lastPrayedStyle = -1;
+    private boolean active = false;
+
+    public void reset() {
+        status = "Idle";
+        currentStyle = "Unknown";
+        blockedHitCount = 0;
+        lastPrayedStyle = -1;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+        if (!active && lastPrayedStyle != -1) {
+            deactivateCurrentPrayer();
+            lastPrayedStyle = -1;
+            blockedHitCount = 0;
+            status = "Stopped";
+            currentStyle = "None";
+        }
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    /**
+     * Called from @Subscribe onAnimationChanged in the plugin.
+     * Fires INSTANTLY on the client thread when any actor's animation changes.
+     */
+    public void onAnimationChanged(AnimationChanged event) {
+        if (!active) return;
+
+        Actor actor = event.getActor();
+        if (!(actor instanceof NPC)) return;
+
+        NPC npc = (NPC) actor;
+        if (!ALL_GORILLA_IDS.contains(npc.getId())) return;
+
+        // Check if this gorilla is targeting us
+        Player player = Microbot.getClient().getLocalPlayer();
+        if (player == null || !player.equals(npc.getInteracting())) return;
+
+        int anim = npc.getAnimation();
+        int style = animToStyle(anim);
+        if (style == -1) return; // Not an attack animation
+
+        if (style != lastPrayedStyle) {
+            switchPrayer(style);
+            lastPrayedStyle = style;
+            blockedHitCount = 0; // Reset count on style switch
+        }
+    }
+
+    /**
+     * Called from @Subscribe onHitsplatApplied in the plugin.
+     * Tracks blocked hits (0 damage) to predict style switches.
+     */
+    public void onHitsplatApplied(HitsplatApplied event) {
+        if (!active) return;
+
+        // Only track hitsplats on the player
+        Actor actor = event.getActor();
+        Player player = Microbot.getClient().getLocalPlayer();
+        if (player == null || !actor.equals(player)) return;
+
+        // 0 damage = blocked by prayer
+        if (event.getHitsplat().getAmount() == 0) {
+            blockedHitCount++;
+            status = "Praying " + currentStyle + " (" + blockedHitCount + "/3 blocked)";
+            if (blockedHitCount >= 3) {
+                log.info("[DemonicGorilla] 3 blocked hits — expecting style switch!");
+                status = "Switch incoming!";
+            }
+        } else {
+            // Took damage — reset counter (prayer was wrong or boulder hit)
+            blockedHitCount = 0;
+        }
+    }
+
+    /**
+     * Called from @Subscribe onOverheadTextChanged in the plugin.
+     * Detects the "Rhaaaaaaa!" scream that confirms a style switch.
+     */
+    public void onOverheadTextChanged(OverheadTextChanged event) {
+        if (!active) return;
+
+        Actor actor = event.getActor();
+        if (!(actor instanceof NPC)) return;
+
+        NPC npc = (NPC) actor;
+        if (!ALL_GORILLA_IDS.contains(npc.getId())) return;
+
+        String text = event.getOverheadText();
+        if (text != null && text.contains("Rhaaaaaaa")) {
+            log.info("[DemonicGorilla] Style switch confirmed via overhead scream!");
+            blockedHitCount = 0;
+            status = "Style switched!";
+        }
+    }
+
+    private int animToStyle(int animation) {
+        if (animation == ANIM_MELEE) return 0;
+        if (animation == ANIM_RANGED) return 1;
+        if (animation == ANIM_MAGIC) return 2;
+        return -1;
+    }
+
+    private void deactivateCurrentPrayer() {
+        switch (lastPrayedStyle) {
+            case 0: Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MELEE, false); break;
+            case 1: Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_RANGE, false); break;
+            case 2: Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC, false); break;
+        }
+        log.info("[DemonicGorilla] Deactivated prayer");
+    }
+
+    private void switchPrayer(int style) {
+        switch (style) {
+            case 0:
+                currentStyle = "Melee";
+                log.info("[DemonicGorilla] → Protect from Melee (instant)");
+                Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MELEE, true);
+                break;
+            case 1:
+                currentStyle = "Ranged";
+                log.info("[DemonicGorilla] → Protect from Missiles (instant)");
+                Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_RANGE, true);
+                break;
+            case 2:
+                currentStyle = "Magic";
+                log.info("[DemonicGorilla] → Protect from Magic (instant)");
+                Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC, true);
+                break;
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/HesporiBossHelper.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/HesporiBossHelper.java
@@ -1,0 +1,454 @@
+package net.runelite.client.plugins.microbot.leaguestoolkit;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.HeadIcon;
+import net.runelite.api.NPC;
+import net.runelite.api.Perspective;
+import net.runelite.api.Projectile;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.AnimationID;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.api.gameval.SpotanimID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.api.MenuAction;
+import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
+import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
+import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+
+@Slf4j
+public class HesporiBossHelper {
+
+    // NPC IDs
+    private static final int HESPORI_NORMAL = NpcID.HESPORI;                    // 8583
+    private static final int HESPORI_ECHO = NpcID.LEAGUE_6_HESPORI;             // 15615
+    private static final int HEALER_ACTIVE = NpcID.HESPORI_HEALER_ACTIVE;       // 8584
+    private static final int HEALER_INACTIVE = NpcID.HESPORI_HEALER_INACTIVE;   // 8585
+
+    // Attack animations
+    private static final int ANIM_RANGED = AnimationID.HESPORI_ATTACK_RANGED;   // 8224
+    private static final int ANIM_SPECIAL = AnimationID.HESPORI_ATTACK_SPECIAL;  // 8223 (magic)
+
+    // Leagues 6 Hespori projectile IDs (discovered from in-game testing)
+    private static final int RANGE_PROJ = 3677;   // Ranged attack — pray against, don't dodge
+    private static final int MAGIC_PROJ = 3678;   // Magic attack — pray against, don't dodge
+    private static final int VINE_PROJ = 3680;     // Vine/quadrant explosion — DODGE THIS
+
+    @Getter
+    private String status = "Idle";
+    @Getter
+    private String currentPrayer = "None";
+    @Getter
+    private String phase = "Combat";
+
+    private int lastSeenAnimation = -1;
+    private int lastPrayedStyle = -1; // 0=missiles, 1=magic
+    @Getter @Setter
+    private volatile boolean vineDetected = false;
+    @Getter @Setter
+    private volatile int dodgeX = -1, dodgeY = -1;
+    private volatile long lastDodgeTime = 0;
+    private static final long DODGE_COOLDOWN_MS = 5000; // Don't dodge again for 5 seconds
+
+    private ScheduledExecutorService fastExecutor;
+    private ScheduledFuture<?> fastLoop;
+    private LeaguesToolkitConfig config;
+
+    public void start(LeaguesToolkitConfig config) {
+        this.config = config;
+        reset();
+        if (fastExecutor == null) {
+            fastExecutor = Executors.newSingleThreadScheduledExecutor();
+        }
+        fastLoop = fastExecutor.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) return;
+                tick();
+            } catch (Exception ex) {
+                log.error("[Hespori] Fast loop error", ex);
+            }
+        }, 0, 150, TimeUnit.MILLISECONDS);
+        log.info("[Hespori] Fast prayer loop started (150ms)");
+    }
+
+    public void stop() {
+        if (fastLoop != null) {
+            fastLoop.cancel(false);
+            fastLoop = null;
+        }
+        if (lastPrayedStyle != -1) {
+            Rs2Prayer.disableAllPrayers();
+            lastPrayedStyle = -1;
+        }
+        status = "Stopped";
+        currentPrayer = "None";
+    }
+
+    public void reset() {
+        status = "Idle";
+        currentPrayer = "None";
+        phase = "Combat";
+        lastSeenAnimation = -1;
+        lastPrayedStyle = -1;
+    }
+
+    public void tick() {
+        Rs2NpcModel hespori = findHespori();
+        if (hespori == null) {
+            status = "No Hespori found";
+            return;
+        }
+
+        // Eat if HP low
+        if (Rs2Player.getHealthPercentage() <= 50) {
+            Rs2Player.eatAt(50);
+        }
+
+        // Drink prayer if low
+        Rs2Player.drinkPrayerPotionAt(20);
+
+        phase = "Combat";
+
+        // === FAST LOOP ONLY: prayer switching + eat/drink ===
+        // ALL movement/clicking handled by tickCombat() on the main loop
+
+        // Read boss animation for prayer switching
+        int anim = Microbot.getClientThread().runOnClientThreadOptional(
+                () -> hespori.getNpc().getAnimation()
+        ).orElse(-1);
+
+        if (anim != -1 && anim != lastSeenAnimation) {
+            lastSeenAnimation = anim;
+            int style = animToStyle(anim);
+            if (style != -1 && style != lastPrayedStyle) {
+                switchPrayer(style);
+                lastPrayedStyle = style;
+            }
+        }
+
+        // Default: keep Protect from Magic on if no recent attack detected
+        if (lastPrayedStyle == -1) {
+            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC, true);
+            currentPrayer = "Magic (default)";
+        }
+
+        status = "Fighting Hespori (" + currentPrayer + ")";
+    }
+
+    /**
+     * Flower phase: boss is invulnerable, kill active flowers.
+     * Boss doesn't use magic during this phase — only ranged.
+     * Flowers show overhead prayers:
+     * - Protect from Melee (HeadIcon.MELEE) → use ranged/magic weapon
+     * - Protect from Ranged+Magic (HeadIcon.RANGE_MAGE) → use melee weapon
+     */
+    private void handleFlowerPhase() {
+        // Keep Protect from Missiles on during flower phase (boss only uses ranged here)
+        if (!Rs2Prayer.isPrayerActive(Rs2PrayerEnum.PROTECT_RANGE)) {
+            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_RANGE, true);
+            currentPrayer = "Missiles (flowers)";
+        }
+
+        // Kill ONE flower per tickCombat call — avoids blocking client thread with tight loop
+        Rs2NpcModel flower = findActiveFlower();
+        if (flower == null) return;
+
+        // Check overhead prayer for weapon switch
+        HeadIcon flowerPrayer = Microbot.getClientThread().runOnClientThreadOptional(
+                () -> flower.getHeadIcon()
+        ).orElse(null);
+
+        if (flowerPrayer != null && config != null) {
+            boolean needsMelee = (flowerPrayer == HeadIcon.RANGED || flowerPrayer == HeadIcon.MAGIC
+                    || flowerPrayer == HeadIcon.RANGE_MAGE);
+            if (needsMelee) {
+                String meleeWeapon = config.hesporiMeleeWeapon();
+                if (!Rs2Equipment.isWearing(meleeWeapon) && Rs2Inventory.hasItem(meleeWeapon)) {
+                    Rs2Inventory.wield(meleeWeapon);
+                    sleep(150, 300);
+                }
+            } else {
+                String mageWeapon = config.hesporiMageWeapon();
+                if (!Rs2Equipment.isWearing(mageWeapon) && Rs2Inventory.hasItem(mageWeapon)) {
+                    Rs2Inventory.wield(mageWeapon);
+                    sleep(150, 300);
+                }
+            }
+        }
+
+        status = "Killing flower";
+        Microbot.getRs2NpcCache().query()
+                .withId(flower.getId())
+                .interact(flower.getId(), "Attack");
+    }
+
+    // Vine dodge is handled by handleVineDodge() called from tickCombat
+
+    /**
+     * Called from tickCombat (main 1-second loop) — safe to click/walk here.
+     */
+    public boolean handleVineDodge() {
+        if (!vineDetected) return false;
+        vineDetected = false;
+        dodgeX = -1;
+        dodgeY = -1;
+
+        // Cooldown — don't dodge again within 5 seconds
+        if (System.currentTimeMillis() - lastDodgeTime < DODGE_COOLDOWN_MS) {
+            return false;
+        }
+
+        WorldPoint myPos = Rs2Player.getWorldLocation();
+        if (myPos == null) return false;
+
+        // Determine which quadrant we're in relative to boss center
+        // Boss LocalPoint is always (7104, 7104) — convert to world offset direction
+        // Just move 5 tiles in the opposite direction from boss center
+        LocalPoint myLocal = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            var player = Microbot.getClient().getLocalPlayer();
+            return player != null ? player.getLocalLocation() : null;
+        }).orElse(null);
+
+        if (myLocal == null) return false;
+
+        int bossLocalX = 7104, bossLocalY = 7104;
+        int dx = (myLocal.getX() > bossLocalX) ? -5 : 5;
+        int dy = (myLocal.getY() > bossLocalY) ? -5 : 5;
+
+        WorldPoint dodgeTarget = new WorldPoint(myPos.getX() + dx, myPos.getY() + dy, myPos.getPlane());
+
+        status = "Dodging vine!";
+        log.info("[Hespori] Vine dodge — Rs2Walker.walkFastCanvas to {}", dodgeTarget);
+        Rs2Walker.walkFastCanvas(dodgeTarget);
+        lastDodgeTime = System.currentTimeMillis();
+        sleep(600, 900);
+        return true;
+    }
+
+    private Rs2NpcModel findHespori() {
+        // Both normal and Echo Hespori use the same NPC ID (8583)
+        return findAliveNpc(HESPORI_NORMAL);
+    }
+
+    /**
+     * Find an active flower by ID first, falling back to name-based search for Echo variants.
+     */
+    private Rs2NpcModel findActiveFlower() {
+        // Try by known ID first
+        Rs2NpcModel byId = findAliveNpc(HEALER_ACTIVE);
+        if (byId != null) return byId;
+
+        // Fallback: search by name "Flower" for Echo variants that might use different IDs
+        return Microbot.getRs2NpcCache().query()
+                .where(npc -> {
+                    String name = npc.getName();
+                    return name != null && name.equalsIgnoreCase("Flower");
+                })
+                .where(npc -> !npc.isDead())
+                .where(npc -> {
+                    // Only active flowers (not inactive/cyan ones)
+                    HeadIcon icon = Microbot.getClientThread().runOnClientThreadOptional(
+                            () -> npc.getHeadIcon()
+                    ).orElse(null);
+                    return icon != null; // Active flowers have overhead prayers, inactive don't
+                })
+                .nearest();
+    }
+
+    private Rs2NpcModel findAliveNpc(int id) {
+        return Microbot.getRs2NpcCache().query()
+                .withId(id)
+                .where(npc -> !npc.isDead())
+                .nearest();
+    }
+
+    /**
+     * Called from the main 1-second toolkit loop to handle attacking.
+     * Separated from the fast prayer loop to avoid threading issues with doInvoke.
+     */
+    public void tickCombat() {
+        log.info("[Hespori] tickCombat called");
+        Rs2NpcModel hespori = findHespori();
+        if (hespori == null) {
+            log.info("[Hespori] tickCombat: findHespori returned null — NPC not found or dead");
+            return;
+        }
+        log.info("[Hespori] tickCombat: found NPC id={}, dead={}", hespori.getId(), hespori.isDead());
+
+        // Handle vine dodge FIRST — highest priority
+        if (handleVineDodge()) {
+            return;
+        }
+
+        // Handle flower phase attacking
+        Rs2NpcModel activeFlower = findActiveFlower();
+        if (activeFlower != null) {
+            handleFlowerPhase();
+            return;
+        }
+
+        // Ensure main weapon equipped
+        if (config != null) {
+            String mainWeapon = config.hesporiMainWeapon();
+            if (!Rs2Equipment.isWearing(mainWeapon) && Rs2Inventory.hasItem(mainWeapon)) {
+                Rs2Inventory.wield(mainWeapon);
+                sleep(150, 300);
+            }
+        }
+
+        // NOTE: No walk range check — player is already in the circular arena.
+        // Instance coordinate mismatch makes distance calculations unreliable.
+
+        // Only click attack if not already interacting with Hespori
+        boolean alreadyFighting = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            var player = Microbot.getClient().getLocalPlayer();
+            if (player == null) return false;
+            var target = player.getInteracting();
+            if (target == null) return false;
+            return target.equals(hespori.getNpc());
+        }).orElse(false);
+
+        if (!alreadyFighting) {
+            status = "Attacking Hespori";
+            // Dump full NPC state for debugging, then attack
+            Microbot.getClientThread().invoke(() -> {
+                try {
+                    NPC rawNpc = hespori.getNpc();
+                    if (rawNpc == null) {
+                        log.error("[Hespori] rawNpc is null");
+                        return;
+                    }
+
+                    // Dump all info
+                    log.info("[Hespori] === NPC DEBUG ===");
+                    log.info("[Hespori] NPC id={}, index={}, name={}", rawNpc.getId(), rawNpc.getIndex(), rawNpc.getName());
+                    log.info("[Hespori] worldLocation={}", rawNpc.getWorldLocation());
+                    log.info("[Hespori] localLocation={}", rawNpc.getLocalLocation());
+                    log.info("[Hespori] animation={}, isDead={}", rawNpc.getAnimation(), rawNpc.isDead());
+
+                    var comp = Microbot.getClient().getNpcDefinition(rawNpc.getId());
+                    if (comp != null) {
+                        log.info("[Hespori] Composition actions: {}", java.util.Arrays.toString(comp.getActions()));
+                    } else {
+                        log.error("[Hespori] NPCComposition is null for id={}", rawNpc.getId());
+                    }
+
+                    var canvasPoly = rawNpc.getCanvasTilePoly();
+                    log.info("[Hespori] canvasTilePoly={}", canvasPoly != null ? canvasPoly.getBounds() : "null");
+
+                    // Verify the action exists and find its index
+                    String[] actions = comp != null ? comp.getActions() : null;
+                    if (actions == null) {
+                        log.error("[Hespori] No actions on NPC");
+                        return;
+                    }
+
+                    // Find attack action — don't hardcode, check what's available
+                    String attackAction = null;
+                    int attackIndex = -1;
+                    for (int i = 0; i < actions.length; i++) {
+                        if (actions[i] != null && actions[i].toLowerCase().contains("attack")) {
+                            attackAction = actions[i];
+                            attackIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (attackAction == null) {
+                        log.error("[Hespori] No attack-like action found in: {}", java.util.Arrays.toString(actions));
+                        return;
+                    }
+
+                    log.info("[Hespori] Found action '{}' at index {}", attackAction, attackIndex);
+
+                    MenuAction menuAction = MenuAction.of(MenuAction.NPC_FIRST_OPTION.getId() + attackIndex);
+                    log.info("[Hespori] MenuAction opcode: {} (id={})", menuAction, menuAction.getId());
+
+                    Microbot.getClient().menuAction(
+                            0, 0, menuAction, rawNpc.getIndex(), -1,
+                            attackAction, rawNpc.getName() != null ? rawNpc.getName() : ""
+                    );
+                    log.info("[Hespori] menuAction dispatched successfully");
+                } catch (Exception e) {
+                    log.error("[Hespori] Attack error", e);
+                }
+            });
+            sleep(1200, 1500);
+        } else {
+            status = "Fighting Hespori (" + currentPrayer + ")";
+        }
+    }
+
+    private boolean isMeleeWeaponEquipped(LeaguesToolkitConfig config) {
+        if (config == null) return false;
+        String mainWeapon = config.hesporiMainWeapon();
+        String meleeWeapon = config.hesporiMeleeWeapon();
+        // If the main weapon is the same as the melee weapon, we're in melee mode
+        return Rs2Equipment.isWearing(mainWeapon) && mainWeapon.equalsIgnoreCase(meleeWeapon);
+    }
+
+    private int animToStyle(int animation) {
+        if (animation == ANIM_RANGED) return 0;   // Ranged → Protect from Missiles
+        if (animation == ANIM_SPECIAL) return 1;   // Magic → Protect from Magic
+        return -1;
+    }
+
+    private void switchPrayer(int style) {
+        switch (style) {
+            case 0:
+                currentPrayer = "Missiles";
+                log.info("[Hespori] → Protect from Missiles (ranged)");
+                Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_RANGE, true);
+                break;
+            case 1:
+                currentPrayer = "Magic";
+                log.info("[Hespori] → Protect from Magic");
+                Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC, true);
+                break;
+        }
+    }
+
+    private WorldPoint findSafeTile(WorldPoint center, int distance) {
+        Map<WorldPoint, Integer> dangerousTiles = Rs2Tile.getDangerousGraphicsObjectTiles();
+        List<WorldPoint> candidates = new ArrayList<>();
+
+        for (int dx = -distance; dx <= distance; dx++) {
+            for (int dy = -distance; dy <= distance; dy++) {
+                if (dx == 0 && dy == 0) continue;
+                WorldPoint candidate = new WorldPoint(
+                        center.getX() + dx, center.getY() + dy, center.getPlane());
+                if (!dangerousTiles.containsKey(candidate) && Rs2Tile.isWalkable(candidate)) {
+                    candidates.add(candidate);
+                }
+            }
+        }
+
+        if (candidates.isEmpty()) return null;
+
+        Rs2NpcModel boss = findHespori();
+        if (boss != null) {
+            WorldPoint bossLoc = boss.getWorldLocation();
+            candidates.sort(Comparator.comparingInt(c -> c.distanceTo(bossLoc)));
+        }
+
+        return candidates.get(0);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/KrakenBossHelper.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/KrakenBossHelper.java
@@ -1,0 +1,188 @@
+package net.runelite.client.plugins.microbot.leaguestoolkit;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+
+@Slf4j
+public class KrakenBossHelper {
+
+    // NPC IDs
+    private static final int BOSS_WHIRLPOOL = NpcID.SLAYER_KRAKEN_BOSS_WHIRLPOOL;       // 496
+    private static final int BOSS_AWAKE = NpcID.SLAYER_KRAKEN_BOSS;                       // 494
+    private static final int TENTACLE_WHIRLPOOL = NpcID.SLAYER_KRAKEN_BOSS_TENTACLE_WHIRLPOOL; // 5534
+    private static final int TENTACLE_AWAKE = NpcID.SLAYER_KRAKEN_BOSS_TENTACLE;          // 5535
+
+    @Getter
+    private String status = "Idle";
+    private boolean antibanInitialized = false;
+
+    public void reset() {
+        status = "Idle";
+        antibanInitialized = false;
+    }
+
+    public boolean tick(LeaguesToolkitConfig config) {
+        // Initialize antiban on first tick
+        if (!antibanInitialized) {
+            Rs2Antiban.resetAntibanSettings();
+            Rs2Antiban.antibanSetupTemplates.applyCombatSetup();
+            Rs2AntibanSettings.simulateMistakes = true;
+            Rs2AntibanSettings.takeMicroBreaks = true;
+            Rs2AntibanSettings.microBreakChance = 0.02;
+            Rs2AntibanSettings.actionCooldownChance = 0.15;
+            Rs2AntibanSettings.moveMouseOffScreen = true;
+            antibanInitialized = true;
+            log.info("[Kraken] Antiban initialized");
+        }
+
+        // Keep Protect from Magic on at all times
+        if (!Rs2Prayer.isPrayerActive(Rs2PrayerEnum.PROTECT_MAGIC)) {
+            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC, true);
+        }
+
+        // Eat food if HP low
+        if (Rs2Player.getHealthPercentage() <= config.krakenEatAt()) {
+            status = "Eating";
+            Rs2Player.eatAt(config.krakenEatAt());
+            sleep(300, 500);
+        }
+
+        // Drink prayer pot if low
+        if (config.krakenDrinkPrayer()) {
+            Rs2Player.drinkPrayerPotionAt(config.krakenPrayerThreshold());
+        }
+
+        // Wait if already in combat
+        if (Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
+            // Check what we're fighting
+            Rs2NpcModel awakeTentacle = findAliveNpc(TENTACLE_AWAKE);
+            Rs2NpcModel boss = findAliveNpc(BOSS_AWAKE);
+            if (awakeTentacle != null) {
+                status = "Killing tentacle";
+                return true;
+            }
+            if (boss != null) {
+                status = "Fighting Kraken";
+                return true;
+            }
+        }
+
+        // Step 1: Kill any awake tentacles first
+        Rs2NpcModel awakeTentacle = findAliveNpc(TENTACLE_AWAKE);
+        if (awakeTentacle != null) {
+            if (!Rs2Combat.inCombat()) {
+                status = "Attacking tentacle";
+                awakeTentacle.click("Attack");
+                sleep(600, 900);
+            } else {
+                status = "Killing tentacle";
+            }
+            return true;
+        }
+
+        // Step 2: Disturb next tentacle whirlpool
+        Rs2NpcModel tentaclePool = findNpc(TENTACLE_WHIRLPOOL);
+        if (tentaclePool != null) {
+            status = "Disturbing tentacle";
+            tentaclePool.click("Disturb");
+            sleep(600, 900);
+            return true;
+        }
+
+        // Step 3: All tentacles dead — disturb the boss whirlpool
+        Rs2NpcModel bossPool = findNpc(BOSS_WHIRLPOOL);
+        if (bossPool != null) {
+            status = "Disturbing Kraken boss";
+            bossPool.click("Disturb");
+            sleep(600, 900);
+            return true;
+        }
+
+        // Step 4: Boss is awake — attack it
+        Rs2NpcModel boss = findAliveNpc(BOSS_AWAKE);
+        if (boss != null) {
+            if (!Rs2Combat.inCombat()) {
+                status = "Attacking Kraken";
+                boss.click("Attack");
+                sleep(600, 900);
+            } else {
+                status = "Fighting Kraken";
+            }
+            return true;
+        }
+
+        // Step 4: Boss is dead — loot valuable drops before respawn
+        if (lootValuableDrops()) {
+            status = "Looting";
+            return true;
+        }
+
+        // Between kills — safe to do antiban here while waiting
+        if (findNpc(BOSS_WHIRLPOOL) == null && findNpc(BOSS_AWAKE) == null) {
+            status = "Waiting for respawn...";
+            Rs2Antiban.actionCooldown();
+            Rs2Antiban.takeMicroBreakByChance();
+            return true;
+        }
+
+        // Also safe to antiban before starting a new kill cycle
+        if (findNpc(BOSS_WHIRLPOOL) != null && findNpc(TENTACLE_WHIRLPOOL) != null
+                && findAliveNpc(TENTACLE_AWAKE) == null && findAliveNpc(BOSS_AWAKE) == null) {
+            Rs2Antiban.actionCooldown();
+            Rs2Antiban.takeMicroBreakByChance();
+        }
+
+        status = "Idle";
+        return true;
+    }
+
+    /**
+     * Loot high-value drops like Trident of the seas (full).
+     * Eats food to make space if inventory is full.
+     */
+    private boolean lootValuableDrops() {
+        // Check for valuable drops nearby
+        String[] valuableItems = {"Trident of the seas (full)", "Kraken tentacle", "Jar of dirt", "Pet kraken"};
+        for (String item : valuableItems) {
+            if (Rs2GroundItem.exists(item, 10)) {
+                if (Rs2Inventory.isFull()) {
+                    // Eat food to make space
+                    if (!Rs2Inventory.getInventoryFood().isEmpty()) {
+                        Rs2Player.eatAt(100);
+                        sleep(300, 500);
+                    }
+                }
+                Rs2GroundItem.loot(item, 10);
+                sleep(600, 900);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Rs2NpcModel findNpc(int id) {
+        return Microbot.getRs2NpcCache().query()
+                .withId(id)
+                .nearest();
+    }
+
+    private Rs2NpcModel findAliveNpc(int id) {
+        return Microbot.getRs2NpcCache().query()
+                .withId(id)
+                .where(npc -> !npc.isDead())
+                .nearest();
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/LeaguesToolkitConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/LeaguesToolkitConfig.java
@@ -8,31 +8,45 @@ import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
 
 @ConfigGroup("LeaguesToolkit")
-@ConfigInformation("<h2>Leagues Toolkit</h2>" +
+@ConfigInformation("<h2>Leagues Toolkit <em>(BETA)</em></h2>" +
         "<h3>Version: " + LeaguesToolkitPlugin.version + "</h3>" +
-        "<p><strong>Anti-AFK:</strong> Presses a random arrow key before the idle timer kicks in. " +
+        "<p><em>This plugin is in BETA. Not all features are fully polished — some boss helpers " +
+        "may have edge cases in instanced areas. Use Prayer/eat only mode for boss helpers " +
+        "if the full automation isn't working reliably.</em></p>" +
+        "<hr/>" +
+        "<p><strong>Anti-AFK:</strong> Presses a random arrow key before the idle timer logs you out. " +
         "Great for long AFK sessions with auto-bank relics (e.g. Endless Harvest).</p>" +
-        "<p><strong>Toci's Gem Store:</strong> Walks to Toci in Aldarin, buys uncut gems, " +
-        "and either sells cut gems back or banks them via the Banker's Briefcase. Three modes:</p>" +
+        "<p><strong>Demonic Gorilla Prayer:</strong> Event-driven prayer switching — reacts instantly " +
+        "to gorilla attack animations via onAnimationChanged (no polling delay). " +
+        "Tracks blocked hits (0 damage) to predict style switches (3 blocked = switch incoming). " +
+        "Detects the 'Rhaaaaaaa!' overhead scream to confirm switches.</p>" +
+        "<p><strong>Toci's Gem Store:</strong> Automated gem trading at Toci in Aldarin. Three modes:</p>" +
         "<ul>" +
-        "<li><em>Buy &amp; Bank</em> — fast stockpile: buy uncut gems, briefcase to bank, walk back, repeat.</li>" +
-        "<li><em>Buy, Cut &amp; Sell</em> — buy uncut, cut with chisel, sell cut gems back to Toci for profit.</li>" +
-        "<li><em>Buy, Cut &amp; Bank</em> — buy uncut, cut, bank via briefcase, walk back, repeat.</li>" +
+        "<li><em>Buy &amp; Bank</em> — fast stockpile uncut gems via Banker's Briefcase Last-destination.</li>" +
+        "<li><em>Buy, Cut &amp; Sell</em> — buy uncut, cut with chisel, sell cut back to Toci.</li>" +
+        "<li><em>Buy, Cut &amp; Bank</em> — buy uncut, cut, bank via briefcase.</li>" +
         "</ul>" +
-        "<p><strong>Wealthy Citizen Thieving:</strong> Pickpockets Wealthy citizens with auto coin pouch opening. " +
-        "Requires the <strong>Larcenist relic</strong> for 100% success rate (no stuns). " +
-        "Configure the pouch threshold (max 280 before they auto-destroy).</p>" +
-        "<p><strong>Easy Clue Opener:</strong> Farms reward caskets using the Aldarin bank easy clue method. " +
-        "Opens Scroll box (easy) — if the clue is a dig type, digs with spade repeatedly until a casket " +
-        "or a different clue appears. Non-dig clues are dropped and the next scroll box opens. " +
-        "Caskets stack in your inventory. Configurable action speed. Requires a spade and scroll boxes.</p>" +
-        "<p><strong>Snape Grass Telegrab:</strong> Walks to the snape grass spawn and casts Telekinetic Grab " +
-        "on repeat. Requires 33 Magic, law runes, and air runes (or air staff equipped). " +
-        "Stops when inventory is full.</p>" +
-        "<p><strong>Transmutation:</strong> Casts Alchemic Divergence or Convergence on noted items " +
-        "to upgrade/downgrade through tiers (e.g. Iron ore all the way to Runite ore). " +
-        "Have the starting items noted in your inventory before enabling. " +
-        "Requires the Transmutation relic and the transmutation ledger.</p>")
+        "<p><strong>Wealthy Citizen Thieving:</strong> Pickpockets Wealthy citizens (Larcenist relic required " +
+        "for 100% success). Opens coin pouches at configurable threshold (max 280).</p>" +
+        "<p><strong>Easy Clue Opener:</strong> Aldarin bank easy clue farming. Opens scroll boxes, " +
+        "digs if clue ID is 29853, drops non-dig clues, stacks caskets. Configurable delays.</p>" +
+        "<p><strong>Hespori (Echo):</strong> Prayer switches between Magic and Missiles based on attack animation. " +
+        "Kills flowers with correct combat style based on their overhead prayer (weapon switching). " +
+        "Vine dodge moves to opposite quadrant when projectile 3680 is detected. " +
+        "Prayer/eat only mode available for manual combat with automated prayer.</p>" +
+        "<p><strong>Kraken Boss:</strong> Full automation — disturbs tentacles one by one (Disturb → Attack → kill), " +
+        "then wakes and kills the boss. Loots Trident of the seas, Kraken tentacle, Jar of dirt, Pet kraken. " +
+        "Keeps Protect from Magic on. Start inside the boss room with a slayer task.</p>" +
+        "<p><strong>Snape Grass Telegrab:</strong> Walks to spawn, casts Telekinetic Grab on repeat. " +
+        "Banks via briefcase Last-destination or walks to nearest bank when full. " +
+        "Requires 33 Magic, law runes, air runes or air staff.</p>" +
+        "<p><strong>Ourania Altar:</strong> Crafts runes at ZMI, banks via briefcase to Eniola. " +
+        "Deposits only crafted runes (keeps air runes + noted pure essence). " +
+        "Works with Transmutation running concurrently. Eniola requires auto-pay runes.</p>" +
+        "<p><strong>Transmutation:</strong> Casts Alchemic Divergence/Convergence on noted items " +
+        "to upgrade/downgrade through tiers. Dropdown selection for start and target items. " +
+        "Shop-aware timeout (pauses detection when shop is open). " +
+        "Have starting items noted in inventory before enabling.</p>")
 public interface LeaguesToolkitConfig extends Config {
 
     @ConfigSection(
@@ -89,9 +103,30 @@ public interface LeaguesToolkitConfig extends Config {
     }
 
     @ConfigSection(
+            name = "Demonic Gorilla Prayer",
+            description = "Auto-switches protection prayers based on the gorilla's current attack style",
+            position = 1,
+            closedByDefault = true
+    )
+    String gorillaPrayerSection = "gorillaPrayerSection";
+
+    @ConfigItem(
+            keyName = "enableGorillaPrayer",
+            name = "Enable",
+            description = "Automatically switches between Protect from Melee, Missiles, and Magic " +
+                    "based on which demonic gorilla variant is attacking you. " +
+                    "Detects style changes by NPC ID transformation.",
+            position = 0,
+            section = gorillaPrayerSection
+    )
+    default boolean enableGorillaPrayer() {
+        return false;
+    }
+
+    @ConfigSection(
             name = "Toci's Gem Store",
             description = "Automated gem buying, cutting, and selling/banking at Toci in Aldarin",
-            position = 1,
+            position = 2,
             closedByDefault = true
     )
     String gemCutterSection = "gemCutterSection";
@@ -146,7 +181,7 @@ public interface LeaguesToolkitConfig extends Config {
     @ConfigSection(
             name = "Wealthy Citizen Thieving",
             description = "Pickpockets Wealthy citizens, opens coin pouches at a threshold",
-            position = 2,
+            position = 3,
             closedByDefault = true
     )
     String thievingSection = "thievingSection";
@@ -178,7 +213,7 @@ public interface LeaguesToolkitConfig extends Config {
     @ConfigSection(
             name = "Snape Grass Telegrab",
             description = "Telegrab snape grass at a fixed location",
-            position = 2,
+            position = 4,
             closedByDefault = true
     )
     String snapeGrassSection = "snapeGrassSection";
@@ -198,7 +233,7 @@ public interface LeaguesToolkitConfig extends Config {
     @ConfigSection(
             name = "Easy Clue Opener",
             description = "Opens scroll boxes, digs dig-clues, drops non-dig clues, opens reward caskets",
-            position = 4,
+            position = 5,
             closedByDefault = true
     )
     String easyClueSection = "easyClueSection";
@@ -255,9 +290,177 @@ public interface LeaguesToolkitConfig extends Config {
     }
 
     @ConfigSection(
+            name = "Hespori (Echo)",
+            description = "Prayer switching and fight management for Hespori Echo boss",
+            position = 6,
+            closedByDefault = true
+    )
+    String hesporiSection = "hesporiSection";
+
+    @ConfigItem(
+            keyName = "enableHespori",
+            name = "Enable",
+            description = "Manages the Hespori Echo fight. Auto-switches between Protect from Magic and Missiles " +
+                    "based on attack animation, kills flowers with correct combat style based on their overhead prayer, " +
+                    "dodges vine attacks. Uses a fast 150ms loop. " +
+                    "Bring both a melee weapon and a ranged/magic weapon for flower phases.",
+            position = 0,
+            section = hesporiSection
+    )
+    default boolean enableHespori() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "hesporiPrayerOnly",
+            name = "Prayer/eat only",
+            description = "Only handle prayer switching, eating, and dodging. " +
+                    "You control attacking and flower killing manually.",
+            position = 1,
+            section = hesporiSection
+    )
+    default boolean hesporiPrayerOnly() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "hesporiMainWeapon",
+            name = "Main weapon (boss)",
+            description = "Weapon to fight the boss with. Echo Hespori is weak to slash (e.g. Abyssal tentacle)",
+            position = 1,
+            section = hesporiSection
+    )
+    default String hesporiMainWeapon() {
+        return "Abyssal tentacle";
+    }
+
+    @ConfigItem(
+            keyName = "hesporiMeleeWeapon",
+            name = "Melee weapon (flowers)",
+            description = "Weapon for flowers praying ranged+magic. Can be same as main weapon if main is melee.",
+            position = 2,
+            section = hesporiSection
+    )
+    default String hesporiMeleeWeapon() {
+        return "Abyssal tentacle";
+    }
+
+    @ConfigItem(
+            keyName = "hesporiMageWeapon",
+            name = "Magic/Ranged weapon (flowers)",
+            description = "Weapon for flowers praying melee (e.g. Trident of the seas, Magic shortbow)",
+            position = 3,
+            section = hesporiSection
+    )
+    default String hesporiMageWeapon() {
+        return "Trident of the seas";
+    }
+
+    @ConfigSection(
+            name = "Kraken Boss",
+            description = "Automates the Kraken boss fight — disturb tentacles, wake boss, attack, repeat",
+            position = 7,
+            closedByDefault = true
+    )
+    String krakenSection = "krakenSection";
+
+    @ConfigItem(
+            keyName = "enableKraken",
+            name = "Enable",
+            description = "Automates the Kraken boss fight. Keeps Protect from Magic on, disturbs " +
+                    "all 4 tentacle whirlpools, wakes the boss, attacks until dead, repeats. " +
+                    "Requires a Kraken slayer task and magic combat. Start inside the boss room.",
+            position = 0,
+            section = krakenSection
+    )
+    default boolean enableKraken() {
+        return false;
+    }
+
+    @Range(min = 10, max = 90)
+    @ConfigItem(
+            keyName = "krakenEatAt",
+            name = "Eat at HP %",
+            description = "Eat food when HP drops below this percentage",
+            position = 1,
+            section = krakenSection
+    )
+    default int krakenEatAt() {
+        return 50;
+    }
+
+    @ConfigItem(
+            keyName = "krakenDrinkPrayer",
+            name = "Drink prayer pots",
+            description = "Automatically drink prayer potions",
+            position = 2,
+            section = krakenSection
+    )
+    default boolean krakenDrinkPrayer() {
+        return true;
+    }
+
+    @Range(min = 1, max = 99)
+    @ConfigItem(
+            keyName = "krakenPrayerThreshold",
+            name = "Drink prayer at",
+            description = "Drink prayer potion when points drop below this",
+            position = 3,
+            section = krakenSection
+    )
+    default int krakenPrayerThreshold() {
+        return 20;
+    }
+
+    @ConfigSection(
+            name = "Ourania Altar",
+            description = "Craft runes at the Ourania (ZMI) Altar with briefcase banking and transmutation",
+            position = 8,
+            closedByDefault = true
+    )
+    String ouraniaSection = "ouraniaSection";
+
+    @ConfigItem(
+            keyName = "enableOurania",
+            name = "Enable",
+            description = "Crafts runes at Ourania Altar. Banks via briefcase Last-destination to Eniola. " +
+                    "Transmutation runs concurrently to convert air runes to noted pure essence. " +
+                    "Keep air runes, briefcase (equipped), and transmutation ledger in inventory. " +
+                    "Eniola requires runes for banking (auto-pay).",
+            position = 0,
+            section = ouraniaSection
+    )
+    default boolean enableOurania() {
+        return false;
+    }
+
+    @Range(min = 1, max = 100)
+    @ConfigItem(
+            keyName = "ouraniaEatAtPercent",
+            name = "Eat at HP %",
+            description = "Eat food from bank when HP drops below this percentage",
+            position = 1,
+            section = ouraniaSection
+    )
+    default int ouraniaEatAtPercent() {
+        return 50;
+    }
+
+    @ConfigItem(
+            keyName = "ouraniaFoodName",
+            name = "Food name",
+            description = "Name of food to withdraw and eat at bank (e.g. Salmon, Lobster)",
+            position = 2,
+            section = ouraniaSection
+    )
+    default String ouraniaFoodName() {
+        return "Salmon";
+    }
+
+    @ConfigSection(
             name = "Transmutation",
             description = "Casts Alchemic Divergence/Convergence to upgrade or downgrade noted items through tiers",
-            position = 5,
+            position = 9,
             closedByDefault = true
     )
     String transmuteSection = "transmuteSection";

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/LeaguesToolkitPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/LeaguesToolkitPlugin.java
@@ -2,7 +2,12 @@ package net.runelite.client.plugins.microbot.leaguestoolkit;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.OverheadTextChanged;
+import net.runelite.api.events.ProjectileMoved;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.PluginConstants;
@@ -20,7 +25,7 @@ import javax.inject.Inject;
 )
 @Slf4j
 public class LeaguesToolkitPlugin extends Plugin {
-    public static final String version = "1.2.0";
+    public static final String version = "1.3.0";
 
     @Inject
     private LeaguesToolkitConfig config;
@@ -41,5 +46,61 @@ public class LeaguesToolkitPlugin extends Plugin {
     @Override
     protected void shutDown() {
         leaguesToolkitScript.shutdown();
+    }
+
+    @Subscribe
+    public void onAnimationChanged(AnimationChanged event) {
+        if (config.enableGorillaPrayer()) {
+            leaguesToolkitScript.getGorillaPrayerHelper().onAnimationChanged(event);
+        }
+    }
+
+    @Subscribe
+    public void onHitsplatApplied(HitsplatApplied event) {
+        if (config.enableGorillaPrayer()) {
+            leaguesToolkitScript.getGorillaPrayerHelper().onHitsplatApplied(event);
+        }
+    }
+
+    @Subscribe
+    public void onOverheadTextChanged(OverheadTextChanged event) {
+        if (config.enableGorillaPrayer()) {
+            leaguesToolkitScript.getGorillaPrayerHelper().onOverheadTextChanged(event);
+        }
+    }
+
+    @Subscribe
+    public void onProjectileMoved(ProjectileMoved event) {
+        if (!config.enableHespori() || config.hesporiPrayerOnly()) return;
+        int id = event.getProjectile().getId();
+        // Vine/quadrant explosion projectile — calculate dodge position on client thread
+        if (id == 3680) {
+            var helper = leaguesToolkitScript.getHesporiBossHelper();
+            if (!helper.isVineDetected()) {
+                log.info("[LeaguesToolkit] Vine 3680 — calculating dodge position");
+                // Calculate dodge canvas position (we're on client thread, safe to access)
+                var player = net.runelite.client.plugins.microbot.Microbot.getClient().getLocalPlayer();
+                if (player != null) {
+                    var myLocal = player.getLocalLocation();
+                    // Boss is always at center of arena: LocalPoint(7104, 7104)
+                    // Determine which quadrant player is in relative to boss
+                    // and move to the OPPOSITE quadrant
+                    int bossX = 7104, bossY = 7104;
+                    int dx = (myLocal.getX() > bossX) ? -768 : 768;  // If east of boss → go west
+                    int dy = (myLocal.getY() > bossY) ? -768 : 768;  // If north of boss → go south
+                    var dodgeLocal = new net.runelite.api.coords.LocalPoint(
+                            myLocal.getX() + dx, myLocal.getY() + dy, myLocal.getWorldView());
+                    var poly = net.runelite.api.Perspective.getCanvasTilePoly(
+                            net.runelite.client.plugins.microbot.Microbot.getClient(), dodgeLocal);
+                    if (poly != null) {
+                        var bounds = poly.getBounds();
+                        helper.setDodgeX((int) bounds.getCenterX());
+                        helper.setDodgeY((int) bounds.getCenterY());
+                        helper.setVineDetected(true); // Set AFTER coordinates are stored
+                        log.info("[LeaguesToolkit] Dodge position: ({}, {})", bounds.getCenterX(), bounds.getCenterY());
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/LeaguesToolkitScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/LeaguesToolkitScript.java
@@ -20,6 +20,8 @@ public class LeaguesToolkitScript extends Script {
     };
 
     @Getter
+    private final DemonicGorillaPrayerHelper gorillaPrayerHelper = new DemonicGorillaPrayerHelper();
+    @Getter
     private final GemCutter gemCutter = new GemCutter();
     @Getter
     private final Transmuter transmuter = new Transmuter();
@@ -28,11 +30,21 @@ public class LeaguesToolkitScript extends Script {
     @Getter
     private final EasyClueOpener easyClueOpener = new EasyClueOpener();
     @Getter
+    private final HesporiBossHelper hesporiBossHelper = new HesporiBossHelper();
+    @Getter
+    private final KrakenBossHelper krakenBossHelper = new KrakenBossHelper();
+    @Getter
+    private final OuraniaRunner ouraniaRunner = new OuraniaRunner();
+    @Getter
     private final SnapeGrassTelegrabber snapeGrassTelegrabber = new SnapeGrassTelegrabber();
 
+    private boolean gorillaPrayerWasEnabled = false;
     private boolean gemCutterWasEnabled = false;
     private boolean thievingWasEnabled = false;
     private boolean easyClueWasEnabled = false;
+    private boolean hesporiWasEnabled = false;
+    private boolean krakenWasEnabled = false;
+    private boolean ouraniaWasEnabled = false;
     private boolean snapeGrassWasEnabled = false;
     private boolean transmuteWasEnabled = false;
 
@@ -44,6 +56,20 @@ public class LeaguesToolkitScript extends Script {
 
                 if (config.enableAntiAfk()) {
                     runAntiAfk(config);
+                }
+
+                if (config.enableGorillaPrayer()) {
+                    if (!gorillaPrayerWasEnabled) {
+                        gorillaPrayerHelper.reset();
+                        gorillaPrayerHelper.setActive(true);
+                        gorillaPrayerWasEnabled = true;
+                    }
+                    // Fully event-driven — no tick/poll needed
+                } else {
+                    if (gorillaPrayerWasEnabled) {
+                        gorillaPrayerHelper.setActive(false);
+                    }
+                    gorillaPrayerWasEnabled = false;
                 }
 
                 if (config.enableGemCutter()) {
@@ -75,6 +101,42 @@ public class LeaguesToolkitScript extends Script {
                     easyClueOpener.tick(config);
                 } else {
                     easyClueWasEnabled = false;
+                }
+
+                if (config.enableHespori()) {
+                    if (!hesporiWasEnabled) {
+                        hesporiBossHelper.start(config);
+                        hesporiWasEnabled = true;
+                    }
+                    // Combat runs from the main loop (safe thread for doInvoke)
+                    if (!config.hesporiPrayerOnly()) {
+                        hesporiBossHelper.tickCombat();
+                    }
+                } else {
+                    if (hesporiWasEnabled) {
+                        hesporiBossHelper.stop();
+                    }
+                    hesporiWasEnabled = false;
+                }
+
+                if (config.enableKraken()) {
+                    if (!krakenWasEnabled) {
+                        krakenBossHelper.reset();
+                        krakenWasEnabled = true;
+                    }
+                    krakenBossHelper.tick(config);
+                } else {
+                    krakenWasEnabled = false;
+                }
+
+                if (config.enableOurania()) {
+                    if (!ouraniaWasEnabled) {
+                        ouraniaRunner.reset();
+                        ouraniaWasEnabled = true;
+                    }
+                    ouraniaRunner.tick(config);
+                } else {
+                    ouraniaWasEnabled = false;
                 }
 
                 if (config.enableSnapeGrass()) {
@@ -130,6 +192,8 @@ public class LeaguesToolkitScript extends Script {
     @Override
     public void shutdown() {
         super.shutdown();
+        gorillaPrayerHelper.setActive(false);
+        hesporiBossHelper.stop();
         transmuter.reset();
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/OuraniaRunner.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/leaguestoolkit/OuraniaRunner.java
@@ -1,0 +1,253 @@
+package net.runelite.client.plugins.microbot.leaguestoolkit;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.api.gameval.ObjectID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+@Slf4j
+public class OuraniaRunner {
+
+    private static final WorldArea ALTAR_AREA = new WorldArea(new WorldPoint(3054, 5574, 0), 12, 12);
+    private static final WorldPoint ENIOLA_AREA = new WorldPoint(3014, 5625, 0);
+    private static final String BRIEFCASE_NAME = "Banker's briefcase";
+    private static final int PURE_ESSENCE_ID = 7936; // Pure essence (BLANKRUNE_HIGH in gameval)
+    private static final String PURE_ESSENCE_NAME = "Pure essence";
+
+    private enum State {
+        CRAFTING,
+        TELEPORTING_TO_BANK,
+        BANKING,
+        WALKING_TO_ALTAR
+    }
+
+    @Getter
+    private String status = "Idle";
+    private State state = State.CRAFTING;
+    private int bankFailCount = 0;
+    private static final int MAX_BANK_FAILS = 3;
+
+    public void reset() {
+        status = "Idle";
+        state = State.CRAFTING;
+        bankFailCount = 0;
+    }
+
+    public boolean tick(LeaguesToolkitConfig config) {
+        switch (state) {
+            case CRAFTING:
+                return handleCrafting();
+            case TELEPORTING_TO_BANK:
+                return handleTeleportToBank();
+            case BANKING:
+                return handleBanking(config);
+            case WALKING_TO_ALTAR:
+                return handleWalkingToAltar(config);
+        }
+        return true;
+    }
+
+    private boolean handleCrafting() {
+        // Check if we have pure essence to craft
+        if (!Rs2Inventory.hasItem(PURE_ESSENCE_ID)) {
+            if (isNearAltar()) {
+                status = "No essence — heading to bank";
+                state = State.TELEPORTING_TO_BANK;
+                return true;
+            } else if (isNearEniola()) {
+                status = "At bank, no essence";
+                state = State.BANKING;
+                return true;
+            } else {
+                status = "No essence — teleporting to bank";
+                state = State.TELEPORTING_TO_BANK;
+                return true;
+            }
+        }
+
+        if (!isNearAltar()) {
+            status = "Walking to altar";
+            state = State.WALKING_TO_ALTAR;
+            return true;
+        }
+
+        if (Rs2Player.isAnimating()) {
+            status = "Crafting...";
+            return true;
+        }
+
+        status = "Crafting runes at altar";
+        Microbot.getRs2TileObjectCache().query()
+                .withId(ObjectID.RC_ZMI_DUNGEON_CRACKED_CENTER_ALTAR)
+                .interact("craft-rune");
+        Rs2Inventory.waitForInventoryChanges(5000);
+        return true;
+    }
+
+    private boolean handleTeleportToBank() {
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) {
+            status = "In transit...";
+            return true;
+        }
+
+        if (isNearEniola()) {
+            status = "At Eniola";
+            state = State.BANKING;
+            return true;
+        }
+
+        // Use briefcase to teleport to bank
+        if (Rs2Equipment.isWearing(BRIEFCASE_NAME)) {
+            status = "Briefcase Last-destination to Eniola";
+            Rs2Equipment.interact(BRIEFCASE_NAME, "Last-destination");
+            sleep(2000, 3000);
+            sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isMoving(), 10000);
+            sleep(500, 1000);
+            if (isNearEniola()) {
+                state = State.BANKING;
+            }
+        } else {
+            // No briefcase — walk to Eniola
+            status = "No briefcase — walking to Eniola";
+            log.warn("[Ourania] Briefcase not equipped, falling back to walk");
+            Rs2Walker.walkTo(ENIOLA_AREA, 4);
+            sleepUntil(() -> isNearEniola() || !Rs2Player.isMoving(), 30000);
+            if (isNearEniola()) {
+                state = State.BANKING;
+            }
+        }
+        return true;
+    }
+
+    private boolean handleBanking(LeaguesToolkitConfig config) {
+        if (!Rs2Bank.isOpen()) {
+            Rs2NpcModel eniola = Microbot.getRs2NpcCache().query()
+                    .withId(NpcID.RC_ZMI_BANKER).nearest();
+            if (eniola == null) {
+                status = "Can't find Eniola — walking closer";
+                Rs2Walker.walkTo(ENIOLA_AREA, 4);
+                sleepUntil(() -> !Rs2Player.isMoving(), 5000);
+                return true;
+            }
+            status = "Opening bank at Eniola";
+            eniola.click("bank");
+            sleepUntil(Rs2Bank::isOpen, 5000);
+
+            // Auto-pay exhaustion detection — if bank didn't open after clicking, runes may be depleted
+            if (!Rs2Bank.isOpen()) {
+                bankFailCount++;
+                log.warn("[Ourania] Bank failed to open (attempt {}/{})", bankFailCount, MAX_BANK_FAILS);
+                if (bankFailCount >= MAX_BANK_FAILS) {
+                    status = "Eniola refused banking — auto-pay runes depleted?";
+                    log.error("[Ourania] Stopping: Eniola refused banking {} times — check auto-pay runes", MAX_BANK_FAILS);
+                    return false;
+                }
+                sleep(1000, 2000);
+                return true;
+            }
+            bankFailCount = 0;
+            return true;
+        }
+
+        // Deposit crafted runes only — keep air runes, noted pure essence, ledger, etc.
+        status = "Depositing crafted runes";
+        // Collect IDs to deposit first, then deposit (avoid modifying stream mid-iteration)
+        java.util.List<Integer> toDeposit = Rs2Inventory.items()
+                .filter(item -> item.getName().toLowerCase().contains("rune")
+                        && !item.getName().toLowerCase().contains("air rune")
+                        && !item.getName().toLowerCase().contains("pure essence"))
+                .map(item -> item.getId())
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
+
+        for (int id : toDeposit) {
+            Rs2Bank.depositAll(id);
+            Rs2Inventory.waitForInventoryChanges(1800);
+        }
+
+        // Eat food if HP low
+        if (Rs2Player.getHealthPercentage() <= config.ouraniaEatAtPercent()) {
+            status = "Eating food at bank";
+            int maxEats = 10;
+            while (--maxEats > 0 && Rs2Player.getHealthPercentage() < 100 && Rs2Bank.hasItem(config.ouraniaFoodName())) {
+                Rs2Bank.withdrawOne(config.ouraniaFoodName());
+                Rs2Inventory.waitForInventoryChanges(1800);
+                Rs2Player.useFood();
+                Rs2Inventory.waitForInventoryChanges(1800);
+            }
+        }
+
+        // If no pure essence in bank, deposit our noted stack so it becomes available unnoted
+        if (!Rs2Bank.hasBankItem(PURE_ESSENCE_NAME)) {
+            if (Rs2Inventory.hasItem(PURE_ESSENCE_NAME)) {
+                status = "Depositing noted pure essence to unnote";
+                Rs2Bank.depositAll(PURE_ESSENCE_ID);
+                Rs2Inventory.waitForInventoryChanges(1800);
+            } else {
+                status = "No pure essence anywhere — waiting for transmutation";
+                Rs2Bank.closeBank();
+                sleep(3000, 5000);
+                return true;
+            }
+        }
+
+        status = "Withdrawing pure essence";
+        Rs2Bank.withdrawAll(PURE_ESSENCE_ID);
+        Rs2Inventory.waitForInventoryChanges(1800);
+        Rs2Bank.closeBank();
+        sleepUntil(() -> !Rs2Bank.isOpen(), 3000);
+
+        state = State.WALKING_TO_ALTAR;
+        return true;
+    }
+
+    private boolean handleWalkingToAltar(LeaguesToolkitConfig config) {
+        if (isNearAltar()) {
+            state = State.CRAFTING;
+            return true;
+        }
+
+        if (Rs2Player.isMoving()) {
+            status = "Walking to altar...";
+            // Eat while walking if HP low
+            if (Rs2Player.getHealthPercentage() <= config.ouraniaEatAtPercent()) {
+                if (Rs2Inventory.hasItem(config.ouraniaFoodName())) {
+                    Rs2Player.useFood();
+                }
+            }
+            return true;
+        }
+
+        status = "Walking to altar";
+        // Walk via the short path through the cave
+        Rs2Walker.walkTo(new WorldPoint(3060, 5580, 0), 6);
+        sleep(2000, 3000);
+        return true;
+    }
+
+    private boolean isNearAltar() {
+        WorldPoint loc = Rs2Player.getWorldLocation();
+        return loc != null && ALTAR_AREA.contains(loc);
+    }
+
+    private boolean isNearEniola() {
+        Rs2NpcModel eniola = Microbot.getRs2NpcCache().query()
+                .withId(NpcID.RC_ZMI_BANKER).nearest();
+        if (eniola == null) return false;
+        WorldPoint loc = Rs2Player.getWorldLocation();
+        return loc != null && loc.distanceTo2D(eniola.getWorldLocation()) < 12;
+    }
+}


### PR DESCRIPTION
## Summary
Adds four new helpers to the existing Leagues Toolkit plugin:

- **Demonic Gorilla prayer helper** — fully event-driven (no polling). Switches Protect prayers instantly on `onAnimationChanged`, tracks blocked hits via `onHitsplatApplied`, and confirms style switches on the `Rhaaaaaaa!` overhead text.
- **Hespori (Echo) boss helper** — prayer-only mode on a fast 150ms loop (ranged→missiles, magic→pray magic). Optional combat mode adds flower-phase weapon switching and projectile-driven vine dodge (ID 3680) that walks to the opposite quadrant of the boss center.
- **Kraken boss helper** — full fight automation: disturb whirlpool tentacles (5534), kill (5535), repeat for all 4, then disturb boss (496) and kill (494). Loots Trident, tentacle, Jar of dirt, and Pet kraken. Protect from Magic always on.
- **Ourania (ZMI) runner** — bank → walk → craft loop. Uses Banker's briefcase teleport for return trips. Pure essence only (ID 7936). Bails after 3 consecutive bank failures.

Each helper is gated by its own config toggle and integrates with the existing `LeaguesToolkitScript` enable/disable lifecycle.

Plugin version bumped 1.2.0 → 1.3.0.

## Test plan
- [ ] Enable Demonic Gorilla helper, fight a gorilla, confirm instant prayer switches and that the `X/3 blocked` counter updates
- [ ] Enable Hespori prayer-only, take a few hits without combat mode and confirm prayers swap on animation
- [ ] Enable Hespori full combat, verify boss attack, flower kills (weapon switch by head icon), and that vine projectile triggers a dodge
- [ ] Enable Kraken helper, run a full Kraken kill with 4 tentacles → boss → loot
- [ ] Enable Ourania runner with pure essence + briefcase equipped, confirm bank → altar → craft → teleport loop