### PR TITLE
fix(RoguesDen): reset potion bank flags on plugin init

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenPlugin.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 )
 @Slf4j
 public class RoguesDenPlugin extends Plugin {
-    public static final String version = "1.0.0";
+    public static final String version = "1.0.1";
     private final HashMap<TileObject, Tile> obstaclesHull = new HashMap();
     private final HashMap<TileObject, Tile> obstaclesTile = new HashMap();
     private boolean hasGem;

--- a/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/roguesden/RoguesDenScript.java
@@ -144,6 +144,8 @@ public class RoguesDenScript extends Script {
                         return;
                     }
 
+                    hasStaminaPotionInBank = true;
+                    hasEnergyPotionInBank = true;
                     Rs2Camera.setPitch(Rs2Random.between(300, 383));
                     initObstacles();
                     Microbot.enableAutoRunOn = false;


### PR DESCRIPTION
## Summary
- `hasStaminaPotionInBank` and `hasEnergyPotionInBank` were not reset when the plugin was toggled off and back on, causing the script to permanently skip potion withdrawal for the rest of the client session.
- Moved the flag reset into the `init` block so a fresh plugin start always re-checks the bank for potions.

## Test plan
- [x] Start Rogues' Den plugin with stamina/energy potions in bank, verify it withdraws and drinks them
- [x] Stop and restart the plugin, verify it withdraws and drinks potions again on the next round