### PR TITLE
fix(FarmTreeRun): skip walker for nearby patches, respect master toggles, fix rake

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunPlugin.java
@@ -30,7 +30,7 @@ import java.awt.*;
 )
 @Slf4j
 public class FarmTreeRunPlugin extends Plugin {
-    public static final String version = "1.2.0";
+    public static final String version = "1.2.1";
     @Inject
     private FarmTreeRunConfig config;
     @Provides

--- a/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/farmtreerun/FarmTreeRunScript.java
@@ -388,7 +388,7 @@ public class FarmTreeRunScript extends Script {
     }
 
     private boolean validateSpecialPatches(FarmTreeRunConfig config) {
-        if (config.priffddinasCrystalTreePatch()) {
+        if (config.enableTrees() && config.priffddinasCrystalTreePatch()) {
             int farmingLevel = Rs2Player.getRealSkillLevel(Skill.FARMING);
             if (farmingLevel < 74) {
                 Microbot.showMessage("Prifddinas Crystal tree requires 74 Farming (you have " + farmingLevel + "). Disable the Prifddinas patch or train Farming before starting. Shutting down.");
@@ -413,7 +413,7 @@ public class FarmTreeRunScript extends Script {
     }
 
     private void dropCrap() {
-        int[] junk = {ItemID.EMPTY_PLANT_POT, ItemID.BUCKET, ItemID.WEEDS};
+        int[] junk = {ItemID.EMPTY_PLANT_POT, ItemID.BUCKET};
         for (int id : junk) {
             if (Rs2Inventory.hasItem(id)) {
                 Rs2Inventory.dropAll(id);
@@ -423,8 +423,10 @@ public class FarmTreeRunScript extends Script {
     }
 
     private boolean walkToLocation(WorldPoint location) {
-        Rs2Walker.walkTo(location);
-        sleepUntil(() -> Rs2Player.distanceTo(location) < 16);
+        if (Rs2Player.distanceTo(location) >= 16) {
+            Rs2Walker.walkTo(location);
+            sleepUntil(() -> Rs2Player.distanceTo(location) < 16);
+        }
         return Rs2Player.distanceTo(location) < 16;
     }
 
@@ -476,7 +478,7 @@ public class FarmTreeRunScript extends Script {
                 }
             }
 
-            if(config.fossilTreePatch()){
+            if(config.enableHardTrees() && config.fossilTreePatch()){
                 if (Rs2Bank.hasItem(ItemID.DIGSITE_PENDANT_5)) {
                     items.add(new FarmingItem(ItemID.DIGSITE_PENDANT_5, 1));
                 } else if (Rs2Bank.hasItem(ItemID.DIGSITE_PENDANT_4)) {
@@ -499,7 +501,7 @@ public class FarmTreeRunScript extends Script {
                 }
             }
 
-            if (config.useSkillsNecklace() && (config.farmingGuildTreePatch() || config.farmingGuildFruitTreePatch())) {
+            if (config.useSkillsNecklace() && ((config.enableTrees() && config.farmingGuildTreePatch()) || (config.enableFruitTrees() && config.farmingGuildFruitTreePatch()))) {
                 if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE6)) {
                     items.add(new FarmingItem(ItemID.SKILLS_NECKLACE6, 1, false, true));
                 } else if (Rs2Bank.hasItem(ItemID.SKILLS_NECKLACE5)) {
@@ -543,19 +545,19 @@ public class FarmTreeRunScript extends Script {
             if (hardTreeSaplingsCount > 0)
                 items.add(new FarmingItem(selectedHardTree.getSaplingId(), hardTreeSaplingsCount));
 
-            if (config.protectTrees() && regularTreeSaplingsCount > 0)
+            if (config.enableTrees() && config.protectTrees() && regularTreeSaplingsCount > 0)
                 items.add(new FarmingItem(selectedTree.getPaymentId(), selectedTree.getPaymentAmount() * regularTreeSaplingsCount, true));
 
-            if (config.protectHardTrees())
+            if (config.enableHardTrees() && config.protectHardTrees())
                 items.add(new FarmingItem(selectedHardTree.getPaymentId(), selectedHardTree.getPaymentAmount() * hardTreeSaplingsCount, true));
 
-            if (config.protectFruitTrees())
+            if (config.enableFruitTrees() && config.protectFruitTrees())
                 items.add(new FarmingItem(selectedFruitTree.getPaymentId(), selectedFruitTree.getPaymentAmount() * fruitTreeSaplingsCount, true));
 
-            if (config.taverleyTreePatch())
+            if (config.enableTrees() && config.taverleyTreePatch())
                 items.add(new FarmingItem(ItemID.TAVERLEY_TELEPORT, 1, false, true));
 
-            if (config.lletyaFruitTreePatch()) {
+            if (config.enableFruitTrees() && config.lletyaFruitTreePatch()) {
                 if (Rs2Bank.hasItem(ItemID.ETERNAL_TELEPORT_CRYSTAL)) {
                     items.add(new FarmingItem(ItemID.ETERNAL_TELEPORT_CRYSTAL, 1));
                 } else if (Rs2Bank.hasItem(ItemID.TELEPORT_CRYSTAL_1)) {
@@ -881,7 +883,8 @@ public class FarmTreeRunScript extends Script {
         System.out.println("Raking the patch...");
 
         Rs2GameObject.interact(treePatch, "rake");
-        Rs2Player.waitForXpDrop(Skill.FARMING, 10000);
+        sleepUntil(() -> !Rs2GameObject.hasAction(Rs2GameObject.findObjectComposition(treePatch.getId()), "Rake"), 30000);
+        sleep(400, 1200);
         if (Rs2Inventory.hasItem(ItemID.WEEDS)) {
             Rs2Inventory.dropAll(ItemID.WEEDS);
             sleepUntil(() -> !Rs2Inventory.hasItem(ItemID.WEEDS), 5000);


### PR DESCRIPTION
## Summary
- **Skip Rs2Walker for nearby interactions**: `walkToLocation` now checks distance before invoking the walker — when the player is already within 16 tiles of the patch (i.e. right next to the gardener or leprechaun), Rs2Walker is not called
- **Master toggles gate all sub-checks**: Disabling a tree type (hardwood/fruit/regular) via `enableHardTrees`/`enableFruitTrees`/`enableTrees` now skips all related banking withdrawals (digsite pendant, skills necklace, teleports, protection payments) and validation (Prifddinas level/quest check)
- **Rake waits for completion**: Raking now waits until the patch loses its Rake action before dropping weeds once, instead of dropping mid-rake after every XP drop

## Test plan
- [x] Run a tree run with only fruit trees enabled — verify no hardwood/regular tree items are withdrawn
- [x] Run a tree run with only regular trees — verify no fruit tree teleports or protection items are withdrawn
- [x] Observe that Rs2Walker is not invoked when moving between patch, gardener, and leprechaun
- [x] Verify raking a weedy patch completes fully before weeds are dropped