### PR TITLE
Fix/combat hotkeys prayer threading

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysConfig.java
@@ -12,6 +12,35 @@ import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
 @ConfigGroup("combathotkeys")
 public interface CombatHotkeysConfig extends Config {
 
+    // =========================================================================
+    // DEBUG SECTION — appears at the top (position 0) so it's always visible
+    // =========================================================================
+
+    @ConfigSection(
+            name = "Debug",
+            description = "Enable the on-screen debug panel and verbose logging to the RuneLite log",
+            position = 0,
+            closedByDefault = true
+    )
+    String debugSection = "debugSection";
+
+    @ConfigItem(
+            keyName = "debugMode",
+            name = "Show debug panel",
+            description = "Renders a debug overlay showing the last key received, last action dispatched, "
+                    + "submitted/succeeded/failed counters, and any error. Also enables TRACE-level logging "
+                    + "from the plugin — check the RuneLite log (Help → Open logs folder) for full detail.",
+            position = 0,
+            section = debugSection
+    )
+    default boolean debugMode() {
+        return false;
+    }
+
+    // =========================================================================
+    // OFFENSIVE SECTION
+    // =========================================================================
+
     @ConfigSection(
             name = "Offensive Hotkeys",
             description = "Offensive Prayer and attack hotkeys",
@@ -86,6 +115,10 @@ public interface CombatHotkeysConfig extends Config {
     )
     default Keybind specialAttackKey() { return Keybind.NOT_SET; }
 
+    // =========================================================================
+    // DEFENSIVE PRAYERS SECTION
+    // =========================================================================
+
     @ConfigSection(
             name = "Defensive Prayers",
             description = "Defensive Prayer hotkeys",
@@ -128,6 +161,10 @@ public interface CombatHotkeysConfig extends Config {
     {
         return Keybind.NOT_SET;
     }
+
+    // =========================================================================
+    // FOOD & POTIONS SECTION
+    // =========================================================================
 
     @ConfigSection(
             name = "Food & Potions",
@@ -172,12 +209,27 @@ public interface CombatHotkeysConfig extends Config {
         return Keybind.NOT_SET;
     }
 
+    // =========================================================================
+    // GEAR SETUPS SECTION
+    // =========================================================================
+
     @ConfigSection(
             name = "Gear setups",
             description = "Gear setups",
             position = 4
     )
     String gearSetup = "gearSetup";
+
+    @ConfigItem(
+            keyName = "maxDelay",
+            name = "Max Equip Delay (ms)",
+            description = "Maximum random delay (in milliseconds) between equipping items",
+            position = 0,
+            section = gearSetup
+    )
+    default int maxDelay() {
+        return 500;
+    }
 
     @ConfigItem(
             keyName = "Hotkey for gear 1",
@@ -286,64 +338,16 @@ public interface CombatHotkeysConfig extends Config {
             keyName = "Gear IDs 5",
             name = "Gear IDs 5",
             description = "List of Gear IDs comma separated",
-            position = 2,
+            position = 10,
             section = gearSetup
     )
     default String gearList5() {
         return "";
     }
 
-    @ConfigItem(
-            keyName = "dance boolean",
-            name = "dance",
-            description = "Select this if you want to setup dance",
-            position = 9
-    )
-    default boolean yesDance() {
-        return false;
-    }
-
-    // config item for a keybind to enable the dance feature
-    @ConfigItem(
-            keyName = "dance",
-            name = "Dance",
-            description = "Dance",
-            position = 7
-    )
-    default Keybind dance() {
-        return Keybind.NOT_SET;
-    }
-
-    // hidden config for worldpoint called tile1
-    @ConfigItem(
-            keyName = "tile1",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default WorldPoint tile1() {
-        return null;
-    }
-    @ConfigItem(
-            keyName = "tile2",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default WorldPoint tile2() {
-        return null;
-    }
-
-    @ConfigItem(
-            keyName = "maxDelay",
-            name = "Max Equip Delay (ms)",
-            description = "Maximum random delay (in milliseconds) between equipping items",
-            position = 0,
-            section = gearSetup
-    )
-    default int maxDelay() {
-        return 500; // default max delay of 500ms
-    }
+    // =========================================================================
+    // MULTISKILLING SECTION
+    // =========================================================================
 
     @ConfigSection(
             name = "Multiskilling",
@@ -370,24 +374,66 @@ public interface CombatHotkeysConfig extends Config {
     )
     default String itemToAlch() { return null; }
 
-    public enum MeleePrayerOption {
+    // =========================================================================
+    // DANCE SECTION
+    // =========================================================================
+
+    @ConfigItem(
+            keyName = "dance boolean",
+            name = "dance",
+            description = "Select this if you want to setup dance",
+            position = 9
+    )
+    default boolean yesDance() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "dance",
+            name = "Dance",
+            description = "Dance",
+            position = 7
+    )
+    default Keybind dance() {
+        return Keybind.NOT_SET;
+    }
+
+    @ConfigItem(
+            keyName = "tile1",
+            name = "",
+            description = "",
+            hidden = true
+    )
+    default WorldPoint tile1() {
+        return null;
+    }
+
+    @ConfigItem(
+            keyName = "tile2",
+            name = "",
+            description = "",
+            hidden = true
+    )
+    default WorldPoint tile2() {
+        return null;
+    }
+
+    // =========================================================================
+    // ENUMS
+    // =========================================================================
+
+    enum MeleePrayerOption {
         SUPERHUMAN_STRENGTH(Rs2PrayerEnum.SUPERHUMAN_STRENGTH),
         ULTIMATE_STRENGTH(Rs2PrayerEnum.ULTIMATE_STRENGTH),
         CHIVALRY(Rs2PrayerEnum.CHIVALRY),
         PIETY(Rs2PrayerEnum.PIETY);
 
         private final Rs2PrayerEnum prayer;
-
-        MeleePrayerOption(Rs2PrayerEnum prayer) {
-            this.prayer = prayer;
-        }
-
-        public Rs2PrayerEnum getPrayer() {
-            return prayer;
-        }
+        MeleePrayerOption(Rs2PrayerEnum prayer) { this.prayer = prayer; }
+        public Rs2PrayerEnum getPrayer() { return prayer; }
     }
 
-    public enum RangedPrayerOption {
+    enum RangedPrayerOption {
         SHARP_EYE(Rs2PrayerEnum.SHARP_EYE),
         HAWK_EYE(Rs2PrayerEnum.HAWK_EYE),
         EAGLE_EYE(Rs2PrayerEnum.EAGLE_EYE),
@@ -395,30 +441,18 @@ public interface CombatHotkeysConfig extends Config {
         RIGOUR(Rs2PrayerEnum.RIGOUR);
 
         private final Rs2PrayerEnum prayer;
-
-        RangedPrayerOption(Rs2PrayerEnum prayer) {
-            this.prayer = prayer;
-        }
-
-        public Rs2PrayerEnum getPrayer() {
-            return prayer;
-        }
+        RangedPrayerOption(Rs2PrayerEnum prayer) { this.prayer = prayer; }
+        public Rs2PrayerEnum getPrayer() { return prayer; }
     }
 
-    public enum MagicPrayerOption {
+    enum MagicPrayerOption {
         MYSTIC_WILL(Rs2PrayerEnum.MYSTIC_WILL),
         MYSTIC_LORE(Rs2PrayerEnum.MYSTIC_LORE),
         MYSTIC_MIGHT(Rs2PrayerEnum.MYSTIC_MIGHT),
         AUGURY(Rs2PrayerEnum.AUGURY);
 
         private final Rs2PrayerEnum prayer;
-
-        MagicPrayerOption(Rs2PrayerEnum prayer) {
-            this.prayer = prayer;
-        }
-
-        public Rs2PrayerEnum getPrayer() {
-            return prayer;
-        }
+        MagicPrayerOption(Rs2PrayerEnum prayer) { this.prayer = prayer; }
+        public Rs2PrayerEnum getPrayer() { return prayer; }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysOverlay.java
@@ -15,58 +15,234 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.awt.*;
+import java.time.Instant;
 
 public class CombatHotkeysOverlay extends Overlay {
 
-    CombatHotkeysConfig config;
+    private static final int PANEL_X = 10;
+    private static final int PANEL_Y = 10;
+    private static final int PANEL_W = 310;
+    private static final int ROW_H  = 16;
+    private static final int PAD    = 6;
+
+    private static final Color BG_COLOR     = new Color(0, 0, 0, 180);
+    private static final Color BORDER_COLOR = new Color(255, 165, 0, 220);   // orange
+    private static final Color LABEL_COLOR  = new Color(180, 180, 180);
+    private static final Color VALUE_COLOR  = Color.WHITE;
+    private static final Color OK_COLOR     = new Color(80, 220, 80);
+    private static final Color ERR_COLOR    = new Color(255, 80, 80);
+    private static final Color TITLE_COLOR  = new Color(255, 165, 0);
+
+    private final CombatHotkeysPlugin plugin;
+    private final CombatHotkeysConfig config;
+
     @Inject
     CombatHotkeysOverlay(CombatHotkeysPlugin plugin, CombatHotkeysConfig config)
     {
-
         super(plugin);
+        this.plugin = plugin;
         this.config = config;
         setPosition(OverlayPosition.DYNAMIC);
         setNaughty();
         setLayer(OverlayLayer.ABOVE_SCENE);
     }
+
     @Override
     public Dimension render(Graphics2D graphics) {
         try {
-            if(config.yesDance()) {
+            // ----------------------------------------------------------------
+            // Dance tiles (original behaviour — always rendered when enabled)
+            // ----------------------------------------------------------------
+            if (config.yesDance()) {
                 drawTile(graphics, config.tile1(), Color.GREEN, "Tile 1", new BasicStroke(2));
                 drawTile(graphics, config.tile2(), Color.GREEN, "Tile 2", new BasicStroke(2));
             }
-        } catch(Exception ex) {
+
+            // ----------------------------------------------------------------
+            // Debug panel — only rendered when debug mode is on
+            // ----------------------------------------------------------------
+            if (config.debugMode()) {
+                renderDebugPanel(graphics);
+            }
+
+        } catch (Exception ex) {
             Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
         }
         return null;
     }
-    private void drawTile(Graphics2D graphics, WorldPoint point, Color color, @Nullable String label, Stroke borderStroke)
-    {
-        WorldPoint playerLocation = Rs2Player.getWorldLocation();
 
-        if (point.distanceTo(playerLocation) >= 32)
-        {
-            return;
+    // -------------------------------------------------------------------------
+    // DEBUG PANEL
+    // -------------------------------------------------------------------------
+
+    /**
+     * Renders a compact diagnostic panel in the top-left corner of the game
+     * canvas.  All data is read atomically from the plugin's public fields so
+     * this method never touches game state.
+     *
+     * Layout (each row is ROW_H px tall):
+     *   ┌─ Combat Hotkeys DEBUG (v1.1.2) ──────────────────────────┐
+     *   │ Last key received : protectMelee                          │
+     *   │ Key age           : 0.3 s ago                            │
+     *   │ Last action       : toggle prayer PROTECT_MELEE          │
+     *   │ Submitted         : 4                                    │
+     *   │ Succeeded         : 4   Failed: 0                        │
+     *   │ Last error        : -                                    │
+     *   │ Logged in         : true                                 │
+     *   │ Thread            : AWT-EventQueue-0                     │
+     *   └──────────────────────────────────────────────────────────┘
+     *
+     * Reading this panel tells you at a glance:
+     *  - "Last key received" never updates  → keyPressed is not firing; the
+     *    keybind in config does not match what you're pressing, or the
+     *    KeyManager is not registered.
+     *  - "Last key received" updates but "Last action" doesn't → dispatch()
+     *    was reached but the executor was null/shutdown (logged as an error).
+     *  - Submitted increments but Succeeded doesn't → Rs2Prayer.toggle()
+     *    threw; check "Last error" and the RuneLite log.
+     *  - Everything looks fine but prayer doesn't toggle → Rs2Prayer itself
+     *    has a bug (e.g. prayer tab not open, out of prayer points).
+     */
+    private void renderDebugPanel(Graphics2D graphics) {
+        Font originalFont = graphics.getFont();
+        Font monoFont = new Font(Font.MONOSPACED, Font.PLAIN, 11);
+        graphics.setFont(monoFont);
+        FontMetrics fm = graphics.getFontMetrics(monoFont);
+
+        // Collect all rows to render first so we can size the background
+        String keyReceived  = plugin.getLastKeyReceived().get();
+        String lastAction   = plugin.getLastActionDispatched().get();
+        int    submitted    = plugin.getTotalActionsSubmitted().get();
+        int    succeeded    = plugin.getTotalActionsSucceeded().get();
+        int    failed       = plugin.getTotalActionsFailed().get();
+        String lastError    = plugin.getLastError().get();
+        boolean loggedIn    = Microbot.isLoggedIn();
+
+        // Age of last keypress
+        String keyAge;
+        long ts = plugin.getLastKeyTimestamp();
+        if (ts == 0) {
+            keyAge = "never";
+        } else {
+            long ageSec = (Instant.now().toEpochMilli() - ts);
+            keyAge = String.format("%.1f s ago", ageSec / 1000.0);
         }
+
+        String[] labels = {
+                "Last key     :",
+                "Key age      :",
+                "Last action  :",
+                "Submitted    :",
+                "Succeeded    :",
+                "Failed       :",
+                "Last error   :",
+                "Logged in    :",
+        };
+        String[] values = {
+                keyReceived,
+                keyAge,
+                lastAction,
+                String.valueOf(submitted),
+                String.valueOf(succeeded),
+                String.valueOf(failed),
+                lastError,
+                String.valueOf(loggedIn),
+        };
+        Color[] valueColors = {
+                VALUE_COLOR,
+                LABEL_COLOR,
+                VALUE_COLOR,
+                VALUE_COLOR,
+                succeeded > 0 ? OK_COLOR : LABEL_COLOR,
+                failed    > 0 ? ERR_COLOR : LABEL_COLOR,
+                lastError.equals("-") ? LABEL_COLOR : ERR_COLOR,
+                loggedIn ? OK_COLOR : ERR_COLOR,
+        };
+
+        int rows   = labels.length;
+        int titleH = ROW_H + 4;
+        int totalH = titleH + rows * ROW_H + PAD * 2;
+        int x      = PANEL_X;
+        int y      = PANEL_Y;
+
+        // Background
+        graphics.setColor(BG_COLOR);
+        graphics.fillRoundRect(x, y, PANEL_W, totalH, 8, 8);
+
+        // Border
+        graphics.setColor(BORDER_COLOR);
+        graphics.setStroke(new BasicStroke(1.5f));
+        graphics.drawRoundRect(x, y, PANEL_W, totalH, 8, 8);
+
+        // Title bar
+        graphics.setColor(TITLE_COLOR);
+        Font titleFont = monoFont.deriveFont(Font.BOLD, 11f);
+        graphics.setFont(titleFont);
+        String title = "Combat Hotkeys DEBUG  v" + CombatHotkeysPlugin.version;
+        graphics.drawString(title, x + PAD, y + PAD + fm.getAscent());
+        graphics.setFont(monoFont);
+
+        // Divider under title
+        graphics.setColor(BORDER_COLOR);
+        graphics.setStroke(new BasicStroke(1f));
+        graphics.drawLine(x + 1, y + titleH, x + PANEL_W - 1, y + titleH);
+
+        // Data rows
+        int rowY = y + titleH + PAD;
+        for (int i = 0; i < rows; i++) {
+            int baseY = rowY + i * ROW_H + fm.getAscent();
+
+            // Label (dimmer)
+            graphics.setColor(LABEL_COLOR);
+            graphics.drawString(labels[i], x + PAD, baseY);
+
+            // Value (coloured)
+            graphics.setColor(valueColors[i]);
+            int labelW = fm.stringWidth(labels[i]);
+            // Truncate long values so they don't overflow the panel
+            String val = truncate(values[i], fm, PANEL_W - labelW - PAD * 3);
+            graphics.drawString(val, x + PAD + labelW + 4, baseY);
+        }
+
+        graphics.setFont(originalFont);
+    }
+
+    /** Truncate a string to fit within maxWidth pixels, appending "…" if needed. */
+    private String truncate(String s, FontMetrics fm, int maxWidth) {
+        if (s == null) return "null";
+        if (fm.stringWidth(s) <= maxWidth) return s;
+        while (s.length() > 1 && fm.stringWidth(s + "…") > maxWidth) {
+            s = s.substring(0, s.length() - 1);
+        }
+        return s + "…";
+    }
+
+    // -------------------------------------------------------------------------
+    // DANCE TILE DRAWING (unchanged from original)
+    // -------------------------------------------------------------------------
+
+    private void drawTile(Graphics2D graphics, WorldPoint point, Color color,
+                          @Nullable String label, Stroke borderStroke)
+    {
+        if (point == null) return;
+
+        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        if (playerLocation == null) return;
+
+        if (point.distanceTo(playerLocation) >= 32) return;
 
         LocalPoint lp = LocalPoint.fromWorld(Microbot.getClient(), point);
-        if (lp == null)
-        {
-            return;
-        }
+        if (lp == null) return;
 
         Polygon poly = Perspective.getCanvasTilePoly(Microbot.getClient(), lp);
-        if (poly != null)
-        {
+        if (poly != null) {
             OverlayUtil.renderPolygon(graphics, poly, color, new Color(0, 0, 0, 50), borderStroke);
         }
 
-        if (!Strings.isNullOrEmpty(label))
-        {
-            Point canvasTextLocation = Perspective.getCanvasTextLocation(Microbot.getClient(), graphics, lp, label, 0);
-            if (canvasTextLocation != null)
-            {
+        if (!Strings.isNullOrEmpty(label)) {
+            Point canvasTextLocation = Perspective.getCanvasTextLocation(
+                    Microbot.getClient(), graphics, lp, label, 0);
+            if (canvasTextLocation != null) {
                 OverlayUtil.renderTextLocation(graphics, canvasTextLocation, label, color);
             }
         }

--- a/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/combathotkeys/CombatHotkeysPlugin.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.combathotkeys;
 
 import com.google.inject.Provides;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.MenuAction;
 import net.runelite.api.events.MenuEntryAdded;
@@ -24,6 +25,11 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import javax.inject.Inject;
 import java.awt.*;
 import java.awt.event.KeyEvent;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static net.runelite.client.plugins.microbot.util.Global.sleep;
 
@@ -41,7 +47,57 @@ import static net.runelite.client.plugins.microbot.util.Global.sleep;
 )
 @Slf4j
 public class CombatHotkeysPlugin extends Plugin implements KeyListener {
-    public static final String version = "1.1.0";
+    // v1.1.2 — fix: replaced runOnSeperateThread (silently drops calls when a prior
+    //          task is still running on the shared ClientThread executor) with a
+    //          dedicated single-thread ExecutorService owned by this plugin.
+    //          Added debug logging + on-screen overlay panel to trace hotkey dispatch.
+    public static final String version = "1.1.2";
+
+    // -------------------------------------------------------------------------
+    // DEBUG STATE — read by CombatHotkeysOverlay to render the debug panel
+    // -------------------------------------------------------------------------
+
+    /** True while debug mode is on (toggled via config). */
+    @Getter
+    volatile boolean debugMode = false;
+
+    /** Last hotkey name that reached keyPressed. */
+    @Getter
+    final AtomicReference<String> lastKeyReceived = new AtomicReference<>("-");
+
+    /** Timestamp of the last keyPressed hit (epoch ms). */
+    @Getter
+    volatile long lastKeyTimestamp = 0;
+
+    /** Last action that was dispatched to the executor. */
+    @Getter
+    final AtomicReference<String> lastActionDispatched = new AtomicReference<>("-");
+
+    /** How many hotkey actions have been submitted to the executor total. */
+    @Getter
+    final AtomicInteger totalActionsSubmitted = new AtomicInteger(0);
+
+    /** How many hotkey actions completed without throwing. */
+    @Getter
+    final AtomicInteger totalActionsSucceeded = new AtomicInteger(0);
+
+    /** How many hotkey actions threw an exception. */
+    @Getter
+    final AtomicInteger totalActionsFailed = new AtomicInteger(0);
+
+    /** Last error message from the executor, if any. */
+    @Getter
+    final AtomicReference<String> lastError = new AtomicReference<>("-");
+
+    // -------------------------------------------------------------------------
+    // PRIVATE EXECUTOR
+    // runOnSeperateThread() uses a single scheduledFuture on the ClientThread
+    // singleton.  If *any* other plugin or the script loop has submitted a task
+    // that hasn't finished yet the gate `if (!scheduledFuture.isDone()) return`
+    // silently drops our call.  A plugin-owned executor has no such contention.
+    // -------------------------------------------------------------------------
+    private ExecutorService hotkeyExecutor;
+
     @Inject
     private CombatHotkeysConfig config;
 
@@ -62,22 +118,90 @@ public class CombatHotkeysPlugin extends Plugin implements KeyListener {
     @Inject
     private CombatHotkeysScript script;
 
+    // -------------------------------------------------------------------------
+    // LIFECYCLE
+    // -------------------------------------------------------------------------
 
     @Override
     protected void startUp() throws AWTException {
+        hotkeyExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "CombatHotkeys-executor");
+            t.setDaemon(true);
+            return t;
+        });
+        log.info("[CombatHotkeys] Plugin starting — executor created");
+
         keyManager.registerKeyListener(this);
 
         if (overlayManager != null) {
             overlayManager.add(overlay);
         }
         script.run(config);
+        log.info("[CombatHotkeys] Plugin started successfully (v{})", version);
     }
 
+    @Override
     protected void shutDown() {
         script.shutdown();
         keyManager.unregisterKeyListener(this);
         overlayManager.remove(overlay);
+
+        if (hotkeyExecutor != null) {
+            hotkeyExecutor.shutdownNow();
+            hotkeyExecutor = null;
+        }
+        log.info("[CombatHotkeys] Plugin shut down");
     }
+
+    // -------------------------------------------------------------------------
+    // HELPERS
+    // -------------------------------------------------------------------------
+
+    /**
+     * Submit an action to the plugin-owned executor.
+     *
+     * Every submission is logged so we can tell in the debug overlay (and in
+     * the RuneLite log) whether the keypress is reaching the dispatcher at all,
+     * whether the executor accepted it, and whether it threw.
+     */
+    private void dispatch(String actionName, Runnable action) {
+        if (hotkeyExecutor == null || hotkeyExecutor.isShutdown()) {
+            log.warn("[CombatHotkeys] dispatch('{}') — executor is null/shutdown, ignoring", actionName);
+            lastError.set("executor null/shutdown for: " + actionName);
+            return;
+        }
+
+        lastActionDispatched.set(actionName);
+        totalActionsSubmitted.incrementAndGet();
+        log.debug("[CombatHotkeys] Submitting '{}' to executor", actionName);
+
+        hotkeyExecutor.submit(() -> {
+            try {
+                log.debug("[CombatHotkeys] Executing '{}'", actionName);
+                action.run();
+                totalActionsSucceeded.incrementAndGet();
+                log.debug("[CombatHotkeys] '{}' completed OK", actionName);
+            } catch (Exception ex) {
+                totalActionsFailed.incrementAndGet();
+                lastError.set(actionName + ": " + ex.getMessage());
+                log.error("[CombatHotkeys] '{}' threw an exception: {}", actionName, ex.getMessage(), ex);
+            }
+        });
+    }
+
+    /** Record which key was just pressed and log it. */
+    private void recordKeyHit(String keyName) {
+        lastKeyReceived.set(keyName);
+        lastKeyTimestamp = Instant.now().toEpochMilli();
+        log.debug("[CombatHotkeys] keyPressed matched: '{}' | loggedIn={} | thread={}",
+                keyName,
+                Microbot.isLoggedIn(),
+                Thread.currentThread().getName());
+    }
+
+    // -------------------------------------------------------------------------
+    // KEY LISTENER
+    // -------------------------------------------------------------------------
 
     @Override
     public void keyTyped(KeyEvent e) {
@@ -85,141 +209,173 @@ public class CombatHotkeysPlugin extends Plugin implements KeyListener {
 
     @Override
     public void keyPressed(KeyEvent e) {
-        if (!Microbot.isLoggedIn()){
+        // Refresh debug flag from config on every keypress so toggling it in
+        // the config panel takes effect immediately without a restart.
+        debugMode = config.debugMode();
+
+        if (!Microbot.isLoggedIn()) {
+            if (debugMode) {
+                log.debug("[CombatHotkeys] keyPressed — not logged in, ignoring (keyCode={})", e.getKeyCode());
+            }
             return;
         }
 
-        if(config.dance().matches(e)){
+        if (config.dance().matches(e)) {
+            recordKeyHit("dance");
             e.consume();
             script.dance = !script.dance;
+            log.debug("[CombatHotkeys] dance toggled -> {}", script.dance);
         }
 
+        // ------------------------------------------------------------------
+        // OFFENSIVE PRAYERS
+        // ------------------------------------------------------------------
         if (config.offensiveMeleeKey().matches(e)) {
+            recordKeyHit("offensiveMelee");
             e.consume();
-            Rs2Prayer.toggle(config.offensiveMeleePrayer().getPrayer());
+            final Rs2PrayerEnum prayer = config.offensiveMeleePrayer().getPrayer();
+            dispatch("toggle prayer " + prayer.getName(), () -> Rs2Prayer.toggle(prayer));
         }
 
         if (config.offensiveRangeKey().matches(e)) {
+            recordKeyHit("offensiveRange");
             e.consume();
-            Rs2Prayer.toggle(config.offensiveRangePrayer().getPrayer());
+            final Rs2PrayerEnum prayer = config.offensiveRangePrayer().getPrayer();
+            dispatch("toggle prayer " + prayer.getName(), () -> Rs2Prayer.toggle(prayer));
         }
 
         if (config.offensiveMagicKey().matches(e)) {
+            recordKeyHit("offensiveMagic");
             e.consume();
-            Rs2Prayer.toggle(config.offensiveMagicPrayer().getPrayer());
+            final Rs2PrayerEnum prayer = config.offensiveMagicPrayer().getPrayer();
+            dispatch("toggle prayer " + prayer.getName(), () -> Rs2Prayer.toggle(prayer));
         }
 
         if (config.specialAttackKey().matches(e)) {
+            recordKeyHit("specialAttack");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                Rs2Combat.setSpecState(!Rs2Combat.getSpecState());
-                return null;
-            });
+            dispatch("toggle spec", () -> Rs2Combat.setSpecState(!Rs2Combat.getSpecState()));
         }
 
+        // ------------------------------------------------------------------
+        // DEFENSIVE / PROTECTION PRAYERS
+        // ------------------------------------------------------------------
         if (config.protectFromMagic().matches(e)) {
+            recordKeyHit("protectMagic");
             e.consume();
-            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC);
+            dispatch("toggle prayer PROTECT_MAGIC", () -> Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MAGIC));
         }
 
         if (config.protectFromMissles().matches(e)) {
+            recordKeyHit("protectRange");
             e.consume();
-            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_RANGE);
+            dispatch("toggle prayer PROTECT_RANGE", () -> Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_RANGE));
         }
 
         if (config.protectFromMelee().matches(e)) {
+            recordKeyHit("protectMelee");
             e.consume();
-            Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MELEE);
+            dispatch("toggle prayer PROTECT_MELEE", () -> Rs2Prayer.toggle(Rs2PrayerEnum.PROTECT_MELEE));
         }
 
+        // ------------------------------------------------------------------
+        // FOOD & POTIONS
+        // ------------------------------------------------------------------
         if (config.eatBestFood().matches(e)) {
+            recordKeyHit("eatBestFood");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                Rs2Player.useFood();
-                return null;
-            });
+            dispatch("eat best food", Rs2Player::useFood);
         }
 
         if (config.eatFastFood().matches(e)) {
+            recordKeyHit("eatFastFood");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                Rs2Player.useFastFood();
-                return null;
-            });
+            dispatch("eat fast food", Rs2Player::useFastFood);
         }
 
         if (config.drinkPrayerPotion().matches(e)) {
+            recordKeyHit("drinkPrayerPotion");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                Rs2Player.drinkPrayerPotion();
-                return null;
-            });
+            dispatch("drink prayer potion", Rs2Player::drinkPrayerPotion);
         }
 
+        // ------------------------------------------------------------------
+        // GEAR SWAPS
+        // ------------------------------------------------------------------
         if (config.gear1().matches(e)) {
+            recordKeyHit("gear1");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                equipGear(config.gearList1());
-                return null;
-            });
+            final String list = config.gearList1();
+            dispatch("equip gear 1", () -> equipGear(list));
         }
 
         if (config.gear2().matches(e)) {
+            recordKeyHit("gear2");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                equipGear(config.gearList2());
-                return null;
-            });
+            final String list = config.gearList2();
+            dispatch("equip gear 2", () -> equipGear(list));
         }
 
         if (config.gear3().matches(e)) {
+            recordKeyHit("gear3");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                equipGear(config.gearList3());
-                return null;
-            });
+            final String list = config.gearList3();
+            dispatch("equip gear 3", () -> equipGear(list));
         }
 
         if (config.gear4().matches(e)) {
+            recordKeyHit("gear4");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                equipGear(config.gearList4());
-                return null;
-            });
+            final String list = config.gearList4();
+            dispatch("equip gear 4", () -> equipGear(list));
         }
 
         if (config.gear5().matches(e)) {
+            recordKeyHit("gear5");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                equipGear(config.gearList5());
-                return null;
-            });
+            final String list = config.gearList5();
+            dispatch("equip gear 5", () -> equipGear(list));
         }
 
+        // ------------------------------------------------------------------
+        // ALCHEMY
+        // ------------------------------------------------------------------
         if (config.highAlchemyKey().matches(e)) {
+            recordKeyHit("highAlchemy");
             e.consume();
-            Microbot.getClientThread().runOnSeperateThread(() -> {
-                Rs2Magic.alch(config.itemToAlch(),50, 75);
-                return null;
-            });
+            final String item = config.itemToAlch();
+            dispatch("high alch " + item, () -> Rs2Magic.alch(item, 50, 75));
         }
     }
 
