### PR TITLE
fix(sandcrabs): run aggression check on client thread

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/sandcrabs/SandCrabScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sandcrabs/SandCrabScript.java
@@ -204,18 +204,55 @@ public class SandCrabScript extends Script {
      *
      * @return true if npc is aggressive
      */
-    private boolean isNpcAggressive() {
+    private boolean isNpcAggressive()
+    {
+        if (Microbot.getClient() == null || Microbot.getClientThread() == null)
+        {
+            return false;
+        }
+
+        java.util.concurrent.atomic.AtomicBoolean result = new java.util.concurrent.atomic.AtomicBoolean(false);
+        java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+
+        Microbot.getClientThread().invoke(() ->
+        {
+            try
+            {
+
         List<Rs2NpcModel> npcs = Microbot.getRs2NpcCache().query().withName("Sandy rocks").toListOnClientThread();
         if (npcs.isEmpty()) {
-            return false;
+            result.set(false); return;
         }
         for (Rs2NpcModel sandyRock : npcs) {
             if (!sandyRock.getNpc().getWorldArea().isInMeleeDistance(Rs2Player.getWorldLocation()))
                 continue;
 
+            result.set(false); return;
+        }
+        result.set(true); return;
+    
+            }
+            catch (Exception ignored)
+            {
+                result.set(false);
+            }
+            finally
+            {
+                done.countDown();
+            }
+        });
+
+        try
+        {
+            done.await(750, java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
             return false;
         }
-        return true;
+
+        return result.get();
     }
 
     /**


### PR DESCRIPTION
Fixes SandCrabScript repeatedly throwing java.lang.IllegalStateException: must be called on client thread. The crash occurred in isNpcAggressive() when NPC/player world area access was performed from the SandCrab scheduled script thread instead of the RuneLite client thread. Tested locally: SandCrabPlugin starts successfully, walking/scanning works, and the repeated client-thread crash no longer occurs.