### PR TITLE
feat(aiofighter): telegrab unreachable loot

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -322,7 +322,7 @@ public interface AIOFighterConfig extends Config {
     @ConfigItem(
             keyName = "telegrabUnreachableLoot",
             name = "Telegrab unreachable loot",
-            description = "Use Telekinetic Grab (needs 33 Magic + law & air runes) to pick up wanted loot you can't walk to, e.g. caged or fenced-off drops. Off = walk to loot as normal.",
+            description = "Use Telekinetic Grab (needs 33 Magic + law & air runes) to pick up wanted loot you can't walk to, e.g. caged or fenced-off drops. If you can't cast (missing runes/level) that loot is skipped, not walked to. Off = walk to loot as normal.",
             position = 60,
             section = lootSection
     )

--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterConfig.java
@@ -320,6 +320,17 @@ public interface AIOFighterConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "telegrabUnreachableLoot",
+            name = "Telegrab unreachable loot",
+            description = "Use Telekinetic Grab (needs 33 Magic + law & air runes) to pick up wanted loot you can't walk to, e.g. caged or fenced-off drops. Off = walk to loot as normal.",
+            position = 60,
+            section = lootSection
+    )
+    default boolean toggleTelegrabUnreachableLoot() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "Bury Bones",
             name = "Bury Bones",
             description = "Picks up and Bury Bones. Casts Sinister Offering if possible.",

