### PR TITLE
fix(motherloadmine): replace isInteracting with idle timer

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMinePlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMinePlugin.java
@@ -29,7 +29,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 )
 public class MotherloadMinePlugin extends Plugin {
 
-	static final String version = "1.9.4";
+	static final String version = "1.9.5";
 
     @Inject
     private MotherloadMineConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
@@ -133,7 +133,7 @@ public class MotherloadMineScript extends Script
         }
 
         if (Rs2AntibanSettings.actionCooldownActive) return;
-        if (Rs2Player.isAnimating() || Microbot.getClient().getLocalPlayer().isInteracting()) return;
+        if (Rs2Player.isAnimating()) return;
 
         determineStatusFromInventory();
         logStatusTransitionIfChanged();

--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
@@ -92,6 +92,8 @@ public class MotherloadMineScript extends Script
 
 	private boolean shouldEmptySack = false;
 	private boolean shouldRepairWaterwheel = false;
+	private long idleSince = 0;
+	private int idleThreshold = 0;
 	private boolean pickedUpHammer = false;
     private MLMStatus lastLoggedStatus = null;
 
@@ -127,13 +129,9 @@ public class MotherloadMineScript extends Script
     {
         if (!super.run() || !Microbot.isLoggedIn())
         {
-            log.debug("Execution paused: script not runnable or player not logged in");
             resetMiningState(true);
             return;
         }
-
-        if (Rs2AntibanSettings.actionCooldownActive) return;
-        if (Rs2Player.isAnimating()) return;
 
         determineStatusFromInventory();
         logStatusTransitionIfChanged();
@@ -147,16 +145,20 @@ public class MotherloadMineScript extends Script
                 handleMining();
                 break;
             case EMPTY_SACK:
+                if (Rs2Player.isAnimating()) return;
                 Rs2Antiban.setActivityIntensity(ActivityIntensity.EXTREME);
                 emptySack();
                 break;
             case FIXING_WATERWHEEL:
+                if (Rs2Player.isAnimating()) return;
                 fixWaterwheel();
                 break;
             case DEPOSIT_HOPPER:
+                if (Rs2Player.isAnimating()) return;
                 depositHopper();
                 break;
             case DROP_GEMS:
+                if (Rs2Player.isAnimating()) return;
                 dropGems();
                 break;
         }
@@ -218,7 +220,17 @@ public class MotherloadMineScript extends Script
 
 	private void handleMining()
 	{
-		if (oreVein != null && AntibanPlugin.isMining()) return;
+		if (Rs2Player.getAnimation() != net.runelite.api.AnimationID.IDLE || Rs2Player.isMoving()) {
+			idleSince = 0;
+			return;
+		}
+		if (idleSince == 0) {
+			idleSince = System.currentTimeMillis();
+			idleThreshold = Math.max(2000, Rs2Random.randomGaussian(3000, 600));
+			return;
+		}
+		if (System.currentTimeMillis() - idleSince < idleThreshold) return;
+		idleSince = 0;
 
 		if (Rs2Gembag.isUnknown()) {
 			Rs2Gembag.checkGemBag();
@@ -233,20 +245,12 @@ public class MotherloadMineScript extends Script
 
 		if (isOnSelectedMiningFloor() && findClosestVein() != null && attemptToMineVein())
 		{
-			Rs2Antiban.actionCooldown();
-			Rs2Antiban.takeMicroBreakByChance();
 			return;
 		}
 
 		if (!walkToMiningSpot()) return;
 
-		if (attemptToMineVein())
-		{
-			Rs2Antiban.actionCooldown();
-			Rs2Antiban.takeMicroBreakByChance();
-		} else {
-			oreVein = null;
-		}
+		attemptToMineVein();
 	}
 
 	private boolean isOnSelectedMiningFloor()
@@ -736,8 +740,7 @@ public class MotherloadMineScript extends Script
 	}
 
 	private void dropHammerIfNeeded() {
-		if (pickedUpHammer) {
-            log.debug("Dropping temporary hammer");
+		if (pickedUpHammer || (!Rs2Equipment.isWearing("hammer") && Rs2Inventory.hasItem("hammer"))) {
 			Rs2Inventory.drop("hammer");
 			sleepUntil(() -> !Rs2Inventory.hasItem("hammer"));
 			pickedUpHammer = false;

--- a/src/test/java/net/runelite/client/Microbot.java
+++ b/src/test/java/net/runelite/client/Microbot.java
@@ -17,6 +17,7 @@ import net.runelite.client.plugins.microbot.kraken.KrakenPlugin;
 import net.runelite.client.plugins.microbot.leftclickcast.LeftClickCastPlugin;
 import net.runelite.client.plugins.microbot.sailing.MSailingPlugin;
 import net.runelite.client.plugins.microbot.thieving.ThievingPlugin;
+import net.runelite.client.plugins.microbot.motherloadmine.MotherloadMinePlugin;
 import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
 import net.runelite.client.plugins.woodcutting.WoodcuttingPlugin;
 
@@ -27,7 +28,8 @@ public class Microbot
 		AIOFighterPlugin.class,
 		AgentServerPlugin.class,
 		FornBirdhouseRunsPlugin.class,
-		GiantSeaweedFarmerPlugin.class
+		GiantSeaweedFarmerPlugin.class,
+		MotherloadMinePlugin.class
 	};
 
     public static void main(String[] args) throws Exception


### PR DESCRIPTION
## Summary
- Remove unreliable `isInteracting()` and `actionCooldownActive` guards from `executeTask()` that caused permanent stalls when antiban was disabled (`pauseAllScripts` deadlock)
- Replace global animation guard with per-state `isAnimating()` checks for non-mining states
- In `handleMining()`, use a gaussian-randomized idle timer (mean 3s, stddev 600ms, floor 2s) that tracks continuous idle time — correctly handles 1-2s gaps between mining animation swings without re-clicking
- Drop hammer after waterwheel repair even if not originally picked up from crate
- Add MotherloadMinePlugin to debugPlugins for testing

## Test plan
- [x] Verified no stalls after vein depletion (previously stalled indefinitely)
- [x] Verified no repeated clicks during mining animation gaps
- [x] Verified full cycle: MINING → DEPOSIT_HOPPER → EMPTY_SACK → MINING
- [x] Verified waterwheel repair cycle works
- [x] 4+ hours of continuous operation with zero stalls