### PR TITLE
feat(FarmTreeRun): compost type selection, leprechaun support, and bug fixes

### DIFF
--- a/docs/superpowers/plans/2026-05-17-tree-runner-compost-types.md
+++ b/docs/superpowers/plans/2026-05-17-tree-runner-compost-types.md
@@ -1,0 +1,319 @@
+# Farm Tree Runner: Compost Type Selection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the boolean compost toggle with a dropdown supporting Compost, Supercompost, Ultracompost, and Bottomless Compost Bucket, with automatic quantity calculation and empty-bucket cleanup.
+
+**Architecture:** New `CompostType` enum holds item IDs and a reusable flag. Config swaps the boolean for a dropdown. Script banking calculates withdrawal quantity based on unprotected patch count. `handlePlantingTree()` drops empty buckets after consumable compost use.
+
+**Tech Stack:** Java 11, RuneLite plugin API, Lombok
+
+---
+
+### Task 1: Create `CompostType` enum
+
+**Files:**
+- Create: `src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/CompostType.java`
+
+- [ ] **Step 1: Create the enum file**
+
+```java
+package net.runelite.client.plugins.microbot.farmtreerun.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.gameval.ItemID;
+
+@Getter
+@RequiredArgsConstructor
+public enum CompostType {
+    NONE("None", -1, false),
+    COMPOST("Compost", ItemID.COMPOST, false),
+    SUPERCOMPOST("Supercompost", ItemID.SUPERCOMPOST, false),
+    ULTRACOMPOST("Ultracompost", ItemID.ULTRACOMPOST, false),
+    BOTTOMLESS_BUCKET("Bottomless bucket", ItemID.BOTTOMLESS_COMPOST_BUCKET_22997, true);
+
+    private final String name;
+    private final int itemId;
+    private final boolean reusable;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `cd /home/alex/Developer/MB/Microbot-Hub/.worktrees/tree-runner-compost && ./gradlew build -PpluginList=FarmTreeRunPlugin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/CompostType.java
+git commit -m "feat(FarmTreeRun): add CompostType enum for compost selection"
+```
+
+---
+
+### Task 2: Update config to use `CompostType` dropdown
+
+**Files:**
+- Modify: `src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunConfig.java`
+
+- [ ] **Step 1: Add import for `CompostType`**
+
+Add to the import block:
+
+```java
+import net.runelite.client.plugins.microbot.farmtreerun.enums.CompostType;
+```
+
+- [ ] **Step 2: Replace the `useCompost()` boolean config with `compostType()` dropdown**
+
+Replace this block (lines 163-171):
+
+```java
+    @ConfigItem(
+            keyName = "useCompost",
+            name = "Use compost",
+            description = "Only bottomless compost bucket is supported",
+            position = 1,
+            section = gearSection
+    )
+    default boolean useCompost() { return true; }
+```
+
+With:
+
+```java
+    @ConfigItem(
+            keyName = "compostType",
+            name = "Compost type",
+            description = "Select compost type. Only applied at patches without protection enabled.",
+            position = 1,
+            section = gearSection
+    )
+    default CompostType compostType() { return CompostType.NONE; }
+```
+
+- [ ] **Step 3: Update `@ConfigInformation` HTML**
+
+In the `@ConfigInformation` annotation, replace:
+
+```
+    <li>Filled Bottomless compost bucket</li>
+```
+
+With:
+
+```
+    <li>Compost / Supercompost / Ultracompost / Bottomless compost bucket</li>
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `cd /home/alex/Developer/MB/Microbot-Hub/.worktrees/tree-runner-compost && ./gradlew build -PpluginList=FarmTreeRunPlugin`
+Expected: BUILD FAILURE — `FarmTreeRunScript.java` still references `config.useCompost()`. This confirms the config change is wired in and the script needs updating next.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunConfig.java
+git commit -m "feat(FarmTreeRun): replace useCompost boolean with compostType dropdown"
+```
+
+---
+
+### Task 3: Update script to use `CompostType`
+
+**Files:**
+- Modify: `src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java`
+
+- [ ] **Step 1: Add import for `CompostType`**
+
+Add to the import block:
+
+```java
+import net.runelite.client.plugins.microbot.farmtreerun.enums.CompostType;
+```
+
+- [ ] **Step 2: Update `isCompostEnabled()` method (line ~998)**
+
+The method currently reads:
+
+```java
+private boolean isCompostEnabled(FarmTreeRunConfig config) {
+    if (!config.useCompost())
+        return false;
+
+    if (!getSelectedTreePatches(config).isEmpty() && !config.protectTrees())
+        return true;
+
+    if (!getSelectedHardTreePatches(config).isEmpty() && !config.protectHardTrees())
+        return true;
+
+    return !getSelectedFruitTreePatches(config).isEmpty() && !config.protectFruitTrees();
+}
+```
+
+Replace `config.useCompost()` with `config.compostType() == CompostType.NONE`:
+
+```java
+private boolean isCompostEnabled(FarmTreeRunConfig config) {
+    if (config.compostType() == CompostType.NONE)
+        return false;
+
+    if (!getSelectedTreePatches(config).isEmpty() && !config.protectTrees())
+        return true;
+
+    if (!getSelectedHardTreePatches(config).isEmpty() && !config.protectHardTrees())
+        return true;
+
+    return !getSelectedFruitTreePatches(config).isEmpty() && !config.protectFruitTrees();
+}
+```
+
+- [ ] **Step 3: Update the non-banking path (line ~134-135)**
+
+Replace:
+
+```java
+if (isCompostEnabled(config)) {
+    compostItemId = ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
+}
+```
+
+With:
+
+```java
+if (isCompostEnabled(config)) {
+    compostItemId = config.compostType().getItemId();
+}
+```
+
+- [ ] **Step 4: Update banking compost withdrawal block (lines ~460-467)**
+
+Replace:
+
+```java
+if (isCompostEnabled(config)) {
+    if (Rs2Bank.hasItem(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997)) {
+        compostItemId = ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
+        items.add(new FarmingItem(compostItemId, 1));
+    } else {
+        Microbot.log("Only bottomless compost is supported. Skipping composting.");
+    }
+}
+```
+
+With:
+
+```java
+if (isCompostEnabled(config)) {
+    CompostType compostType = config.compostType();
+    compostItemId = compostType.getItemId();
+    if (compostType.isReusable()) {
+        if (Rs2Bank.hasItem(compostItemId)) {
+            items.add(new FarmingItem(compostItemId, 1));
+        } else {
+            Microbot.log("Bottomless compost bucket not found in bank. Skipping composting.");
+            compostItemId = null;
+        }
+    } else {
+        int unprotectedCount = 0;
+        if (!config.protectTrees())
+            unprotectedCount += getSelectedTreePatches(config).size();
+        if (!config.protectFruitTrees())
+            unprotectedCount += getSelectedFruitTreePatches(config).size();
+        if (!config.protectHardTrees())
+            unprotectedCount += getSelectedHardTreePatches(config).size();
+        if (unprotectedCount > 0) {
+            if (Rs2Bank.hasItem(compostItemId)) {
+                items.add(new FarmingItem(compostItemId, unprotectedCount));
+            } else {
+                Microbot.log("Selected compost not found in bank. Skipping composting.");
+                compostItemId = null;
+            }
+        } else {
+            compostItemId = null;
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Update `useCompostOnPatch()` method (lines ~927-938)**
+
+Replace:
+
+```java
+private boolean useCompostOnPatch(FarmTreeRunConfig config, Patch patch) {
+    if (!config.useCompost() || compostItemId == null)
+        return false;
+
+    if (!config.protectTrees() && patch.kind == TreeKind.TREE)
+        return true;
+
+    if (!config.protectHardTrees() && patch.kind == TreeKind.HARD_TREE)
+        return true;
+
+    return !config.protectFruitTrees() && patch.kind == TreeKind.FRUIT_TREE;
+}
+```
+
+With:
+
+```java
+private boolean useCompostOnPatch(FarmTreeRunConfig config, Patch patch) {
+    if (config.compostType() == CompostType.NONE || compostItemId == null)
+        return false;
+
+    if (!config.protectTrees() && patch.kind == TreeKind.TREE)
+        return true;
+
+    if (!config.protectHardTrees() && patch.kind == TreeKind.HARD_TREE)
+        return true;
+
+    return !config.protectFruitTrees() && patch.kind == TreeKind.FRUIT_TREE;
+}
+```
+
+- [ ] **Step 6: Add empty bucket drop in `handlePlantingTree()` (after line ~810)**
+
+After the compost application block, add a bucket drop for consumable compost. The current code:
+
+```java
+if (useCompostOnPatch(config, patch)) {
+    Rs2Inventory.useItemOnObject(compostItemId, treePatch.getId());
+    Rs2Player.waitForXpDrop(Skill.FARMING, 2000);
+    sleep(550, 2200);
+}
+```
+
+Replace with:
+
+```java
+if (useCompostOnPatch(config, patch)) {
+    Rs2Inventory.useItemOnObject(compostItemId, treePatch.getId());
+    Rs2Player.waitForXpDrop(Skill.FARMING, 2000);
+    sleep(550, 2200);
+    if (!config.compostType().isReusable() && Rs2Inventory.hasItem(ItemID.BUCKET)) {
+        Rs2Inventory.drop(ItemID.BUCKET);
+        sleep(300, 600);
+    }
+}
+```
+
+- [ ] **Step 7: Build to verify compilation**
+
+Run: `cd /home/alex/Developer/MB/Microbot-Hub/.worktrees/tree-runner-compost && ./gradlew build -PpluginList=FarmTreeRunPlugin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
+git commit -m "feat(FarmTreeRun): support all compost types with qty calc and bucket drop"
+```

--- a/docs/superpowers/specs/2026-05-17-tree-runner-compost-types-design.md
+++ b/docs/superpowers/specs/2026-05-17-tree-runner-compost-types-design.md
@@ -1,0 +1,72 @@
+# Farm Tree Runner: Compost Type Selection
+
+## Summary
+
+Replace the boolean `useCompost` config (which only supported bottomless compost bucket) with a dropdown enum that supports all four compost types: Compost, Supercompost, Ultracompost, and Bottomless Compost Bucket. Compost is only applied at patches where protection is not enabled.
+
+## New Enum: `CompostType`
+
+File: `src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/CompostType.java`
+
+| Value | ItemID constant | ID | Reusable | Notes |
+|-------|----------------|----|----------|-------|
+| `NONE` | — | -1 | — | No compost |
+| `COMPOST` | `COMPOST` | 6032 | No | Regular compost |
+| `SUPERCOMPOST` | `SUPERCOMPOST` | 6034 | No | Supercompost |
+| `ULTRACOMPOST` | `ULTRACOMPOST` | 21483 | No | Ultracompost |
+| `BOTTOMLESS_BUCKET` | `BOTTOMLESS_COMPOST_BUCKET_22997` | 22997 | Yes | Reusable, withdraw 1 |
+
+Fields: `String name`, `int itemId`, `boolean reusable`.
+
+## Config Change
+
+File: `FarmTreeRunConfig.java`
+
+- Remove `useCompost()` boolean (keyName `"useCompost"`)
+- Add `compostType()` returning `CompostType`, default `NONE`
+  - keyName: `"compostType"` (new key; old `useCompost` values ignored safely)
+  - Section: `gearSection`, position 1
+  - Description: "Select compost type. Only applied at patches without protection enabled."
+
+## Script Changes
+
+File: `FarmTreeRunScript.java`
+
+### `isCompostEnabled(config)`
+
+Change from `config.useCompost()` to `config.compostType() != CompostType.NONE`.
+
+### `useCompostOnPatch(config, patch)`
+
+Change `config.useCompost()` check to `config.compostType() != CompostType.NONE`. Rest of the method (protection gating per tree kind) stays identical.
+
+### Banking: compost withdrawal block
+
+Replace the current bottomless-only block:
+
+1. If `compostType == NONE`: skip, `compostItemId = null`.
+2. If `BOTTOMLESS_BUCKET`: check bank for item 22997, withdraw 1. Same as current.
+3. If `COMPOST / SUPERCOMPOST / ULTRACOMPOST`: count unprotected patches across all three tree categories (regular trees if `!protectTrees()`, fruit trees if `!protectFruitTrees()`, hardwood if `!protectHardTrees()`). Withdraw that count of the selected compost item ID.
+
+Unprotected patch count reuses the existing `getSelectedTreePatches()`, `getSelectedFruitTreePatches()`, `getSelectedHardTreePatches()` methods — sum their sizes, filtered by protection config.
+
+### `handlePlantingTree()`: drop empty bucket after use
+
+After applying consumable compost (not bottomless) and waiting for the Farming XP drop, drop the resulting empty bucket (`ItemID.BUCKET`, 1925) to free the inventory slot before planting the sapling.
+
+### Non-banking path
+
+The `else` branch (when `config.banking()` is false) currently hardcodes `compostItemId = ItemID.BOTTOMLESS_COMPOST_BUCKET_22997`. Change to set `compostItemId = config.compostType().getItemId()` (or `null` if `NONE`).
+
+## Files Touched
+
+| File | Action |
+|------|--------|
+| `enums/CompostType.java` | New |
+| `FarmTreeRunConfig.java` | Modify: replace boolean with enum dropdown |
+| `FarmTreeRunScript.java` | Modify: banking qty logic, `isCompostEnabled`, `useCompostOnPatch`, `handlePlantingTree` bucket drop, non-banking path |
+
+## Config Information Update
+
+Update the `@ConfigInformation` HTML on the config interface:
+- Change "Filled Bottomless compost bucket" in the Optional items list to "Compost / Supercompost / Ultracompost / Bottomless compost bucket"

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunConfig.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.farmtreerun;
 
 import net.runelite.client.config.*;
+import net.runelite.client.plugins.microbot.farmtreerun.enums.CompostType;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.FruitTreeEnum;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.HardTreeEnums;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.TreeEnums;
@@ -32,7 +33,7 @@ import net.runelite.client.plugins.microbot.farmtreerun.enums.TreeEnums;
         "<br> Optional:\n" +
         "<ol>\n" +
         "    <li>Items for protection payment</li>\n" +
-        "    <li>Filled Bottomless compost bucket</li>\n" +
+        "    <li>Compost / Supercompost / Ultracompost / Bottomless compost bucket</li>\n" +
         "</ol>" +
         "<br> Extra information:\n" +
         "<br> If you want to stop the script during your farm run (maybe it gets stuck or whatever reason), make sure to disable 'Banking' and disable patches you previously ran." +
@@ -161,13 +162,13 @@ public interface FarmTreeRunConfig extends Config {
     default boolean banking() { return true; }
 
     @ConfigItem(
-            keyName = "useCompost",
-            name = "Use compost",
-            description = "Only bottomless compost bucket is supported",
+            keyName = "compostType",
+            name = "Compost type",
+            description = "Select compost type. Only applied at patches without protection enabled.",
             position = 1,
             section = gearSection
     )
-    default boolean useCompost() { return true; }
+    default CompostType compostType() { return CompostType.NONE; }
 
     @ConfigItem(
             keyName = "useGraceful",

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
@@ -123,7 +123,7 @@ public class FarmTreeRunScript extends Script {
                 checkSaplingLevelRequirement(config);
                 if (!validateSpecialPatches(config)) return;
 
-                dropEmptyPlantPots();
+                dropCrap();
                 Patch patch = null;
                 boolean handledPatch = false;
 
@@ -404,12 +404,13 @@ public class FarmTreeRunScript extends Script {
             config.selectedFruitTree().hasRequiredLevel();
     }
 
-    private void dropEmptyPlantPots() {
-        int emptyPlantPot = ItemID.EMPTY_PLANT_POT;
-        if (!Rs2Player.isAnimating() && !Rs2Player.isMoving() && !Rs2Player.isInteracting()) {
-            if (Rs2Inventory.hasItem(emptyPlantPot)) {
-                Rs2Inventory.dropAll(emptyPlantPot);
-                sleepUntil(() -> !Rs2Inventory.hasItem(emptyPlantPot), 8000);
+    private void dropCrap() {
+        if (Rs2Player.isAnimating()) return;
+        int[] junk = {ItemID.EMPTY_PLANT_POT, ItemID.BUCKET, ItemID.WEEDS};
+        for (int id : junk) {
+            if (Rs2Inventory.hasItem(id)) {
+                Rs2Inventory.dropAll(id);
+                sleepUntil(() -> !Rs2Inventory.hasItem(id), 8000);
             }
         }
     }
@@ -513,18 +514,20 @@ public class FarmTreeRunScript extends Script {
             }
 
             if (config.useSkillsNecklace() && (config.farmingGuildTreePatch() || config.farmingGuildFruitTreePatch())) {
-                if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE2)) {
-                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE2, 1));
-                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE3)) {
-                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE3, 1));
-                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE4)) {
-                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE4, 1));
+                if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE6)) {
+                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE6, 1, false, true));
                 } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE5)) {
-                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE5, 1));
-                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE6)) {
-                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE6, 1));
+                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE5, 1, false, true));
+                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE4)) {
+                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE4, 1, false, true));
+                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE3)) {
+                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE3, 1, false, true));
+                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE2)) {
+                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE2, 1, false, true));
+                } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE1)) {
+                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE1, 1, false, true));
                 } else {
-                    items.add(new FarmingItem(ItemID.SKILLS_NECKLACE1, 2));
+                    Microbot.log("No skills necklace found in bank. Skipping.");
                 }
             }
 
