### PR TITLE
feat(EventDismiss): add config toggle to hide lamp info overlay

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissConfig.java
@@ -59,4 +59,15 @@ public interface EventDismissConfig extends Config {
     default boolean checkForLamps() {
         return false;
     }
+
+    @ConfigItem(
+            name = "Show Info Panel",
+            keyName = "showOverlay",
+            position = 4,
+            section = lampSection,
+            description = "Show the lamp info overlay panel"
+    )
+    default boolean showOverlay() {
+        return true;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissOverlay.java
@@ -22,6 +22,10 @@ public class EventDismissOverlay extends OverlayPanel {
 
     @Override
     public Dimension render(Graphics2D graphics) {
+        if (!config.showOverlay()) {
+            return null;
+        }
+
         boolean lampFeaturesActive = config.genieAction() == EventAction.ACCEPT
                 || config.countCheckAction() == EventAction.ACCEPT
                 || config.checkForLamps();

--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissPlugin.java
@@ -26,7 +26,7 @@ import java.awt.*;
 )
 @Slf4j
 public class EventDismissPlugin extends Plugin {
-    public static final String version = "2.0.0";
+    public static final String version = "2.1.0";
 
     @Inject
     private EventDismissConfig config;


### PR DESCRIPTION
## Summary
- Adds a **Show Info Panel** config toggle (default `true`) in the Lamp Events section so users can hide the overlay while keeping lamp features active
- Guard clause in `EventDismissOverlay.render()` returns `null` when disabled — follows the same pattern as HunterKebbits, GauntletHelper, etc.
- Version bump `2.0.0` → `2.1.0`

## Test plan
- [x] Enable EventDismiss plugin with a lamp feature active — overlay should appear
- [x] Toggle "Show Info Panel" off — overlay should disappear
- [x] Toggle it back on — overlay should reappear
- [x] Disable all lamp features with overlay toggle on — overlay should still hide (existing behavior)