-
     private void equipGear(String gearListConfig) {
+        if (gearListConfig == null || gearListConfig.isBlank()) {
+            log.warn("[CombatHotkeys] equipGear called with empty/null gear list");
+            return;
+        }
         String[] itemIDs = gearListConfig.split(",");
-
         for (String value : itemIDs) {
-            int itemId = Integer.parseInt(value);
-            Rs2Inventory.equip(itemId);
-
-            int delay = Rs2Random.between(0, config.maxDelay());
-            sleep(delay);
+            value = value.trim();
+            if (value.isEmpty()) continue;
+            try {
+                int itemId = Integer.parseInt(value);
+                log.debug("[CombatHotkeys] Equipping item id={}", itemId);
+                Rs2Inventory.equip(itemId);
+                int delay = Rs2Random.between(0, config.maxDelay());
+                sleep(delay);
+            } catch (NumberFormatException ex) {
+                log.error("[CombatHotkeys] Invalid item ID in gear list: '{}'", value);
+                lastError.set("bad gear ID: " + value);
+            }
         }
     }
 
     @Override
     public void keyReleased(KeyEvent e) {}
+
+    // -------------------------------------------------------------------------
+    // MENU ENTRY EVENTS (dance tile marking)
+    // -------------------------------------------------------------------------
 
     @Subscribe
     public void onMenuEntryAdded(MenuEntryAdded event)


### PR DESCRIPTION
Prayer hotkeys were calling Rs2Prayer.toggle() directly on the key
listener thread, causing focus loss and input lag on every press.
Replaced runOnSeperateThread (silently drops calls when the shared
ClientThread future is busy) with a plugin-owned ExecutorService.
Also added a debug overlay panel toggled via config. Bump to v1.1.2.