### PR TITLE
feat(birdhouse): teleport savings, southern rowboat, seaweed chaining

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsConfig.java
@@ -86,4 +86,45 @@ public interface FornBirdhouseRunsConfig extends Config {
         return false;
     }
 
+    @ConfigItem(
+            keyName = "startGiantSeaweedAfter",
+            name = "Start Giant Seaweed after run",
+            description = "When the birdhouse run finishes, start the TaF Giant Seaweed plugin (if installed)",
+            section = optionsSection,
+            position = 1
+    )
+    default boolean startGiantSeaweedAfter() {
+        return false;
+    }
+
+    @ConfigSection(
+            name = "Debug",
+            description = "Debug and testing options",
+            position = 3,
+            closedByDefault = true
+    )
+    String debugSection = "debug";
+
+    @ConfigItem(
+            keyName = "enableOverrideStartState",
+            name = "Enable Override Start State",
+            description = "When enabled, the plugin will skip to the selected state on startup",
+            section = debugSection,
+            position = 0
+    )
+    default boolean enableOverrideStartState() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "overrideStartState",
+            name = "Override Start State",
+            description = "Skip to a specific state instead of starting from the beginning",
+            section = debugSection,
+            position = 1
+    )
+    default FornBirdhouseRunsInfo.states overrideStartState() {
+        return FornBirdhouseRunsInfo.states.GEARING;
+    }
+
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsPlugin.java
@@ -26,7 +26,7 @@ import java.awt.*;
 )
 @Slf4j
 public class FornBirdhouseRunsPlugin extends Plugin {
-    final static String version = "1.1.1";
+    final static String version = "1.1.2";
     @Provides
     FornBirdhouseRunsConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(FornBirdhouseRunsConfig.class);

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsScript.java
@@ -39,6 +39,7 @@ public class FornBirdhouseRunsScript extends Script {
     private static final WorldPoint birdhouseLocation2 = new WorldPoint(3768, 3761, 0);
     private static final WorldPoint birdhouseLocation3 = new WorldPoint(3677, 3882, 0);
     private static final WorldPoint birdhouseLocation4 = new WorldPoint(3679, 3815, 0);
+    private static final WorldPoint SOUTH_ROWBOAT = new WorldPoint(3724, 3807, 0);
     // Each location maps to a BIRDHOUSE_TRANSMIT_* varp. See isEmpty/isBuilt/isSeeded
     // below for the canonical state decoding (matches RuneLite's BirdHouseState).
     private static final int VARP_HOUSE_1 = VarPlayerID.BIRDHOUSE_TRANSMIT_D; // Verdant SW
@@ -105,8 +106,12 @@ public class FornBirdhouseRunsScript extends Script {
                         return;
                     }
                     initialized = true;
-                    
-                    if (config.useInventorySetup()) {
+
+                    states startOverride = config.enableOverrideStartState() ? config.overrideStartState() : states.GEARING;
+                    if (startOverride != states.GEARING) {
+                        log.info("Override start state → {}", startOverride);
+                        botStatus = startOverride;
+                    } else if (config.useInventorySetup()) {
                         boolean hasInventorySetup = config.inventorySetup() != null && Rs2InventorySetup.isInventorySetup(config.inventorySetup().getName());
                         if (hasInventorySetup) {
                             var inventorySetup = new Rs2InventorySetup(config.inventorySetup(), mainScheduledFuture);
@@ -134,9 +139,16 @@ public class FornBirdhouseRunsScript extends Script {
                     } else {
                         log.info("Inventory already prepared — skipping bank trip");
                     }
-                    botStatus = states.TELEPORTING;
+                    if (startOverride == states.GEARING) {
+                        botStatus = states.TELEPORTING;
+                    }
                 }
                 if (!super.run()) return;
+
+                if (!Rs2Walker.disableTeleports && isOnFossilIsland()) {
+                    Rs2Walker.disableTeleports = true;
+                    log.info("On Fossil Island — disabling teleports for remaining walks");
+                }
 
                 boolean advanced = true;
                 while (advanced) {
@@ -244,6 +256,7 @@ public class FornBirdhouseRunsScript extends Script {
                             emptyNests();
 
                             if (config.goToBank()) {
+                                Rs2Walker.walkTo(SOUTH_ROWBOAT, 3);
                                 Rs2Walker.walkTo(BankLocation.FOSSIL_ISLAND_WRECK.getWorldPoint());
                                 if (!Rs2Bank.isOpen()) Rs2Bank.openBank();
                                 Rs2Bank.depositAll();
@@ -252,6 +265,14 @@ public class FornBirdhouseRunsScript extends Script {
                             botStatus = states.FINISHED;
                             notifier.notify(Notification.ON, "Birdhouse run is finished.");
                             log.info("Birdhouse run finished — disabling plugin.");
+
+                            if (config.startGiantSeaweedAfter()) {
+                                log.info("Starting Giant Seaweed Farmer plugin");
+                                if (!Microbot.startPlugin("net.runelite.client.plugins.microbot.GiantSeaweedFarmer.GiantSeaweedFarmerPlugin")) {
+                                    log.warn("Failed to start Giant Seaweed Farmer — is it installed?");
+                                }
+                            }
+
                             Microbot.stopPlugin(plugin);
                             break;
                         case FINISHED:
@@ -287,6 +308,7 @@ public class FornBirdhouseRunsScript extends Script {
     @Override
     public void shutdown() {
         super.shutdown();
+        Rs2Walker.disableTeleports = false;
         initialized = false;
         botStatus = states.TELEPORTING;
         lastObservedStatus = null;
@@ -643,13 +665,13 @@ public class FornBirdhouseRunsScript extends Script {
             return false;
         }
         Rs2Inventory.waitForInventoryChanges(3000);
-        int invAfter = Rs2Inventory.count(bankSeed.getId());
-        int invAfterByName = findInventoryBirdhouseSeed(1).map(Rs2ItemModel::getQuantity).orElse(0);
-        log.info("withdrawSeeds: withdrew 40 {} (id={}); inv after = {} of id={} (by-name lookup = {})",
-                bankSeed.getName(), bankSeed.getId(), invAfter, bankSeed.getId(), invAfterByName);
+        int invAfter = findInventoryBirdhouseSeed(1).map(Rs2ItemModel::getQuantity).orElse(0);
+        log.info("withdrawSeeds: withdrew 40 {} (id={}); inv seed qty = {}",
+                bankSeed.getName(), bankSeed.getId(), invAfter);
         if (invAfter < 40) {
-            log.warn("withdrawSeeds: inventory count of id={} after withdraw is {} (<40). Full inv: [{}]",
-                    bankSeed.getId(), invAfter, dumpInventory());
+            setupErrorMessage = "Withdrew seeds but only got " + invAfter + " (need 40)";
+            log.error(setupErrorMessage);
+            return false;
         }
         return true;
     }

--- a/src/test/java/net/runelite/client/Microbot.java
+++ b/src/test/java/net/runelite/client/Microbot.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.runelite.client.plugins.fishing.FishingPlugin;
+import net.runelite.client.plugins.microbot.GiantSeaweedFarmer.GiantSeaweedFarmerPlugin;
 import net.runelite.client.plugins.microbot.agentserver.AgentServerPlugin;
 import net.runelite.client.plugins.microbot.aiofighter.AIOFighterPlugin;
 import net.runelite.client.plugins.microbot.astralrc.AstralRunesPlugin;
+import net.runelite.client.plugins.microbot.birdhouseruns.FornBirdhouseRunsPlugin;
 import net.runelite.client.plugins.microbot.autofishing.AutoFishingPlugin;
 import net.runelite.client.plugins.microbot.crafting.jewelry.JewelryPlugin;
 import net.runelite.client.plugins.microbot.example.ExamplePlugin;
@@ -23,7 +25,9 @@ public class Microbot
 
 	private static final Class<?>[] debugPlugins = {
 		AIOFighterPlugin.class,
-		AgentServerPlugin.class
+		AgentServerPlugin.class,
+		FornBirdhouseRunsPlugin.class,
+		GiantSeaweedFarmerPlugin.class
 	};
 
     public static void main(String[] args) throws Exception


### PR DESCRIPTION
## Summary
- **Disable teleports on Fossil Island**: Sets `Rs2Walker.disableTeleports=true` once the player arrives on Fossil Island, so the digsite pendant is only consumed once (for the initial teleport). Mushroom tree transports remain available.
- **Force southern rowboat for banking**: Walks to the southern rowboat (3724, 3807) before heading to the wreck bank, avoiding the longer northern route the pathfinder was choosing.
- **Chain Giant Seaweed plugin**: New "Start Giant Seaweed after run" config option launches `GiantSeaweedFarmerPlugin` when the birdhouse run finishes.
- **Fix seed withdrawal warning**: Use real stack quantity (`Rs2ItemModel.getQuantity()`) instead of `Rs2Inventory.count()` (which returns slot count, always 1 for stackable items). Fail fast if <40 seeds withdrawn.
- **Debug section**: New collapsed config section with override start state toggle for testing.
- Version bump to 1.1.2.

## Test plan
- [x] Full birdhouse run: verify pendant consumed only once
- [x] Verify mushroom tree transports still work between birdhouse areas
- [x] Verify banking uses southern rowboat
- [x] Toggle "Start Giant Seaweed after run" and confirm seaweed plugin starts on completion
- [x] Test override start state (set to FINISHING) to skip directly to end-of-run
- [x] Verify seed withdrawal logs correct quantity (no false warning)