### PR TITLE
fix(birdhouse): block rubber cap mushroom transports on Fossil Island

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsPlugin.java
@@ -26,7 +26,7 @@ import java.awt.*;
 )
 @Slf4j
 public class FornBirdhouseRunsPlugin extends Plugin {
-    final static String version = "1.1.2";
+    final static String version = "1.1.3";
     @Provides
     FornBirdhouseRunsConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(FornBirdhouseRunsConfig.class);

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsScript.java
@@ -20,6 +20,8 @@ import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.shortestpath.Restriction;
+import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
 
 import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 
@@ -147,7 +149,8 @@ public class FornBirdhouseRunsScript extends Script {
 
                 if (!Rs2Walker.disableTeleports && isOnFossilIsland()) {
                     Rs2Walker.disableTeleports = true;
-                    log.info("On Fossil Island — disabling teleports for remaining walks");
+                    blockRubberCapMushrooms();
+                    log.info("On Fossil Island — disabling teleports and rubber cap mushrooms for remaining walks");
                 }
 
                 boolean advanced = true;
@@ -309,10 +312,22 @@ public class FornBirdhouseRunsScript extends Script {
     public void shutdown() {
         super.shutdown();
         Rs2Walker.disableTeleports = false;
+        ShortestPathPlugin.getPathfinderConfig().setRestrictedTiles();
         initialized = false;
         botStatus = states.TELEPORTING;
         lastObservedStatus = null;
         stateEnteredAtMs = 0L;
+    }
+
+    private static void blockRubberCapMushrooms() {
+        Restriction[] restrictions = new Restriction[] {
+                new Restriction(3663, 3808, 0),
+                new Restriction(3664, 3808, 0),
+                new Restriction(3665, 3808, 0),
+                new Restriction(3666, 3809, 0),
+                new Restriction(3666, 3810, 0)
+        };
+        ShortestPathPlugin.getPathfinderConfig().setRestrictedTiles(restrictions);
     }
 
     /** Throttle for arrivedAndStill log lines (one per second per target). */


### PR DESCRIPTION
## Summary
- Pathfinder routes through rubber cap mushroom shortcuts on Fossil Island, causing the walker to stall (it plans the transport but can't execute it at runtime).
- Adds tile restrictions on all 5 rubber cap mushroom origin tiles once the player arrives on Fossil Island, preventing the pathfinder from routing through them.
- Restrictions are cleared on plugin shutdown so other plugins aren't affected.
- Version bump to 1.1.3.

Not to mention this transport needs recharging, otherwise it can and will kill you.

## Test plan
- [x] Run birdhouse plugin starting from a non-Fossil-Island location
- [x] Verify walker doesn't attempt rubber cap mushroom shortcuts between birdhouse areas
- [x] Verify mushroom tree (mycelium) transports still work normally
- [x] Verify restrictions are cleared after plugin stops