--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/AIOFighterPlugin.java
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
 )
 @Slf4j
 public class AIOFighterPlugin extends Plugin {
-    public static final String version = "2.1.7";
+    public static final String version = "2.2.0";
     public static boolean needShopping = false;
     private static final String SET = "Set";
     private static final String CENTER_TILE = ColorUtil.wrapWithColorTag("Center Tile", JagexColors.MENU_TARGET);

--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
@@ -33,6 +33,13 @@ public class LootScript extends Script {
     private static final int DEFAULT_MIN_STACK_EXCLUSIVE_ARROWS = 9; // allow 2+
     private static final int DEFAULT_MIN_STACK_EXCLUSIVE_RUNES  = 1; // allow 2+
 
+    // Telegrab (unreachable-loot) tuning
+    private static final int TELEGRAB_ARM_MIN_MS = 300;       // min wait for the spell to arm before clicking
+    private static final int TELEGRAB_ARM_MAX_MS = 500;       // max wait for the spell to arm
+    private static final int TELEGRAB_RANGE_PADDING = 2;      // extra tiles beyond player->item distance when locating it
+    private static final int TELEGRAB_FALLBACK_RANGE = 10;    // search radius if player location is unavailable
+    private static final int TELEGRAB_GRAB_TIMEOUT_MS = 3000; // max wait for the grabbed pile to disappear
+
     private int minFreeSlots = 0;
 
     public LootScript() {}
@@ -107,22 +114,34 @@ public class LootScript extends Script {
             if (wp != null && !Rs2Tile.isTileReachable(wp)) {
                 // Unreachable wanted item (e.g. behind the bars at a caged demon): Telekinetic
                 // Grab it rather than walking, which would just spam "I can't reach that!".
+                // If we can't cast (missing runes/level) the item is skipped, not walked to.
                 final int id = groundItem.getId();
-                if (Rs2Magic.canCast(MagicAction.TELEKINETIC_GRAB) && Rs2Magic.cast(MagicAction.TELEKINETIC_GRAB)) {
-                    sleep(300, 500); // let the spell arm before clicking the item
-                    final WorldPoint me = Rs2Player.getWorldLocation();
-                    final int range = (me == null ? 10 : me.distanceTo(wp) + 2);
-                    Rs2GroundItem.interact(id, "Cast", range);
-                    // Block until this pile is actually grabbed (gone), bounded. Casting once per
-                    // pile stops the loot loop from re-casting mid-grab (the spellbook stutter)
-                    // and keeps the cast/reachability calls off the client thread's hot path,
-                    // which was saturating it and causing TimeoutExceptions in other scripts.
-                    sleepUntil(() -> Rs2GroundItem.getGroundItems().get(wp, id) == null, 3000);
+                if (Rs2Magic.canCast(MagicAction.TELEKINETIC_GRAB)) {
+                    final long before = groundCountById(id);
+                    if (Rs2Magic.cast(MagicAction.TELEKINETIC_GRAB)) {
+                        sleep(TELEGRAB_ARM_MIN_MS, TELEGRAB_ARM_MAX_MS); // let the spell arm before clicking
+                        final WorldPoint me = Rs2Player.getWorldLocation();
+                        final int range = (me == null ? TELEGRAB_FALLBACK_RANGE : me.distanceTo(wp) + TELEGRAB_RANGE_PADDING);
+                        Rs2GroundItem.interact(id, "Cast", range);
+                        // interact() grabs the nearest pile of this id; wait until a pile of this id
+                        // is removed (the same id selector the cast used), bounded. Casting once per
+                        // pile and blocking here stops the loot loop from re-casting mid-grab (the
+                        // spellbook stutter) and keeps cast/reachability calls off the client-thread
+                        // hot path, which was saturating it and causing TimeoutExceptions elsewhere.
+                        sleepUntil(() -> groundCountById(id) < before, TELEGRAB_GRAB_TIMEOUT_MS);
+                    }
                 }
                 return; // never walk to unreachable loot while this option is on
             }
         }
         Rs2GroundItem.coreLoot(groundItem);
+    }
+
+    /** Number of ground-item piles of the given id currently tracked nearby. */
+    private static long groundCountById(int id) {
+        return Rs2GroundItem.getGroundItems().values().stream()
+                .filter(gi -> gi.getId() == id)
+                .count();
     }
 
     /**

--- a/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/aiofighter/loot/LootScript.java
@@ -12,7 +12,14 @@ import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2LootEngine;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.tile.Rs2Tile;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.skillcalculator.skills.MagicAction;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -59,7 +66,7 @@ public class LootScript extends Script {
                 params.setEatFoodForSpace(config.eatFoodForSpace());
 
                 Rs2LootEngine.Builder builder = Rs2LootEngine.with(params)
-                        .withLootAction(Rs2GroundItem::coreLoot);
+                        .withLootAction(gi -> lootOrTelegrab(gi, config));
 
                 // custom filter
                 if (config.looterStyle() == DefaultLooterStyle.ITEM_LIST || config.looterStyle() == DefaultLooterStyle.MIXED) {
@@ -83,6 +90,39 @@ public class LootScript extends Script {
         }, 0, 200, TimeUnit.MILLISECONDS);
 
         return true;
+    }
+
+    /**
+     * Loots a ground item by walking to it (default), or by Telekinetic Grab when the item
+     * is unreachable on foot and the "Telegrab unreachable loot" option is enabled.
+     *
+     * <p>Handles spots like the caged Lesser Demon where drops land behind bars: walking
+     * there just yields "I can't reach that!". When telegrab is enabled and we can cast
+     * (33 Magic + law/air runes) we Telekinetic Grab the item instead. While the option is
+     * on, unreachable items are never walked to, which stops the "can't reach" spam.
+     */
+    private void lootOrTelegrab(GroundItem groundItem, AIOFighterConfig config) {
+        if (config.toggleTelegrabUnreachableLoot()) {
+            final WorldPoint wp = groundItem.getLocation();
+            if (wp != null && !Rs2Tile.isTileReachable(wp)) {
+                // Unreachable wanted item (e.g. behind the bars at a caged demon): Telekinetic
+                // Grab it rather than walking, which would just spam "I can't reach that!".
+                final int id = groundItem.getId();
+                if (Rs2Magic.canCast(MagicAction.TELEKINETIC_GRAB) && Rs2Magic.cast(MagicAction.TELEKINETIC_GRAB)) {
+                    sleep(300, 500); // let the spell arm before clicking the item
+                    final WorldPoint me = Rs2Player.getWorldLocation();
+                    final int range = (me == null ? 10 : me.distanceTo(wp) + 2);
+                    Rs2GroundItem.interact(id, "Cast", range);
+                    // Block until this pile is actually grabbed (gone), bounded. Casting once per
+                    // pile stops the loot loop from re-casting mid-grab (the spellbook stutter)
+                    // and keeps the cast/reachability calls off the client thread's hot path,
+                    // which was saturating it and causing TimeoutExceptions in other scripts.
+                    sleepUntil(() -> Rs2GroundItem.getGroundItems().get(wp, id) == null, 3000);
+                }
+                return; // never walk to unreachable loot while this option is on
+            }
+        }
+        Rs2GroundItem.coreLoot(groundItem);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds an opt-in **"Telegrab unreachable loot"** toggle to AIO Fighter's Loot section (default **off**). When enabled, wanted loot the player can't reach on foot (for example, drops behind the bars at the caged Lesser Demon) is collected with Telekinetic Grab instead of walking to it, which otherwise just spams "I can't reach that!". With the toggle off, looting behaviour is unchanged.

### How it works
- Reachability is checked with `Rs2Tile.isTileReachable` (strict collision flood-fill), so only genuinely unreachable tiles trigger a grab and reachable loot is walked to as before. (`Rs2Walker.canReach` is unsuitable here: it returns true when the player can path to within ~2 tiles of the target, which holds for caged drops you can't actually stand on.)
- It plugs into the existing `Rs2LootEngine` loot action, so it only ever telegrabs items the current loot config already selects (item list / GE value / ashes / bones / etc.). No duplicated selection logic.
- It casts once per pile and waits for the grab to resolve before continuing, keeping the cast and reachability calls off the client-thread hot path (a naive per-tick re-cast saturated the client thread and produced `TimeoutException`s in other scripts).
- Requires 33 Magic plus law and air runes (guarded by `Rs2Magic.canCast`); if it can't cast, the item is skipped rather than walked to.

## Affected files
- `aiofighter/AIOFighterConfig.java` (new `toggleTelegrabUnreachableLoot` option, Loot section, default off)
- `aiofighter/loot/LootScript.java` (telegrab-aware loot action)
- `aiofighter/AIOFighterPlugin.java` (version bump 2.1.7 -> 2.2.0)

`minClientVersion` stays `2.1.32`: verified `Rs2Tile.isTileReachable`, `Rs2Magic.canCast/cast(MagicAction)`, `MagicAction.TELEKINETIC_GRAB`, and the `getGroundItems().get(location, id)` pattern all exist at that tag.

## Test plan
- [x] Build: `./gradlew build -PpluginList=AIOFighterPlugin`
- [x] Caged Lesser Demon (Wizard's Tower top floor) with the toggle on and law/air runes: confirmed it Telekinetic Grabs the drops through the bars and the "I can't reach that!" spam stops.
- [x] Verified live via the agent server: Magic and Hitpoints XP climbing, no `TimeoutException`s, client thread responsive.
- [x] Toggle off: looting behaviour unchanged (walks to loot as before).

## Repro context
The caged Lesser Demon is a classic Telekinetic Grab spot: the demon is safespotted and its drops land behind the cage bars where the player can't walk. The looter tried to walk to them every tick, spamming "I can't reach that!" and never collecting the drops. This adds the telegrab path so those drops are collected, with the Magic XP from the grabs being a nice bonus at this training spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
