### PR TITLE
fix(cluesolver): client-thread safety for clue task classes

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/ClueSolverPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/ClueSolverPlugin.java
@@ -29,7 +29,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @PluginDependency(ClueScrollPlugin.class)
 public class ClueSolverPlugin extends Plugin {
 
-    final static String version = "1.0.2";
+    final static String version = "1.0.5";
     @Inject
     private ClueSolverScript clueSolverScript;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/AnagramClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/AnagramClueTask.java
@@ -3,7 +3,6 @@ package net.runelite.client.plugins.microbot.cluesolver.cluetask;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;
@@ -195,10 +194,6 @@ public class AnagramClueTask extends ClueTask {
         }
         log.warn("Dialogue handling failed.");
         return false;
-    }
-
-    private boolean hasArrived(Player player) {
-        return player.getWorldLocation().equals(location);
     }
 
     private boolean isWithinRadius(WorldPoint targetLocation, WorldPoint playerLocation, int radius) {

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/AnagramClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/AnagramClueTask.java
@@ -79,15 +79,16 @@ public class AnagramClueTask extends ClueTask {
     }
 
     private void processGameTick(GameTick event) {
-        Player player = client.getLocalPlayer();
-        if (player == null)
-            return;
+        // v1.0.5 fix: client-thread-safe location read. processGameTick runs in the
+        // background executor; direct client.getLocalPlayer() throws IllegalStateException.
+        net.runelite.api.coords.WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) return;
 
         switch (state) {
             case WALKING_TO_LOCATION:
-                if (hasArrived(player)) {
+                if (playerLocation.equals(location)) {
                     transitionToInteractionState();
-                } else if (isWithinRadius(location, player.getWorldLocation(), 3)) {
+                } else if (isWithinRadius(location, playerLocation, 3)) {
                     Rs2Walker.walkFastCanvas(location);
                 }
                 break;

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/ClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/ClueTask.java
@@ -3,7 +3,9 @@ package net.runelite.client.plugins.microbot.cluesolver.cluetask;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
+import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.cluesolver.ClueSolverPlugin;
 
 import java.util.concurrent.CompletableFuture;
@@ -64,5 +66,21 @@ public abstract class ClueTask implements Runnable {
      */
     protected boolean preTaskCheck() {
         return client != null && client.getLocalPlayer() != null;
+    }
+
+    /**
+     * v1.0.3 fix: thread-safe player location read.
+     *
+     * <p>Subclasses' processGameTick is submitted to a background executor (see EmoteClueTask
+     * line 97, CrypticClueTask line 77, etc.), so direct {@code client.getLocalPlayer().getWorldLocation()}
+     * calls from those code paths throw {@code IllegalStateException: must be called on client thread}.
+     * Use this helper instead -- it hops to the client thread, reads the location, and returns
+     * null if the player isn't available.
+     */
+    protected WorldPoint getPlayerLocationSafe() {
+        return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            if (client == null || client.getLocalPlayer() == null) return null;
+            return client.getLocalPlayer().getWorldLocation();
+        }).orElse(null);
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/ClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/ClueTask.java
@@ -71,11 +71,10 @@ public abstract class ClueTask implements Runnable {
     /**
      * v1.0.3 fix: thread-safe player location read.
      *
-     * <p>Subclasses' processGameTick is submitted to a background executor (see EmoteClueTask
-     * line 97, CrypticClueTask line 77, etc.), so direct {@code client.getLocalPlayer().getWorldLocation()}
-     * calls from those code paths throw {@code IllegalStateException: must be called on client thread}.
-     * Use this helper instead -- it hops to the client thread, reads the location, and returns
-     * null if the player isn't available.
+     * <p>Subclasses submit {@code processGameTick} to a background executor, so direct
+     * {@code client.getLocalPlayer().getWorldLocation()} calls from those code paths throw
+     * {@code IllegalStateException: must be called on client thread}. Use this helper instead --
+     * it hops to the client thread, reads the location, and returns null if the player isn't available.
      */
     protected WorldPoint getPlayerLocationSafe() {
         return Microbot.getClientThread().runOnClientThreadOptional(() -> {

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CoordinateClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CoordinateClueTask.java
@@ -95,12 +95,13 @@ public class CoordinateClueTask extends ClueTask {
     }
 
     private void processGameTick(GameTick event) {
-        Player player = client.getLocalPlayer();
-        if (player == null) return;
+        // v1.0.5 fix: client-thread-safe location read.
+        net.runelite.api.coords.WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) return;
 
         switch (state) {
             case WALKING_TO_LOCATION:
-                if (isWithinRadius(location, player.getWorldLocation(), 5)) {
+                if (isWithinRadius(location, playerLocation, 5)) {
                     log.info("Arrived at coordinate clue location.");
                     state = (enemy != null) ? State.FIGHTING_ENEMY : State.DIGGING;
                 }
@@ -153,8 +154,10 @@ public class CoordinateClueTask extends ClueTask {
     }
 
     private boolean prepareToDig() {
-        Player player = client.getLocalPlayer();
-        if (!isWithinRadius(location, player.getWorldLocation(), 1)) {
+        // v1.0.5 fix: client-thread-safe location read. Called from processGameTick (background executor).
+        net.runelite.api.coords.WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) return false;
+        if (!isWithinRadius(location, playerLocation, 1)) {
             log.info("Adjusting position to exact location.");
             Rs2Walker.walkFastCanvas(location);
             return false;

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CoordinateClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CoordinateClueTask.java
@@ -3,8 +3,6 @@ package net.runelite.client.plugins.microbot.cluesolver.cluetask;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
-import net.runelite.api.NPC;
-import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CrypticClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CrypticClueTask.java
@@ -85,8 +85,14 @@ public class CrypticClueTask extends ClueTask {
     }
 
     private void processGameTick(GameTick event) {
-        Player player = client.getLocalPlayer();
-        WorldPoint playerLocation = player.getWorldLocation();
+        // v1.0.3 fix: read player location via the client-thread-safe helper instead of
+        // calling client.getLocalPlayer().getWorldLocation() directly from the background
+        // executor (which throws IllegalStateException: must be called on client thread).
+        WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) {
+            log.debug("Player location unavailable; will retry next tick");
+            return;
+        }
         WorldPoint clueLocation = clue.getLocation(clueScrollPlugin);
 
         switch (state) {

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CrypticClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/CrypticClueTask.java
@@ -2,8 +2,6 @@ package net.runelite.client.plugins.microbot.cluesolver.cluetask;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.NPC;
-import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/EmoteClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/EmoteClueTask.java
@@ -131,7 +131,15 @@ public class EmoteClueTask extends ClueTask {
 
     private void handleWalkingToLocation() {
         WorldPoint location = clue.getLocation(clueScrollPlugin);
-        if (client.getLocalPlayer().getWorldLocation().equals(location)) {
+        // v1.0.3 fix: read player location via the client-thread-safe helper instead of
+        // calling client.getLocalPlayer().getWorldLocation() directly from the background
+        // executor (which throws IllegalStateException: must be called on client thread).
+        WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) {
+            log.debug("Player location unavailable; will retry next tick");
+            return;
+        }
+        if (playerLocation.equals(location)) {
             log.info("Arrived at Emote Clue location.");
             state = State.PERFORMING_EMOTES;
         } else {

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/MusicClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/MusicClueTask.java
@@ -85,12 +85,13 @@ public class MusicClueTask extends ClueTask {
     }
 
     private void processGameTick(GameTick event) {
-        Player player = client.getLocalPlayer();
-        if (player == null) return;
+        // v1.0.5 fix: client-thread-safe location read.
+        net.runelite.api.coords.WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) return;
 
         switch (state) {
             case WALKING_TO_LOCATION:
-                if (isWithinRadius(location, player.getWorldLocation(), 5)) {
+                if (isWithinRadius(location, playerLocation, 5)) {
                     log.info("Arrived at music clue location.");
                     state = State.PLAYING_SONG;
                 }

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/MusicClueTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/MusicClueTask.java
@@ -2,8 +2,6 @@ package net.runelite.client.plugins.microbot.cluesolver.cluetask;
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.NPC;
-import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;

--- a/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/RequirementHandlerTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cluesolver/cluetask/RequirementHandlerTask.java
@@ -90,7 +90,18 @@ public class RequirementHandlerTask extends ClueTask {
     private void walkToBank() {
         if (Rs2Bank.isOpen()) {
             fetchNextItem();
-        } else if (client.getLocalPlayer().getWorldLocation().distanceTo(Rs2Bank.getNearestBank().getWorldPoint()) > 10) {
+            return;
+        }
+        // v1.0.4 fix: read player location via the client-thread-safe helper. walkToBank() may
+        // be called from off-client-thread code paths (executeTask flow). Direct
+        // client.getLocalPlayer().getWorldLocation() throws IllegalStateException, which
+        // cascaded into "Failed to open the bank" + walker deadlock.
+        net.runelite.api.coords.WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) {
+            log.debug("Player location unavailable in walkToBank; will retry next tick");
+            return;
+        }
+        if (playerLocation.distanceTo(Rs2Bank.getNearestBank().getWorldPoint()) > 10) {
             Rs2Bank.walkToBankAndUseBank();
         } else {
             openBank();
@@ -149,7 +160,13 @@ public class RequirementHandlerTask extends ClueTask {
     public void onGameTick(GameTick event) {
         if (Rs2Bank.isOpen() && currentRequirement == null) {
             fetchNextItem();
-        } else if (!Rs2Bank.isOpen() && client.getLocalPlayer().getWorldLocation().distanceTo(Rs2Bank.getNearestBank().getWorldPoint()) <= 5) {
+            return;
+        }
+        // v1.0.4 fix: defensive client-thread-safe read. onGameTick is @Subscribe-annotated so
+        // it normally runs on the client thread, but using the helper is harmless and consistent.
+        net.runelite.api.coords.WorldPoint playerLocation = getPlayerLocationSafe();
+        if (playerLocation == null) return;
+        if (!Rs2Bank.isOpen() && playerLocation.distanceTo(Rs2Bank.getNearestBank().getWorldPoint()) <= 5) {
             openBank();
         }
     }


### PR DESCRIPTION
## Summary

Six clue task classes were calling `client.getLocalPlayer().getWorldLocation()` from the script thread (the background executor that clue tasks are scheduled onto). Under Microbot 2.6.x this throws `IllegalStateException: must be called on client thread`, freezing the clue solver mid-travel with no in-game indication of the failure.

This PR adds a `getPlayerLocationSafe()` helper to the `ClueTask` base class that wraps the read with `Microbot.getClientThread().runOnClientThreadOptional(...)`. All six subclasses updated to use the safe accessor.

## Affected files

- `cluesolver/ClueSolverPlugin.java` (version bump only: 1.0.2 -> 1.0.5)
- `cluesolver/cluetask/ClueTask.java` (added helper)
- `cluesolver/cluetask/AnagramClueTask.java`
- `cluesolver/cluetask/CoordinateClueTask.java`
- `cluesolver/cluetask/CrypticClueTask.java`
- `cluesolver/cluetask/EmoteClueTask.java`
- `cluesolver/cluetask/MusicClueTask.java`
- `cluesolver/cluetask/RequirementHandlerTask.java`

A follow-up cleanup commit (`chore: address Copilot review feedback`) removes a dead `hasArrived(Player)` method, unused Player/NPC imports, and rewords the JavaDoc to drop hardcoded line numbers.

## Test plan

- [x] Enable Clue Solver plugin
- [x] Equip a clue scroll (Beginner / Easy / etc.)
- [x] Trigger "travel to clue location"
- [x] Confirm no `IllegalStateException` in the client log
- [x] Confirm clue completes without the plugin freezing

## Repro context

Caught while soak-testing on Microbot 2.6.2. The `IllegalStateException` only surfaces in the client log AFTER the freeze, with no in-game warning. The wrapper pattern matches existing Microbot conventions for client-thread reads (e.g. `Microbot.getClientThread().runOnClientThreadOptional(() -> client.getSkillExperience(skill))` is used widely across the Hub).