### PR TITLE
fix(BlueDragons): banking, spam loop, combat loop, loot config

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonState.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonState.java
@@ -1,11 +1,8 @@
 package net.runelite.client.plugins.microbot.bluedragons;
 
 public enum BlueDragonState {
+    STARTING,
     BANKING,
     TRAVEL_TO_DRAGONS,
-    FIGHTING,
-    LOOTING,
-    STARTING,
-    ESCAPE
+    COMBAT
 }
-

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsConfig.java
@@ -25,12 +25,22 @@ public interface BlueDragonsConfig extends Config {
 
     @ConfigItem(keyName = "lootDragonhide", name = "Loot Blue Dragonhide", description = "Loot blue dragonhide dropped by the dragon", section = lootSection)
     default boolean lootDragonhide() {
-        return true;
+        return false;
     }
 
     @ConfigItem(keyName = "lootEnsouledHead", name = "Loot Ensouled heads", description = "LootEnsouled heads dropped by the dragon", section = lootSection)
     default boolean lootEnsouledHead() {
         return true;
+    }
+
+    @ConfigItem(keyName = "waitForLoot", name = "Wait for loot", description = "Wait for dragon death animation to finish and loot before attacking next", section = lootSection)
+    default boolean waitForLoot() {
+        return true;
+    }
+
+    @ConfigItem(keyName = "eatForLoot", name = "Eat food for loot space", description = "Eat food to make inventory space for loot", section = lootSection)
+    default boolean eatForLoot() {
+        return false;
     }
 
     @ConfigItem(keyName = "lootUntradables", name = "Loot Untradables", description = "Loot untradable drops (clue scrolls, etc.)", section = lootSection)

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsConfig.java
@@ -33,6 +33,11 @@ public interface BlueDragonsConfig extends Config {
         return true;
     }
 
+    @ConfigItem(keyName = "lootUntradables", name = "Loot Untradables", description = "Loot untradable drops (clue scrolls, etc.)", section = lootSection)
+    default boolean lootUntradables() {
+        return false;
+    }
+
     @ConfigItem(keyName = "lootMiscItems", name = "Loot items above value", description = "Should we loot items above the specified value threshold?", section = lootSection)
     default boolean lootMiscItems() {
         return true;

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsOverlay.java
@@ -165,10 +165,8 @@ public class BlueDragonsOverlay extends OverlayPanel {
                 return Color.YELLOW;
             case TRAVEL_TO_DRAGONS:
                 return Color.ORANGE;
-            case FIGHTING:
+            case COMBAT:
                 return Color.GREEN;
-            case LOOTING:
-                return new Color(218, 165, 32);
             default:
                 return Color.WHITE;
         }

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsOverlay.java
@@ -31,13 +31,9 @@ public class BlueDragonsOverlay extends OverlayPanel {
     public static int bonesCollected = 0;
     public static int hidesCollected = 0;
 
-    // For formatting hitpoint values
     private final NumberFormat formatter = NumberFormat.getInstance(Locale.US);
-
-    // Model outline renderer for highlighting NPCs
     private final ModelOutlineRenderer modelOutlineRenderer;
 
-    // Reference to the config
     @Setter
     private BlueDragonsConfig config;
 
@@ -57,31 +53,25 @@ public class BlueDragonsOverlay extends OverlayPanel {
             return null;
         }
 
-        // Always draw the safe spot location
         drawSafeSpot(graphics);
 
-        // Draw overlay panel with information
         panelComponent.setPreferredSize(new Dimension(280, 350));
 
-        // Title with blue dragon emoji and fancy formatting
         panelComponent.getChildren().add(
                 TitleComponent.builder()
-                        .text("\uD83D\uDC09 00 Blue Dragons \uD83D\uDC09")
+                        .text("🐉 00 Blue Dragons 🐉")
                         .color(new Color(0, 170, 255))
                         .build()
         );
 
-        // Runtime section
         panelComponent.getChildren().add(LineComponent.builder()
                 .left("Session Time:")
                 .right(formatDuration(Duration.between(startTime, Instant.now())))
-                .rightColor(new Color(255, 215, 0)) // Gold
+                .rightColor(new Color(255, 215, 0))
                 .build());
 
-        // Add section divider
         addSectionDivider("Current Status");
 
-        // Status section with improved colors
         panelComponent.getChildren().add(
                 LineComponent.builder()
                         .left("Bot State:")
@@ -90,7 +80,6 @@ public class BlueDragonsOverlay extends OverlayPanel {
                         .build()
         );
 
-        // Location information in a more compact format
         WorldPoint playerLocation = Microbot.getClient().getLocalPlayer().getWorldLocation();
         int distanceToSafeSpot = playerLocation.distanceTo(BlueDragonsScript.SAFE_SPOT);
 
@@ -102,7 +91,6 @@ public class BlueDragonsOverlay extends OverlayPanel {
                         .build()
         );
 
-        // Dragon tracking section
         addSectionDivider("Dragon Tracking");
 
         Rs2NpcModel nearestDragon = Microbot.getRs2NpcCache().query().withName("Blue dragon").nearestOnClientThread();
@@ -123,20 +111,18 @@ public class BlueDragonsOverlay extends OverlayPanel {
                     LineComponent.builder()
                             .left("Distance:")
                             .right(playerLocation.distanceTo(nearestDragon.getWorldLocation()) + " tiles")
-                            .rightColor(new Color(135, 206, 235)) // Sky Blue
+                            .rightColor(new Color(135, 206, 235))
                             .build()
             );
         }
 
-        // Statistics section
         addSectionDivider("Loot Tracker");
 
-        // Stats in a grid-like format
         panelComponent.getChildren().add(
                 LineComponent.builder()
                         .left("Dragons Killed:")
                         .right(formatNumber(dragonKillCount))
-                        .rightColor(new Color(50, 205, 50)) // Lime Green
+                        .rightColor(new Color(50, 205, 50))
                         .build()
         );
 
@@ -144,7 +130,7 @@ public class BlueDragonsOverlay extends OverlayPanel {
                 LineComponent.builder()
                         .left("Bones Collected:")
                         .right(formatNumber(bonesCollected))
-                        .rightColor(new Color(222, 184, 135)) // Burlywood
+                        .rightColor(new Color(222, 184, 135))
                         .build()
         );
 
@@ -152,7 +138,7 @@ public class BlueDragonsOverlay extends OverlayPanel {
                 LineComponent.builder()
                         .left("Hides Collected:")
                         .right(formatNumber(hidesCollected))
-                        .rightColor(new Color(70, 130, 180)) // Steel Blue
+                        .rightColor(new Color(70, 130, 180))
                         .build()
         );
 
@@ -182,14 +168,13 @@ public class BlueDragonsOverlay extends OverlayPanel {
             case FIGHTING:
                 return Color.GREEN;
             case LOOTING:
-                return new Color(218, 165, 32); // Gold
+                return new Color(218, 165, 32);
             default:
                 return Color.WHITE;
         }
     }
 
     private void drawSafeSpot(Graphics2D graphics) {
-        // Use the non-deprecated method to convert world point to local point
         LocalPoint localSafeSpot = LocalPoint.fromWorld(Microbot.getClient().getTopLevelWorldView(), BlueDragonsScript.SAFE_SPOT);
 
         if (localSafeSpot != null) {
@@ -222,7 +207,7 @@ public class BlueDragonsOverlay extends OverlayPanel {
         panelComponent.getChildren().add(
                 LineComponent.builder()
                         .left(sectionName)
-                        .leftColor(new Color(255, 165, 0)) // Orange
+                        .leftColor(new Color(255, 165, 0))
                         .build()
         );
     }
@@ -233,14 +218,14 @@ public class BlueDragonsOverlay extends OverlayPanel {
     }
 
     private Color getDragonStatusColor(Rs2NpcModel dragon, boolean isTargeting) {
-        if (dragon == null) return new Color(169, 169, 169); // Dark Gray
-        return isTargeting ? new Color(220, 20, 60) : new Color(50, 205, 50); // Crimson : Lime Green
+        if (dragon == null) return new Color(169, 169, 169);
+        return isTargeting ? new Color(220, 20, 60) : new Color(50, 205, 50);
     }
 
     private Color getSafeSpotColor(int distance) {
-        if (distance == 0) return new Color(50, 205, 50); // Lime Green
-        if (distance <= 5) return new Color(255, 165, 0); // Orange
-        return new Color(220, 20, 60); // Crimson
+        if (distance == 0) return new Color(50, 205, 50);
+        if (distance <= 5) return new Color(255, 165, 0);
+        return new Color(220, 20, 60);
     }
 
     private String formatNumber(int number) {

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsPlugin.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 )
 public class BlueDragonsPlugin extends Plugin {
 
-    public static final String version = "1.1.3";
+    public static final String version = "1.2.0";
     static final String CONFIG = "bluedragons";
 
     @Inject
@@ -48,17 +48,12 @@ public class BlueDragonsPlugin extends Plugin {
     @Override
     protected void startUp() {
         overlay.setScript(script);
-
         overlay.setConfig(config);
-
         overlayManager.add(overlay);
 
         Rs2Antiban.activateAntiban();
-
         Rs2Antiban.resetAntibanSettings();
-
         Rs2Antiban.antibanSetupTemplates.applyCombatSetup();
-
         Rs2Antiban.setActivity(Activity.KILLING_BLUE_DRAGONS);
 
         if (config.startPlugin()) {
@@ -68,43 +63,24 @@ public class BlueDragonsPlugin extends Plugin {
 
     @Override
     protected void shutDown() {
-        script.logOnceToChat("Stopping Blue Dragons plugin...", false, config);
         overlayManager.remove(overlay);
         script.shutdown();
     }
 
     @Subscribe
     public void onConfigChanged(ConfigChanged event) {
-        if (!event.getGroup().equals("bluedragons")) return;
+        if (!event.getGroup().equals(CONFIG)) return;
 
-        switch (event.getKey()) {
-            case "startPlugin":
-                if (config.startPlugin()) {
-                    script.logOnceToChat("Starting Blue Dragon plugin...", false, config);
-                    script.run(config);
-                } else {
-                    script.logOnceToChat("Stopping Blue Dragon plugin!", false, config);
-                    script.shutdown();
-                }
-                break;
-
-            case "lootDragonhide":
-            case "foodType":
-            case "foodAmount":
-            case "eatAtHealthPercent":
-            case "lootEnsouledHead":
-            case "debugLogs":
-                script.logOnceToChat("Configuration changed. Updating script settings.", true, config);
-                if (config.startPlugin()) {
-                    script.updateConfig(config);
-                }
-                break;
-
-            default:
-                break;
+        if ("startPlugin".equals(event.getKey())) {
+            if (config.startPlugin()) {
+                script.run(config);
+            } else {
+                script.shutdown();
+            }
+        } else if (script.isRunning()) {
+            script.updateConfig(config);
         }
     }
-
 
     @Provides
     BlueDragonsConfig provideConfig(ConfigManager configManager) {

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsScript.java
@@ -15,7 +15,6 @@ import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2RunePouch;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
-import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
 import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -30,7 +29,6 @@ import java.util.stream.Collectors;
 public class BlueDragonsScript extends Script {
 
     public static BlueDragonState currentState;
-    private String lastChatMessage = "";
     private BlueDragonsConfig config;
     public static final WorldPoint SAFE_SPOT = new WorldPoint(2918, 9781, 0);
     @Getter
@@ -47,7 +45,18 @@ public class BlueDragonsScript extends Script {
     private static final int MIN_WORLD = 302;
     private static final int MAX_WORLD = 580;
 
+    private static final String[] ITEMS_TO_KEEP = {
+            "Dusty key",
+            "Rune pouch", "Divine rune pouch",
+            "Law rune", "Water rune", "Air rune", "Dust rune",
+            "Falador teleport"
+    };
+
     public boolean run(BlueDragonsConfig config) {
+        if (mainScheduledFuture != null && !mainScheduledFuture.isDone()) {
+            mainScheduledFuture.cancel(true);
+        }
+
         this.config = config;
         currentState = BlueDragonState.STARTING;
 
@@ -63,25 +72,24 @@ public class BlueDragonsScript extends Script {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!super.run() || !Microbot.isLoggedIn()) return;
-
+                if (!isRunning()) return;
 
                 if (isInventoryFull() && currentState != BlueDragonState.BANKING && currentState != BlueDragonState.STARTING) {
-                    logOnceToChat("Global safety: Inventory is full. Switching to BANKING state.", false, config);
+                    Microbot.log("Inventory full. Switching to BANKING.");
                     currentState = BlueDragonState.BANKING;
                 }
 
                 switch (currentState) {
                     case STARTING:
-                        determineStartingState(config);
+                        determineStartingState();
                         break;
 
                     case ESCAPE:
-                        // TODO implement escape with tab and/or teleport - faster than webwalker and can have multiple triggers
                         handleEscape();
                         break;
 
                     case BANKING:
-                        HandleBankingSimple(config);
+                        handleBanking();
                         break;
 
                     case TRAVEL_TO_DRAGONS:
@@ -89,11 +97,11 @@ public class BlueDragonsScript extends Script {
                         break;
 
                     case FIGHTING:
-                        handleFighting(config);
+                        handleFighting();
                         break;
 
                     case LOOTING:
-                        handleLooting(config);
+                        handleLooting();
                         break;
                 }
 
@@ -101,63 +109,68 @@ public class BlueDragonsScript extends Script {
 
             } catch (Exception ex) {
                 consecutiveErrors[0]++;
-                logOnceToChat("Error in Blue Dragons script: " + ex.getMessage(), false, config);
+                Microbot.log("Error in Blue Dragons script: " + ex.getMessage());
 
                 if (config.debugLogs()) {
                     StringBuilder stackTrace = new StringBuilder();
                     for (StackTraceElement element : ex.getStackTrace()) {
                         stackTrace.append(element.toString()).append("\n");
                     }
-                    logOnceToChat("Stack trace: " + stackTrace.toString(), true, config);
+                    Microbot.log("Stack trace: " + stackTrace);
                 }
 
                 if (consecutiveErrors[0] >= MAX_CONSECUTIVE_ERRORS) {
-                    logOnceToChat("Too many consecutive errors. Stopping script for safety.", false, config);
+                    Microbot.log("Too many consecutive errors. Stopping script.");
                     shutdown();
+                    return;
                 }
 
                 if (Rs2Player.isInCombat()) {
-                    logOnceToChat("In combat during error - attempting to eat food", true, config);
                     Rs2Player.eatAt(config.eatAtHealthPercent());
                 }
-
-                sleep(1000 * Math.min(consecutiveErrors[0], 5));
             }
-        }, 0, 100, TimeUnit.MILLISECONDS);
+        }, 0, 600, TimeUnit.MILLISECONDS);
 
         return true;
     }
 
-    ///  --- End of Engine Code ----------------------------------------------------------------------------------------
-    ///-----------------------------------------------------------------------------------------------------------------
-
-    private void determineStartingState(BlueDragonsConfig config) {
-        boolean hasTeleport = hasTeleportToFalador2();
+    private void determineStartingState() {
         boolean hasAgilityOrKey = Microbot.getClient().getRealSkillLevel(Skill.AGILITY) >= 70 || hasDustyKey();
 
-        if (!hasTeleport) {
-            logOnceToChat("Missing teleport to Falador or required runes.", false, config);
-        }
-
         if (!hasAgilityOrKey) {
-            logOnceToChat("Requires Agility level 70 or a Dusty Key.", false, config);
+            Microbot.log("Requires Agility level 70 or a Dusty Key. Stopping.");
+            shutdown();
+            return;
         }
 
-        if (hasTeleport && hasAgilityOrKey) {
+        boolean hasTeleport = hasTeleportToFalador();
+        if (!hasTeleport) {
+            Microbot.log("Missing Falador teleport (tab or runes). Stopping.");
+            shutdown();
+            return;
+        }
+
+        if (needsBanking()) {
             currentState = BlueDragonState.BANKING;
         } else {
-            logOnceToChat("Starting conditions not met. Stopping the plugin.", false, config);
-            shutdown();
+            currentState = BlueDragonState.TRAVEL_TO_DRAGONS;
         }
+    }
+
+    private boolean needsBanking() {
+        int foodCount = Rs2Inventory.getInventoryFood().size();
+        boolean hasLoot = Rs2Inventory.contains("Dragon bones")
+                || Rs2Inventory.contains("Blue dragonhide")
+                || Rs2Inventory.contains("Scaly blue dragonhide")
+                || Rs2Inventory.contains("Dragon spear")
+                || Rs2Inventory.contains("Shield left half")
+                || Rs2Inventory.contains("Ensouled dragon head");
+
+        return hasLoot || foodCount < config.foodAmount();
     }
 
     private boolean isInventoryFull() {
-        boolean simpleFull = Rs2Inventory.isFull();
-        if (!simpleFull) {
-            return Rs2Inventory.emptySlotCount() <= 0;
-        }
-
-        return true;
+        return Rs2Inventory.isFull() || Rs2Inventory.emptySlotCount() <= 0;
     }
 
     private boolean hasDustyKey() {
@@ -165,144 +178,62 @@ public class BlueDragonsScript extends Script {
     }
 
     private boolean hasTeleportToFalador() {
-        logOnceToChat("Checking for Falador teleport or required runes.", true, config);
-
         if (Rs2Inventory.contains("Falador teleport")) {
-            logOnceToChat("Found Falador teleport in inventory.", true, config);
             return true;
         }
-        int lawRuneId = ItemID.LAWRUNE;
-        int waterRuneId = ItemID.WATERRUNE;
-        int dustRuneId = ItemID.DUSTRUNE;
-        int airRuneId = ItemID.AIRRUNE;
-
-        int requiredLawRunes = 1;
-        int requiredAirRunes = 3;
-        int requiredWaterRunes = 1;
-
-        boolean runePouchInInventory = Rs2Inventory.contains("Rune pouch") || Rs2Inventory.contains("Divine rune pouch");
-        boolean hasLawRunes = checkRuneAvailability(lawRuneId, requiredLawRunes, runePouchInInventory);
-        boolean hasWaterRunes = checkRuneAvailability(waterRuneId, requiredWaterRunes, runePouchInInventory);
-        boolean hasAirOrDustRunes = checkRuneAvailability(dustRuneId, requiredAirRunes, runePouchInInventory) ||
-                checkRuneAvailability(airRuneId, requiredAirRunes, runePouchInInventory);
-
-        return hasLawRunes && hasWaterRunes && hasAirOrDustRunes;
+        return Rs2Magic.canCast(MagicAction.FALADOR_TELEPORT);
     }
 
-    private boolean checkRuneAvailability(int runeId, int requiredAmount, boolean checkRunePouch) {
-        boolean inInventory = Rs2Inventory.hasItemAmount(runeId, requiredAmount);
-        boolean inRunePouch = checkRunePouch && Rs2RunePouch.contains(runeId, requiredAmount);
-        return inInventory || inRunePouch;
-    }
-
-
-    private boolean hasTeleportToFalador2() {
-        logOnceToChat("Checking for Falador teleport or required runes.", true, config);
-
-        if (Rs2Inventory.contains("Falador teleport")) {
-            logOnceToChat("Found Falador teleport in inventory.", true, config);
-            return true;
-        }
-
-        if (Rs2Magic.canCast(MagicAction.FALADOR_TELEPORT)){
-            return true;
-        }
-
-        return false;
-    };
-
-    private void handleEscape(){
+    private void handleEscape() {
         Rs2Magic.cast(MagicAction.FALADOR_TELEPORT);
     }
 
+    private void handleBanking() {
+        if (!Rs2Bank.walkToBankAndUseBank(BankLocation.FALADOR_WEST)) {
+            return;
+        }
 
-    private void HandleBankingSimple(BlueDragonsConfig config) {
-        logOnceToChat("Traveling to Falador West bank for depositing looted items.", true, config);
-        logOnceToChat("Current location: " + Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation()), true, config);
+        int foodCount = Rs2Inventory.getInventoryFood().size();
+        boolean hasLoot = Rs2Inventory.contains("Dragon bones")
+                || Rs2Inventory.contains("Blue dragonhide")
+                || Rs2Inventory.contains("Scaly blue dragonhide")
+                || Rs2Inventory.contains("Dragon spear")
+                || Rs2Inventory.contains("Shield left half")
+                || Rs2Inventory.contains("Ensouled dragon head");
 
-        if (Rs2Bank.walkToBankAndUseBank(BankLocation.FALADOR_WEST)) {
+        int foodNeeded = config.foodAmount() - foodCount;
 
-            logOnceToChat("Opened bank. Depositing loot.", true, config);
-            Rs2Bank.depositAll();
-            Rs2Inventory.waitForInventoryChanges(600);
-            sleep(450,750);
-
-            logOnceToChat("Checking food for combat.", true, config);
-            int foodCount = Rs2Inventory.getInventoryFood().size();
-            Rs2Bank.withdrawX(config.foodType().getId(), config.foodAmount() - foodCount);
-            Rs2Inventory.waitForInventoryChanges(600);
+        if (!hasLoot && foodNeeded <= 0) {
             Rs2Bank.closeBank();
-            logOnceToChat("Banking complete. Transitioning to travel state.", true, config);
             currentState = BlueDragonState.TRAVEL_TO_DRAGONS;
-        } else {
-            logOnceToChat("Failed to reach the bank.", true, config);
-        }
-
-    }
-
-    private void withdrawFood(BlueDragonsConfig config) {
-        Rs2Food food = config.foodType();
-        int requiredAmount = config.foodAmount();
-
-        if (food == null || requiredAmount <= 0) {
-            logOnceToChat("Invalid food type or amount in configuration.", true, config);
             return;
         }
 
-        int currentFoodInInventory = Rs2Inventory.count(food.getName());
-        int deficit = requiredAmount - currentFoodInInventory;
-
-        if (deficit <= 0) {
-            logOnceToChat("Inventory already contains the required amount of " + food.getName() + ".", true, config);
-            return;
+        if (hasLoot) {
+            Rs2Bank.depositAllExcept(ITEMS_TO_KEEP);
+            Rs2Inventory.waitForInventoryChanges(600);
+            sleep(450, 750);
         }
 
-        if (!Rs2Bank.isOpen()) {
-            logOnceToChat("Bank is not open. Cannot withdraw food.", true, config);
-            return;
-        }
-
-        boolean bankLoaded = sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5000);
-        if (!bankLoaded) {
-            logOnceToChat("Bank items did not load in time.", true, config);
-            return;
-        }
-
-        if (!Rs2Bank.hasItem(food.getName())) {
-            logOnceToChat(food.getName() + " not found in the bank. Stopping script.", true, config);
-            shutdown();
-            return;
-        }
-
-        logOnceToChat("Attempting to withdraw " + deficit + "x " + food.getName(), false, config);
-
-        int retryCount = 0;
-        final int maxRetries = 3;
-        boolean success = false;
-
-        while (retryCount < maxRetries && !success) {
-            success = Rs2Bank.withdrawX(food.getName(), deficit, true);
-            if (!success) {
-                retryCount++;
-                sleep(500);
-                logOnceToChat("Retrying withdrawal of " + food.getName() + " (" + retryCount + ")", true, config);
+        foodCount = Rs2Inventory.getInventoryFood().size();
+        foodNeeded = config.foodAmount() - foodCount;
+        if (foodNeeded > 0) {
+            if (!Rs2Bank.hasItem(config.foodType().getName())) {
+                Microbot.log("No " + config.foodType().getName() + " in bank. Stopping.");
+                Rs2Bank.closeBank();
+                shutdown();
+                return;
             }
+            Rs2Bank.withdrawX(config.foodType().getId(), foodNeeded);
+            Rs2Inventory.waitForInventoryChanges(600);
         }
 
-        if (!success) {
-            logOnceToChat("Unable to withdraw " + food.getName() + " after multiple attempts. Stopping script.", true, config);
-            shutdown();
-        } else {
-            logOnceToChat("Successfully withdrew " + deficit + "x " + food.getName(), false, config);
-        }
+        Rs2Bank.closeBank();
+        currentState = BlueDragonState.TRAVEL_TO_DRAGONS;
     }
 
     private void handleTravelToDragons() {
-        logOnceToChat("Traveling to dragons.", false, config);
-        logOnceToChat("Player location before travel: " + Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation()), true, config);
-
         if (isPlayerAtSafeSpot()) {
-            logOnceToChat("Already at safe spot. Transitioning to FIGHTING state.", true, config);
             currentState = BlueDragonState.FIGHTING;
             return;
         }
@@ -310,109 +241,77 @@ public class BlueDragonsScript extends Script {
         boolean walkAttemptSuccessful = Rs2Walker.walkTo(SAFE_SPOT, 0);
 
         if (!walkAttemptSuccessful) {
-            logOnceToChat("Failed to start walking to safe spot. Will retry next tick.", true, config);
             return;
         }
 
         boolean reachedNearSafeSpot = sleepUntil(() -> Rs2Player.distanceTo(SAFE_SPOT) <= 5, 60000);
 
         if (reachedNearSafeSpot || Rs2Player.distanceTo(SAFE_SPOT) <= 20) {
-            logOnceToChat("Close to safe spot. Using precise movement for final approach.", true, config);
             moveToSafeSpot();
         } else {
-            logOnceToChat("Failed to get close to safe spot within timeout.", true, config);
-
             int distance = Rs2Player.distanceTo(SAFE_SPOT);
-            logOnceToChat("Current distance to safe spot: " + distance, true, config);
-
             if (distance < 50) {
                 moveToSafeSpot();
             } else {
-                logOnceToChat("Too far from safe spot. Returning to banking state to try again.", true, config);
                 currentState = BlueDragonState.BANKING;
                 return;
             }
         }
 
         if (hopIfPlayerAtSafeSpot()) {
-            logOnceToChat("Hopped worlds due to player detection at safe spot.", true, config);
             return;
         }
 
-        if (isPlayerAtSafeSpot()) {
-            logOnceToChat("Reached safe spot. Transitioning to FIGHTING state.", true, config);
-            currentState = BlueDragonState.FIGHTING;
-        } else {
-            logOnceToChat("Still not at safe spot after multiple attempts. Will continue from current position.", true, config);
-            currentState = BlueDragonState.FIGHTING;
-        }
+        currentState = BlueDragonState.FIGHTING;
     }
 
-    private void handleFighting(BlueDragonsConfig config) {
+    private void handleFighting() {
         if (currentState != BlueDragonState.FIGHTING) {
-            logOnceToChat("Not in FIGHTING state but handleFighting was called. Current state: " + currentState, true, config);
             return;
         }
 
         if (isInventoryFull()) {
-            logOnceToChat("Inventory is full. Switching to BANKING state.", false, config);
             currentState = BlueDragonState.BANKING;
-            return;
-        }
-
-        if (checkForLoot()) {
-            long currentTime = System.currentTimeMillis();
-            if (currentTime - lastLootMessageTime > 10000) {
-                logOnceToChat("Found loot on the ground. Switching to LOOTING state.", false, config);
-                lastLootMessageTime = currentTime;
-            }
-            currentState = BlueDragonState.LOOTING;
-            return;
-        }
-
-        if (!isPlayerAtSafeSpot()) {
-            logOnceToChat("Not at safe spot. Moving back before continuing to fight.", true, config);
-            moveToSafeSpot();
             return;
         }
 
         Rs2Player.eatAt(config.eatAtHealthPercent());
 
+        if (!isPlayerAtSafeSpot()) {
+            moveToSafeSpot();
+            return;
+        }
+
+        if (hasLootNearby()) {
+            currentState = BlueDragonState.LOOTING;
+            return;
+        }
+
         if (!underAttack()) {
             Rs2NpcModel dragon = getAvailableDragon();
             if (dragon != null) {
-                logOnceToChat("Found available dragon. Attacking.", true, config);
                 if (attackDragon(dragon)) {
                     currentTargetId = dragon.getId();
                 }
-            } else {
-                logOnceToChat("No dragons available to attack.", true, config);
-            }
-        } else {
-            if (!isPlayerAtSafeSpot()) {
-                moveToSafeSpot();
             }
         }
     }
 
-    private boolean checkForLoot() {
-        String[] lootItems = {
-                "Dragon bones",
-                "Dragon spear", "Shield left half", "Scaly blue dragonhide"
-        };
-
-        LootingParameters params = new LootingParameters(15, 1, 1, 0, false, true, lootItems);
-
-        return Rs2GroundItem.lootItemsBasedOnNames(params);
+    private boolean hasLootNearby() {
+        if (Rs2GroundItem.exists("Dragon bones", 15)) return true;
+        if (Rs2GroundItem.exists("Dragon spear", 15)) return true;
+        if (Rs2GroundItem.exists("Shield left half", 15)) return true;
+        if (config.lootDragonhide() && Rs2GroundItem.exists("Blue dragonhide", 15)) return true;
+        if (config.lootEnsouledHead() && Rs2GroundItem.exists("Ensouled dragon head", 15)) return true;
+        return false;
     }
 
-    private void handleLooting(BlueDragonsConfig config) {
+    private void handleLooting() {
         if (currentState != BlueDragonState.LOOTING) {
             return;
         }
 
         if (isInventoryFull()) {
-            logOnceToChat("Inventory is full, switching to BANKING state.", false, config);
             currentState = BlueDragonState.BANKING;
             return;
         }
@@ -428,69 +327,58 @@ public class BlueDragonsScript extends Script {
         if (!isInventoryFull()) {
             lootedAnything |= lootItem("Shield left half");
         }
-        if (!isInventoryFull()) {
-            lootedAnything |= lootItem("Scaly blue dragonhide");
-        }
-
-        if (config.lootMiscItems() && !isInventoryFull()) {
-            Rs2GroundItem.lootItemBasedOnValue(new LootingParameters(config.lootValueThreshold(), 9999999, 8, 1, 1, false, true));
-        }
 
         if (config.lootDragonhide() && !isInventoryFull()) {
             lootedAnything |= lootItem("Blue dragonhide");
+            lootedAnything |= lootItem("Scaly blue dragonhide");
         }
 
         if (config.lootEnsouledHead() && !isInventoryFull()) {
             lootedAnything |= lootItem("Ensouled dragon head");
         }
 
+        if (config.lootUntradables() && !isInventoryFull()) {
+            Rs2GroundItem.lootUntradables(new LootingParameters(15, 1, 1, 0, false, true));
+        }
+
+        if (config.lootMiscItems() && !isInventoryFull()) {
+            Rs2GroundItem.lootItemBasedOnValue(new LootingParameters(config.lootValueThreshold(), 9999999, 8, 1, 1, false, true));
+        }
+
         sleep(300, 500);
 
         if (isInventoryFull()) {
-            logOnceToChat("Inventory is full after looting, switching to BANKING state.", false, config);
             currentState = BlueDragonState.BANKING;
             return;
         }
 
-        if (!checkForLoot() || !lootedAnything) {
-            logOnceToChat("Finished looting. Returning to combat.", true, config);
+        if (!hasLootNearby() || !lootedAnything) {
             currentState = BlueDragonState.FIGHTING;
             currentTargetId = null;
         }
     }
 
     private boolean lootItem(String itemName) {
-        if (!isInventoryFull()) {
-            LootingParameters params = new LootingParameters(15, 1, 1, 0, false, true, itemName);
-            boolean looted = Rs2GroundItem.lootItemsBasedOnNames(params);
-            if (looted) {
-                logOnceToChat("Looted: " + itemName, true, config);
+        if (isInventoryFull()) return false;
 
-                if (itemName.equalsIgnoreCase("Dragon bones")) {
-                    BlueDragonsOverlay.bonesCollected++;
-                    Microbot.log("Bones looted: " + BlueDragonsOverlay.bonesCollected);
-                } else if (itemName.equalsIgnoreCase("Blue dragonhide")) {
-                    BlueDragonsOverlay.hidesCollected++;
-                }
-
-                return true;
+        LootingParameters params = new LootingParameters(15, 1, 1, 0, false, true, itemName);
+        boolean looted = Rs2GroundItem.lootItemsBasedOnNames(params);
+        if (looted) {
+            if (itemName.equalsIgnoreCase("Dragon bones")) {
+                BlueDragonsOverlay.bonesCollected++;
+            } else if (itemName.equalsIgnoreCase("Blue dragonhide")) {
+                BlueDragonsOverlay.hidesCollected++;
             }
         }
-        return false;
+        return looted;
     }
-
-
 
     private Rs2NpcModel getAvailableDragon() {
         Rs2NpcModel dragon = Microbot.getRs2NpcCache().query().withName("Blue dragon").nearestOnClientThread();
-        logOnceToChat("Found dragon: " + (dragon != null ? "Yes (ID: " + dragon.getId() + ")" : "No"), true, config);
 
         if (dragon != null) {
             boolean correctId = (dragon.getId() == BLUE_DRAGON_ID_1 || dragon.getId() == BLUE_DRAGON_ID_2 || dragon.getId() == BLUE_DRAGON_ID_3);
-            logOnceToChat("Dragon has correct ID (265, 266, or 267): " + correctId, true, config);
-
             boolean hasLineOfSight = dragon.hasLineOfSight();
-            logOnceToChat("Has line of sight to dragon: " + hasLineOfSight, true, config);
 
             if (correctId && hasLineOfSight) {
                 return dragon;
@@ -503,7 +391,6 @@ public class BlueDragonsScript extends Script {
         final int dragonId = dragon.getId();
 
         if (Rs2Combat.inCombat() && !dragon.isInteractingWithPlayer()) {
-            logOnceToChat("Cannot attack dragon - player is in combat with different target.", true, config);
             return false;
         }
 
@@ -511,9 +398,7 @@ public class BlueDragonsScript extends Script {
             boolean dragonKilled = sleepUntil(() -> Microbot.getRs2NpcCache().query().withId(dragonId).nearest() == null, 60000);
 
             if (dragonKilled) {
-                logOnceToChat("Dragon killed. Transitioning to looting state.", true, config);
                 BlueDragonsOverlay.dragonKillCount++;
-
                 sleep(600, 900);
                 currentState = BlueDragonState.LOOTING;
             }
@@ -532,29 +417,18 @@ public class BlueDragonsScript extends Script {
 
         int distance = Rs2Player.distanceTo(SAFE_SPOT);
 
-        logOnceToChat("Moving to safe spot. Distance: " + distance, true, config);
-
         if (distance > 15) {
-            logOnceToChat("Using walkTo to approach safe spot", true, config);
             Rs2Walker.walkTo(SAFE_SPOT, 0);
-
             sleepUntil(() -> Rs2Player.distanceTo(SAFE_SPOT) <= 5, 30000);
         }
 
         if (!isPlayerAtSafeSpot()) {
-            logOnceToChat("Using walkFastCanvas for final approach to safe spot", true, config);
             Rs2Walker.walkFastCanvas(SAFE_SPOT);
             sleepUntil(this::isPlayerAtSafeSpot, 15000);
         }
 
         if (hopIfPlayerAtSafeSpot()) {
             return;
-        }
-
-        if (!isPlayerAtSafeSpot()) {
-            logOnceToChat("Failed to reach exact safe spot. Will continue with current position.", true, config);
-        } else {
-            logOnceToChat("Successfully reached safe spot.", true, config);
         }
 
         Microbot.pauseAllScripts.compareAndSet(true, false);
@@ -574,7 +448,7 @@ public class BlueDragonsScript extends Script {
         }
 
         if (otherPlayersAtSafeSpot) {
-            logOnceToChat("Player detected at safe spot. Pausing script and hopping worlds.", false, config);
+            Microbot.log("Player at safe spot. Hopping worlds.");
             Microbot.pauseAllScripts.set(true);
 
             boolean hopSuccess = Microbot.hopToWorld(findRandomWorld());
@@ -596,47 +470,22 @@ public class BlueDragonsScript extends Script {
         return targetWorld;
     }
 
-
-
     public void updateConfig(BlueDragonsConfig config) {
-        logOnceToChat("Applying new configuration to Blue Dragons script.", true, config);
         this.config = config;
 
         if (overlay != null) {
             overlay.setConfig(config);
         }
-
-        withdrawFood(config);
-    }
-
-    void logOnceToChat(String message, boolean isDebug, BlueDragonsConfig config) {
-        if (message == null || message.trim().isEmpty()) {
-            message = "Unknown log message (null or empty)...";
-        }
-        if (isDebug && (config == null || !config.debugLogs())) {
-            return;
-        }
-        if (!message.equals(lastChatMessage)) {
-            Microbot.log(message);
-            lastChatMessage = message;
-        }
     }
 
     private boolean underAttack() {
-        return Rs2Player.isAnimating(5000);
+        return Rs2Combat.inCombat();
     }
-
 
     public void shutdown() {
         super.shutdown();
         Rs2Walker.setTarget(null);
         Rs2Walker.disableTeleports = false;
-        if (overlay != null) {
-            overlay.resetStats();
-        }
-        currentState = BlueDragonState.STARTING;
         currentTargetId = null;
     }
-
-
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/bluedragons/BlueDragonsScript.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.gameval.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
@@ -13,9 +12,7 @@ import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
-import net.runelite.client.plugins.microbot.util.inventory.Rs2RunePouch;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
-import net.runelite.client.plugins.microbot.util.misc.Rs2Food;
 import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
@@ -37,7 +34,11 @@ public class BlueDragonsScript extends Script {
     @Inject
     private BlueDragonsOverlay overlay;
 
-    private long lastLootMessageTime = 0;
+    private boolean waitingForLoot = false;
+    private long waitForLootStart = 0;
+    private long lastActionClickTime = 0;
+    private static final long WAIT_FOR_LOOT_TIMEOUT = 5000;
+    private static final long ACTION_GRACE = 2400;
 
     private static final int BLUE_DRAGON_ID_1 = 265;
     private static final int BLUE_DRAGON_ID_2 = 266;
@@ -67,41 +68,24 @@ public class BlueDragonsScript extends Script {
         }
 
         final int[] consecutiveErrors = {0};
-        final int MAX_CONSECUTIVE_ERRORS = 5;
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!super.run() || !Microbot.isLoggedIn()) return;
                 if (!isRunning()) return;
 
-                if (isInventoryFull() && currentState != BlueDragonState.BANKING && currentState != BlueDragonState.STARTING) {
-                    Microbot.log("Inventory full. Switching to BANKING.");
-                    currentState = BlueDragonState.BANKING;
-                }
-
                 switch (currentState) {
                     case STARTING:
                         determineStartingState();
                         break;
-
-                    case ESCAPE:
-                        handleEscape();
-                        break;
-
                     case BANKING:
                         handleBanking();
                         break;
-
                     case TRAVEL_TO_DRAGONS:
                         handleTravelToDragons();
                         break;
-
-                    case FIGHTING:
-                        handleFighting();
-                        break;
-
-                    case LOOTING:
-                        handleLooting();
+                    case COMBAT:
+                        handleCombat();
                         break;
                 }
 
@@ -110,23 +94,9 @@ public class BlueDragonsScript extends Script {
             } catch (Exception ex) {
                 consecutiveErrors[0]++;
                 Microbot.log("Error in Blue Dragons script: " + ex.getMessage());
-
-                if (config.debugLogs()) {
-                    StringBuilder stackTrace = new StringBuilder();
-                    for (StackTraceElement element : ex.getStackTrace()) {
-                        stackTrace.append(element.toString()).append("\n");
-                    }
-                    Microbot.log("Stack trace: " + stackTrace);
-                }
-
-                if (consecutiveErrors[0] >= MAX_CONSECUTIVE_ERRORS) {
+                if (consecutiveErrors[0] >= 5) {
                     Microbot.log("Too many consecutive errors. Stopping script.");
                     shutdown();
-                    return;
-                }
-
-                if (Rs2Player.isInCombat()) {
-                    Rs2Player.eatAt(config.eatAtHealthPercent());
                 }
             }
         }, 0, 600, TimeUnit.MILLISECONDS);
@@ -136,15 +106,13 @@ public class BlueDragonsScript extends Script {
 
     private void determineStartingState() {
         boolean hasAgilityOrKey = Microbot.getClient().getRealSkillLevel(Skill.AGILITY) >= 70 || hasDustyKey();
-
         if (!hasAgilityOrKey) {
             Microbot.log("Requires Agility level 70 or a Dusty Key. Stopping.");
             shutdown();
             return;
         }
 
-        boolean hasTeleport = hasTeleportToFalador();
-        if (!hasTeleport) {
+        if (!hasTeleportToFalador()) {
             Microbot.log("Missing Falador teleport (tab or runes). Stopping.");
             shutdown();
             return;
@@ -165,12 +133,7 @@ public class BlueDragonsScript extends Script {
                 || Rs2Inventory.contains("Dragon spear")
                 || Rs2Inventory.contains("Shield left half")
                 || Rs2Inventory.contains("Ensouled dragon head");
-
         return hasLoot || foodCount < config.foodAmount();
-    }
-
-    private boolean isInventoryFull() {
-        return Rs2Inventory.isFull() || Rs2Inventory.emptySlotCount() <= 0;
     }
 
     private boolean hasDustyKey() {
@@ -178,20 +141,11 @@ public class BlueDragonsScript extends Script {
     }
 
     private boolean hasTeleportToFalador() {
-        if (Rs2Inventory.contains("Falador teleport")) {
-            return true;
-        }
-        return Rs2Magic.canCast(MagicAction.FALADOR_TELEPORT);
-    }
-
-    private void handleEscape() {
-        Rs2Magic.cast(MagicAction.FALADOR_TELEPORT);
+        return Rs2Inventory.contains("Falador teleport") || Rs2Magic.canCast(MagicAction.FALADOR_TELEPORT);
     }
 
     private void handleBanking() {
-        if (!Rs2Bank.walkToBankAndUseBank(BankLocation.FALADOR_WEST)) {
-            return;
-        }
+        if (!Rs2Bank.walkToBankAndUseBank(BankLocation.FALADOR_WEST)) return;
 
         int foodCount = Rs2Inventory.getInventoryFood().size();
         boolean hasLoot = Rs2Inventory.contains("Dragon bones")
@@ -200,7 +154,6 @@ public class BlueDragonsScript extends Script {
                 || Rs2Inventory.contains("Dragon spear")
                 || Rs2Inventory.contains("Shield left half")
                 || Rs2Inventory.contains("Ensouled dragon head");
-
         int foodNeeded = config.foodAmount() - foodCount;
 
         if (!hasLoot && foodNeeded <= 0) {
@@ -234,65 +187,82 @@ public class BlueDragonsScript extends Script {
 
     private void handleTravelToDragons() {
         if (isPlayerAtSafeSpot()) {
-            currentState = BlueDragonState.FIGHTING;
+            currentState = BlueDragonState.COMBAT;
             return;
         }
 
-        boolean walkAttemptSuccessful = Rs2Walker.walkTo(SAFE_SPOT, 0);
+        Rs2Walker.walkTo(SAFE_SPOT, 0);
+        sleepUntil(() -> Rs2Player.distanceTo(SAFE_SPOT) <= 5, 60000);
 
-        if (!walkAttemptSuccessful) {
-            return;
+        if (Rs2Player.distanceTo(SAFE_SPOT) <= 15) {
+            Rs2Walker.walkFastCanvas(SAFE_SPOT);
+            sleepUntil(this::isPlayerAtSafeSpot, 10000);
         }
 
-        boolean reachedNearSafeSpot = sleepUntil(() -> Rs2Player.distanceTo(SAFE_SPOT) <= 5, 60000);
+        if (isPlayerAtSafeSpot()) {
+            hopIfPlayerAtSafeSpot();
+            currentState = BlueDragonState.COMBAT;
+        }
+    }
 
-        if (reachedNearSafeSpot || Rs2Player.distanceTo(SAFE_SPOT) <= 20) {
-            moveToSafeSpot();
-        } else {
-            int distance = Rs2Player.distanceTo(SAFE_SPOT);
-            if (distance < 50) {
-                moveToSafeSpot();
-            } else {
+    /**
+     * Non-blocking combat loop — one action per tick, like AIO Fighter.
+     * Priority: eat → bank if full → loot → safe spot → attack
+     */
+    private void handleCombat() {
+        Rs2Player.eatAt(config.eatAtHealthPercent());
+
+        if (Rs2Inventory.isFull()) {
+            if (config.eatForLoot() && !Rs2Inventory.getInventoryFood().isEmpty()) {
+                Rs2Player.eatAt(100);
+            } else if (needsBanking()) {
                 currentState = BlueDragonState.BANKING;
                 return;
             }
         }
 
-        if (hopIfPlayerAtSafeSpot()) {
-            return;
-        }
-
-        currentState = BlueDragonState.FIGHTING;
-    }
-
-    private void handleFighting() {
-        if (currentState != BlueDragonState.FIGHTING) {
-            return;
-        }
-
-        if (isInventoryFull()) {
-            currentState = BlueDragonState.BANKING;
-            return;
-        }
-
-        Rs2Player.eatAt(config.eatAtHealthPercent());
-
-        if (!isPlayerAtSafeSpot()) {
-            moveToSafeSpot();
+        if (config.waitForLoot() && waitingForLoot) {
+            if (hasLootNearby()) {
+                waitingForLoot = false;
+                lootItems();
+                return;
+            }
+            if (System.currentTimeMillis() - waitForLootStart > WAIT_FOR_LOOT_TIMEOUT) {
+                waitingForLoot = false;
+            }
             return;
         }
 
         if (hasLootNearby()) {
-            currentState = BlueDragonState.LOOTING;
+            lootItems();
             return;
         }
 
-        if (!underAttack()) {
+        if (System.currentTimeMillis() - lastActionClickTime < ACTION_GRACE) return;
+
+        if (!isPlayerAtSafeSpot()) {
+            Rs2Walker.walkFastCanvas(SAFE_SPOT);
+            lastActionClickTime = System.currentTimeMillis();
+            return;
+        }
+
+        if (config.waitForLoot() && currentTargetId != null) {
+            Rs2NpcModel target = Microbot.getRs2NpcCache().query().withId(currentTargetId).nearestOnClientThread();
+            if (target != null && target.isDead()) {
+                waitingForLoot = true;
+                waitForLootStart = System.currentTimeMillis();
+                BlueDragonsOverlay.dragonKillCount++;
+                currentTargetId = null;
+                return;
+            }
+        }
+
+        if (!Rs2Combat.inCombat() && isPlayerAtSafeSpot()) {
             Rs2NpcModel dragon = getAvailableDragon();
             if (dragon != null) {
-                if (attackDragon(dragon)) {
-                    currentTargetId = dragon.getId();
-                }
+                dragon.click("Attack");
+                currentTargetId = dragon.getId();
+                lastActionClickTime = System.currentTimeMillis();
             }
         }
     }
@@ -302,163 +272,88 @@ public class BlueDragonsScript extends Script {
         if (Rs2GroundItem.exists("Dragon spear", 15)) return true;
         if (Rs2GroundItem.exists("Shield left half", 15)) return true;
         if (config.lootDragonhide() && Rs2GroundItem.exists("Blue dragonhide", 15)) return true;
+        if (config.lootDragonhide() && Rs2GroundItem.exists("Scaly blue dragonhide", 15)) return true;
         if (config.lootEnsouledHead() && Rs2GroundItem.exists("Ensouled dragon head", 15)) return true;
         return false;
     }
 
-    private void handleLooting() {
-        if (currentState != BlueDragonState.LOOTING) {
-            return;
+    private void lootItems() {
+        lootItem("Dragon bones");
+        lootItem("Dragon spear");
+        lootItem("Shield left half");
+
+        if (config.lootDragonhide()) {
+            lootItem("Blue dragonhide");
+            lootItem("Scaly blue dragonhide");
         }
 
-        if (isInventoryFull()) {
-            currentState = BlueDragonState.BANKING;
-            return;
+        if (config.lootEnsouledHead()) {
+            lootItem("Ensouled dragon head");
         }
 
-        boolean lootedAnything = false;
-
-        if (!isInventoryFull()) {
-            lootedAnything |= lootItem("Dragon bones");
-        }
-        if (!isInventoryFull()) {
-            lootedAnything |= lootItem("Dragon spear");
-        }
-        if (!isInventoryFull()) {
-            lootedAnything |= lootItem("Shield left half");
+        if (config.lootUntradables() && (!Rs2Inventory.isFull() || config.eatForLoot())) {
+            LootingParameters untradableParams = new LootingParameters(15, 1, 1, 0, false, true);
+            untradableParams.setEatFoodForSpace(config.eatForLoot());
+            Rs2GroundItem.lootUntradables(untradableParams);
         }
 
-        if (config.lootDragonhide() && !isInventoryFull()) {
-            lootedAnything |= lootItem("Blue dragonhide");
-            lootedAnything |= lootItem("Scaly blue dragonhide");
-        }
-
-        if (config.lootEnsouledHead() && !isInventoryFull()) {
-            lootedAnything |= lootItem("Ensouled dragon head");
-        }
-
-        if (config.lootUntradables() && !isInventoryFull()) {
-            Rs2GroundItem.lootUntradables(new LootingParameters(15, 1, 1, 0, false, true));
-        }
-
-        if (config.lootMiscItems() && !isInventoryFull()) {
-            Rs2GroundItem.lootItemBasedOnValue(new LootingParameters(config.lootValueThreshold(), 9999999, 8, 1, 1, false, true));
-        }
-
-        sleep(300, 500);
-
-        if (isInventoryFull()) {
-            currentState = BlueDragonState.BANKING;
-            return;
-        }
-
-        if (!hasLootNearby() || !lootedAnything) {
-            currentState = BlueDragonState.FIGHTING;
-            currentTargetId = null;
+        if (config.lootMiscItems() && (!Rs2Inventory.isFull() || config.eatForLoot())) {
+            String[] ignored = config.lootDragonhide() ? new String[0]
+                    : new String[]{"Blue dragonhide", "Scaly blue dragonhide"};
+            Microbot.log("[Loot] Value-based loot pass (threshold=" + config.lootValueThreshold()
+                    + ", lootDragonhide=" + config.lootDragonhide()
+                    + ", ignored=" + java.util.Arrays.toString(ignored) + ")");
+            LootingParameters valueParams = new LootingParameters(
+                    config.lootValueThreshold(), 9999999, 15, 1, 1, false, true, ignored);
+            valueParams.setEatFoodForSpace(config.eatForLoot());
+            Rs2GroundItem.lootItemBasedOnValue(valueParams);
         }
     }
 
-    private boolean lootItem(String itemName) {
-        if (isInventoryFull()) return false;
-
+    private void lootItem(String itemName) {
+        if (Rs2Inventory.isFull() && !config.eatForLoot()) return;
         LootingParameters params = new LootingParameters(15, 1, 1, 0, false, true, itemName);
-        boolean looted = Rs2GroundItem.lootItemsBasedOnNames(params);
-        if (looted) {
+        params.setEatFoodForSpace(config.eatForLoot());
+        if (Rs2GroundItem.lootItemsBasedOnNames(params)) {
+            Microbot.log("[Loot] Picked up: " + itemName);
             if (itemName.equalsIgnoreCase("Dragon bones")) {
                 BlueDragonsOverlay.bonesCollected++;
             } else if (itemName.equalsIgnoreCase("Blue dragonhide")) {
                 BlueDragonsOverlay.hidesCollected++;
             }
         }
-        return looted;
     }
 
     private Rs2NpcModel getAvailableDragon() {
-        Rs2NpcModel dragon = Microbot.getRs2NpcCache().query().withName("Blue dragon").nearestOnClientThread();
+        Rs2NpcModel dragon = Microbot.getRs2NpcCache().query()
+                .withName("Blue dragon")
+                .where(npc -> !npc.isDead())
+                .nearestOnClientThread();
+        if (dragon == null) return null;
 
-        if (dragon != null) {
-            boolean correctId = (dragon.getId() == BLUE_DRAGON_ID_1 || dragon.getId() == BLUE_DRAGON_ID_2 || dragon.getId() == BLUE_DRAGON_ID_3);
-            boolean hasLineOfSight = dragon.hasLineOfSight();
-
-            if (correctId && hasLineOfSight) {
-                return dragon;
-            }
+        int id = dragon.getId();
+        if ((id == BLUE_DRAGON_ID_1 || id == BLUE_DRAGON_ID_2 || id == BLUE_DRAGON_ID_3) && dragon.hasLineOfSight()) {
+            return dragon;
         }
         return null;
     }
 
-    private boolean attackDragon(Rs2NpcModel dragon) {
-        final int dragonId = dragon.getId();
-
-        if (Rs2Combat.inCombat() && !dragon.isInteractingWithPlayer()) {
-            return false;
-        }
-
-        if (dragon.click("Attack")) {
-            boolean dragonKilled = sleepUntil(() -> Microbot.getRs2NpcCache().query().withId(dragonId).nearest() == null, 60000);
-
-            if (dragonKilled) {
-                BlueDragonsOverlay.dragonKillCount++;
-                sleep(600, 900);
-                currentState = BlueDragonState.LOOTING;
-            }
-
-            return true;
-        }
-        return false;
-    }
-
     private boolean isPlayerAtSafeSpot() {
-        return SAFE_SPOT.equals(Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation()));
+        return SAFE_SPOT.equals(Microbot.getClientThread().invoke(() ->
+                Microbot.getClient().getLocalPlayer().getWorldLocation()));
     }
 
-    private void moveToSafeSpot() {
-        Microbot.pauseAllScripts.compareAndSet(false, true);
-
-        int distance = Rs2Player.distanceTo(SAFE_SPOT);
-
-        if (distance > 15) {
-            Rs2Walker.walkTo(SAFE_SPOT, 0);
-            sleepUntil(() -> Rs2Player.distanceTo(SAFE_SPOT) <= 5, 30000);
-        }
-
-        if (!isPlayerAtSafeSpot()) {
-            Rs2Walker.walkFastCanvas(SAFE_SPOT);
-            sleepUntil(this::isPlayerAtSafeSpot, 15000);
-        }
-
-        if (hopIfPlayerAtSafeSpot()) {
-            return;
-        }
-
-        Microbot.pauseAllScripts.compareAndSet(true, false);
-    }
-
-    private boolean hopIfPlayerAtSafeSpot() {
-        boolean otherPlayersAtSafeSpot = false;
+    private void hopIfPlayerAtSafeSpot() {
         List<Player> players = Rs2Player.getPlayers(it -> it != null).collect(Collectors.toList());
+        boolean occupied = players.stream().anyMatch(p ->
+                p != null && !p.equals(Microbot.getClient().getLocalPlayer())
+                        && p.getWorldLocation().distanceTo(SAFE_SPOT) <= 1);
 
-        for (Player player : players) {
-            if (player != null &&
-                    !player.equals(Microbot.getClient().getLocalPlayer()) &&
-                    player.getWorldLocation().distanceTo(SAFE_SPOT) <= 1) {
-                otherPlayersAtSafeSpot = true;
-                break;
-            }
-        }
-
-        if (otherPlayersAtSafeSpot) {
+        if (occupied) {
             Microbot.log("Player at safe spot. Hopping worlds.");
-            Microbot.pauseAllScripts.set(true);
-
-            boolean hopSuccess = Microbot.hopToWorld(findRandomWorld());
+            Microbot.hopToWorld(findRandomWorld());
             sleep(5000);
-
-            Microbot.pauseAllScripts.set(false);
-            return hopSuccess;
         }
-
-        return false;
     }
 
     private int findRandomWorld() {
@@ -472,14 +367,7 @@ public class BlueDragonsScript extends Script {
 
     public void updateConfig(BlueDragonsConfig config) {
         this.config = config;
-
-        if (overlay != null) {
-            overlay.setConfig(config);
-        }
-    }
-
-    private boolean underAttack() {
-        return Rs2Combat.inCombat();
+        if (overlay != null) overlay.setConfig(config);
     }
 
     public void shutdown() {


### PR DESCRIPTION
## Summary
- **Banking fix**: `depositAllExcept` keeps dusty key, runes, rune pouch instead of `depositAll()` nuking everything
- **Spam loop fix**: cancel existing scheduler before starting new one, 600ms tick rate (was 100ms), guard against orphaned futures
- **Combat rewrite**: collapsed FIGHTING/LOOTING/ESCAPE into single non-blocking COMBAT state (AIO Fighter pattern — one action per tick)
- **Safe spot**: natural lure pattern via tick priority (loot → safe spot → attack), 2.4s grace period prevents botlike rapid-fire bouncing
- **Loot config**: dragonhide/ensouled head/untradable toggles respected everywhere including value-based loot, passive `exists()` checks instead of `lootItemsBasedOnNames` for detection
- **New options**: wait-for-loot (detect death animation, wait for drops), eat-for-loot (eat food to free inventory space), loot untradables
- **Dead dragon filter**: skip dragons in death animation to prevent spam-clicking
- **Smart startup**: skip banking when inventory already has food and no loot

## Test plan
- [x] Start plugin in Taverley dungeon with food + dusty key — should skip banking
- [x] Toggle startPlugin off — should stop cleanly with no log spam
- [x] Kill dragon — should wait for death animation, loot bones, return to safe spot
- [x] Verify blue dragonhide NOT looted when toggle is off
- [x] Verify eat-for-loot eats food when inventory full
- [x] Verify safe spot lure works for distant dragons without bouncing