@@ -803,14 +806,21 @@ public class FarmTreeRunScript extends Script {
         sleep(500, 850);
 
         if (Rs2Dialogue.hasSelectAnOption()) {
+            if (action == PaymentKind.PROTECT) {
+                if (!Rs2Dialogue.clickOption("don't ask")) {
+                    Rs2Dialogue.clickOption("Yes");
+                }
+                sleep(500, 1500);
+                Rs2Dialogue.clickContinue();
+                sleepUntil(() -> !Rs2Dialogue.isInDialogue(), 6000);
+                return true;
+            }
             Rs2Dialogue.clickOption("Yes");
             sleepUntil(() -> isPatchEmpty(patch), 6000);
             if (isPatchEmpty(patch)) {
                 return true;
             }
-            shutdown();
-
-            System.out.println("Failed gardener money payment.");
+            System.out.println("Failed gardener clear payment.");
             return false;
         } else {
             System.out.println("Failed gardener payment.");
@@ -831,10 +841,6 @@ public class FarmTreeRunScript extends Script {
             Rs2Inventory.useItemOnObject(compostItemId, treePatch.getId());
             Rs2Player.waitForXpDrop(Skill.FARMING, 2000);
             sleep(550, 2200);
-            if (!config.compostType().isReusable() && Rs2Inventory.hasItem(ItemID.BUCKET)) {
-                Rs2Inventory.drop(ItemID.BUCKET);
-                sleep(300, 600);
-            }
         }
 
         sleep(250, 1000);
@@ -873,17 +879,8 @@ public class FarmTreeRunScript extends Script {
         Rs2GameObject.interact(treePatch, "rake");
 
         Rs2Player.waitForAnimation();
-        sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isInteracting());
+        sleepUntil(() -> !Rs2Player.isAnimating());
 
-        // Drop the weeds (assuming weeds are added to the inventory)
-        if (!Rs2Player.isMoving() &&
-                !Rs2Player.isAnimating() &&
-                !Rs2Player.isInteracting() && !Rs2Player.isMoving()) {
-            System.out.println("Dropping weeds...");
-            Rs2Inventory.dropAll(ItemID.WEEDS);
-            Rs2Player.waitForAnimation();
-            sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isInteracting());
-        }
     }
 
     private void handleClearAction(GameObject treePatch) {
@@ -901,7 +898,7 @@ public class FarmTreeRunScript extends Script {
 
         // Wait for the clearing animation to finish
         Rs2Player.waitForAnimation();
-        sleepUntil(() -> !Rs2Player.isAnimating() && Rs2Player.isInteracting() && Rs2Player.isMoving());
+        sleepUntil(() -> !Rs2Player.isAnimating() && Rs2Player.isMoving());
     }
 
     private void equipGraceful() {

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
@@ -6,6 +6,7 @@ import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.farmtreerun.enums.CompostType;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.HardTreeEnums;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.FruitTreeEnum;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.TreeEnums;
@@ -132,7 +133,7 @@ public class FarmTreeRunScript extends Script {
 							bank(config);
 						} else {
 							if (isCompostEnabled(config)) {
-								compostItemId = ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
+								compostItemId = config.compostType().getItemId();
 							}
 							botStatus = net.runelite.client.plugins.microbot.farmtreerun.enums.FarmTreeRunState.HANDLE_GNOME_STRONGHOLD_FRUIT_PATCH;
 						}
@@ -458,11 +459,33 @@ public class FarmTreeRunScript extends Script {
             }
 
             if (isCompostEnabled(config)) {
-                if (Rs2Bank.hasItem(ItemID.BOTTOMLESS_COMPOST_BUCKET_22997)) {
-                    compostItemId = ItemID.BOTTOMLESS_COMPOST_BUCKET_22997;
-                    items.add(new FarmingItem(compostItemId, 1));
+                CompostType compostType = config.compostType();
+                compostItemId = compostType.getItemId();
+                if (compostType.isReusable()) {
+                    if (Rs2Bank.hasItem(compostItemId)) {
+                        items.add(new FarmingItem(compostItemId, 1));
+                    } else {
+                        Microbot.log("Bottomless compost bucket not found in bank. Skipping composting.");
+                        compostItemId = null;
+                    }
                 } else {
-                    Microbot.log("Only bottomless compost is supported. Skipping composting.");
+                    int unprotectedCount = 0;
+                    if (!config.protectTrees())
+                        unprotectedCount += getSelectedTreePatches(config).size();
+                    if (!config.protectFruitTrees())
+                        unprotectedCount += getSelectedFruitTreePatches(config).size();
+                    if (!config.protectHardTrees())
+                        unprotectedCount += getSelectedHardTreePatches(config).size();
+                    if (unprotectedCount > 0) {
+                        if (Rs2Bank.hasItem(compostItemId)) {
+                            items.add(new FarmingItem(compostItemId, unprotectedCount));
+                        } else {
+                            Microbot.log("Selected compost not found in bank. Skipping composting.");
+                            compostItemId = null;
+                        }
+                    } else {
+                        compostItemId = null;
+                    }
                 }
             }
 
@@ -808,6 +831,10 @@ public class FarmTreeRunScript extends Script {
             Rs2Inventory.useItemOnObject(compostItemId, treePatch.getId());
             Rs2Player.waitForXpDrop(Skill.FARMING, 2000);
             sleep(550, 2200);
+            if (!config.compostType().isReusable() && Rs2Inventory.hasItem(ItemID.BUCKET)) {
+                Rs2Inventory.drop(ItemID.BUCKET);
+                sleep(300, 600);
+            }
         }
 
         sleep(250, 1000);
@@ -925,7 +952,7 @@ public class FarmTreeRunScript extends Script {
     }
 
     private boolean useCompostOnPatch(FarmTreeRunConfig config, Patch patch) {
-        if (!config.useCompost() || compostItemId == null)
+        if (config.compostType() == CompostType.NONE || compostItemId == null)
             return false;
 
         if (!config.protectTrees() && patch.kind == TreeKind.TREE)
@@ -996,7 +1023,7 @@ public class FarmTreeRunScript extends Script {
      * @return true if configured by player, else false
      */
     private boolean isCompostEnabled(FarmTreeRunConfig config) {
-        if (!config.useCompost())
+        if (config.compostType() == CompostType.NONE)
             return false;
 
         if (!getSelectedTreePatches(config).isEmpty() && !config.protectTrees())

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.farmtreerun.enums.CompostType;
@@ -23,7 +24,11 @@ import net.runelite.client.plugins.microbot.util.magic.Rs2Spellbook;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.awt.event.KeyEvent;
 
 import javax.inject.Inject;
 import java.util.*;
@@ -350,6 +355,13 @@ public class FarmTreeRunScript extends Script {
 
 
                     case FINISHED:
+						if (!Rs2Bank.isOpen()) {
+							if (!Rs2Bank.walkToBank()) return;
+							if (!Rs2Bank.openBank()) return;
+						}
+						Rs2Bank.depositAll();
+						sleepUntil(() -> Rs2Inventory.isEmpty(), 3000);
+						Rs2Bank.closeBank();
 						Microbot.getClientThread().runOnClientThreadOptional(() -> {
 								Microbot.getClient().addChatMessage(ChatMessageType.ENGINE, "", "Tree run completed.", "Acun", false);
 								Microbot.getClient().addChatMessage(ChatMessageType.ENGINE, "", "Made with love by Acun.", "Acun", false);
@@ -467,24 +479,6 @@ public class FarmTreeRunScript extends Script {
                         items.add(new FarmingItem(compostItemId, 1));
                     } else {
                         Microbot.log("Bottomless compost bucket not found in bank. Skipping composting.");
-                        compostItemId = null;
-                    }
-                } else {
-                    int unprotectedCount = 0;
-                    if (!config.protectTrees())
-                        unprotectedCount += getSelectedTreePatches(config).size();
-                    if (!config.protectFruitTrees())
-                        unprotectedCount += getSelectedFruitTreePatches(config).size();
-                    if (!config.protectHardTrees())
-                        unprotectedCount += getSelectedHardTreePatches(config).size();
-                    if (unprotectedCount > 0) {
-                        if (Rs2Bank.hasItem(compostItemId)) {
-                            items.add(new FarmingItem(compostItemId, unprotectedCount));
-                        } else {
-                            Microbot.log("Selected compost not found in bank. Skipping composting.");
-                            compostItemId = null;
-                        }
-                    } else {
                         compostItemId = null;
                     }
                 }
@@ -836,11 +830,21 @@ public class FarmTreeRunScript extends Script {
 
         int saplingToUse = getSaplingToUse(patch, config);
 
-        Microbot.log("Reached here");
         if (useCompostOnPatch(config, patch)) {
-            Rs2Inventory.useItemOnObject(compostItemId, treePatch.getId());
-            Rs2Player.waitForXpDrop(Skill.FARMING, 2000);
-            sleep(550, 2200);
+            boolean hasCompost = Rs2Inventory.hasItem(compostItemId);
+            if (!hasCompost && !config.compostType().isReusable()) {
+                hasCompost = withdrawCompostFromLeprechaun(config.compostType());
+                if (!hasCompost) {
+                    Microbot.showMessage("Tool Leprechaun has no " + config.compostType() + ". Store compost with the leprechaun before starting.");
+                    shutdown();
+                    return false;
+                }
+            }
+            if (hasCompost) {
+                Rs2Inventory.useItemOnObject(compostItemId, treePatch.getId());
+                Rs2Player.waitForXpDrop(Skill.FARMING, 2000);
+                sleep(550, 2200);
+            }
         }
 
         sleep(250, 1000);
@@ -946,6 +950,45 @@ public class FarmTreeRunScript extends Script {
 
     private boolean isFruitTreePatch(Patch patch) {
         return patch.kind == TreeKind.FRUIT_TREE;
+    }
+
+    private boolean withdrawCompostFromLeprechaun(CompostType compostType) {
+        Rs2NpcModel leprechaun = Rs2Npc.getNpc("Tool Leprechaun");
+        if (leprechaun == null) {
+            Microbot.log("Tool Leprechaun not found nearby.");
+            return false;
+        }
+
+        Rs2Npc.interact(leprechaun, "Exchange");
+        sleepUntil(() -> Rs2Widget.isWidgetVisible(125, 0), 5000);
+        if (!Rs2Widget.isWidgetVisible(125, 0)) {
+            Microbot.log("Tool Leprechaun exchange interface did not open.");
+            return false;
+        }
+        sleep(300, 600);
+
+        int childId;
+        switch (compostType) {
+            case COMPOST: childId = 17; break;
+            case SUPERCOMPOST: childId = 18; break;
+            case ULTRACOMPOST: childId = 19; break;
+            default: return false;
+        }
+
+        Widget compostWidget = Rs2Widget.getWidget(125, childId);
+        if (compostWidget == null) {
+            Microbot.log("Compost widget not found in leprechaun interface.");
+            return false;
+        }
+
+        Rs2Widget.clickWidget(compostWidget);
+        sleepUntil(() -> Rs2Inventory.hasItem(compostType.getItemId()), 3000);
+        sleep(300, 600);
+
+        Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+        sleepUntil(() -> !Rs2Widget.isWidgetVisible(125, 0), 2000);
+
+        return Rs2Inventory.hasItem(compostType.getItemId());
     }
 
     private boolean useCompostOnPatch(FarmTreeRunConfig config, Patch patch) {

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/CompostType.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/enums/CompostType.java
@@ -1,0 +1,24 @@
+package net.runelite.client.plugins.microbot.farmtreerun.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.gameval.ItemID;
+
+@Getter
+@RequiredArgsConstructor
+public enum CompostType {
+    NONE("None", -1, false),
+    COMPOST("Compost", ItemID.BUCKET_COMPOST, false),
+    SUPERCOMPOST("Supercompost", ItemID.BUCKET_SUPERCOMPOST, false),
+    ULTRACOMPOST("Ultracompost", ItemID.BUCKET_ULTRACOMPOST, false),
+    BOTTOMLESS_BUCKET("Bottomless bucket", ItemID.BOTTOMLESS_COMPOST_BUCKET_FILLED, true);
+
+    private final String name;
+    private final int itemId;
+    private final boolean reusable;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}


### PR DESCRIPTION
## Summary

- **Compost type dropdown**: Replaced the boolean `useCompost` toggle with a `CompostType` enum dropdown (None / Compost / Supercompost / Ultracompost / Bottomless bucket). Compost is only applied at patches where protection is NOT enabled.
- **Tool Leprechaun compost withdrawal**: Non-reusable compost (regular/super/ultra) is now withdrawn from the Tool Leprechaun at each patch via the Exchange interface (widget group 125), instead of bulk-withdrawing from the bank. Saves inventory slots. Bottomless bucket still comes from bank.
- **Error on missing compost**: Plugin stops with a clear error message if the Tool Leprechaun has no compost of the selected type stored.
- **Bank on finish**: On run completion, the plugin walks to the nearest bank, deposits all items, and shuts down cleanly instead of stopping in the field.
- **Protection dialog fix**: Handles first-time protection dialog ("Yes, and don't ask again") that was causing the plugin to get stuck.
- **Skills necklace crash fix**: Made skills necklace truly optional — plugin no longer shuts down when no necklace is in the bank. Tries highest charge first, logs and skips if none found.
- **Consolidated junk drops**: Merged plant pot, bucket, and weed dropping into a single `dropCrap()` method. Only guards on `isAnimating()` so items can be dropped while moving.
- **Removed unreliable `isInteracting()` checks**: Removed `isInteracting()` guards from `handleRakeAction()` and `handleClearAction()` sleep conditions that were causing stalls.

## Test plan

- [x] Configure compost type to Ultracompost, verify it withdraws from leprechaun at each unprotected patch
- [ ] Verify bottomless bucket still comes from bank when selected
- [x] Verify plugin stops with error when leprechaun has no compost stored
- [ ] Verify plugin walks to bank and deposits after finishing all patches
- [x] Verify protection payment dialog works on first-time accounts
- [x] Verify plugin runs without skills necklace in bank
- [x] Verify junk items (pots, buckets, weeds) are dropped while running between patches