### PR TITLE
fix(eventdismiss): dismiss lamp award dialogue; rename to Random Event Handler

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissOverlay.java
@@ -37,7 +37,7 @@ public class EventDismissOverlay extends OverlayPanel {
         panelComponent.setPreferredSize(new Dimension(200, 0));
 
         panelComponent.getChildren().add(TitleComponent.builder()
-                .text("Event Dismiss")
+                .text("Random Event Handler")
                 .color(Color.CYAN)
                 .build());
 

--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/EventDismissPlugin.java
@@ -13,7 +13,7 @@ import javax.inject.Inject;
 import java.awt.*;
 
 @PluginDescriptor(
-        name = PluginDescriptor.Default + "Event Dismiss",
+        name = PluginDescriptor.Default + "Random Event Handler",
         description = "Dismisses random events and optionally accepts lamps from Genie/Count Check",
         tags = {"random", "events", "microbot", "lamp", "genie"},
         authors = {"Unknown"},
@@ -26,7 +26,7 @@ import java.awt.*;
 )
 @Slf4j
 public class EventDismissPlugin extends Plugin {
-    public static final String version = "2.1.0";
+    public static final String version = "2.1.1";
 
     @Inject
     private EventDismissConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/LampUtility.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/eventdismiss/LampUtility.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.microbot.util.Global;
+import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
@@ -82,6 +83,15 @@ public class LampUtility {
         Global.sleep(600, 1200);
 
         Rs2Widget.clickWidget(LAMP_WIDGET_GROUP, LAMP_CONFIRM_BUTTON);
+
+        // Confirming the skill produces an XP-award "Click here to continue" dialogue.
+        // Dismiss it so the lamp is actually consumed and the leftover dialogue does not
+        // block other plugins once this blocking event releases the script-pause gate.
+        Global.sleepUntil(() -> Rs2Dialogue.hasContinue() || !Rs2Inventory.contains(ItemID.LAMP), 2000);
+        for (int i = 0; i < 5 && Rs2Dialogue.hasContinue(); i++) {
+            Rs2Dialogue.clickContinue();
+            Global.sleep(600, 1200);
+        }
 
         if (!Global.sleepUntil(() -> !Rs2Inventory.contains(ItemID.LAMP), 3000)) {
             log.warn("Lamp was not consumed after confirm");


### PR DESCRIPTION
## Summary
- Fix `LampUtility.useLamp()` leaving the post-confirm "Click here to continue" XP-award dialogue open. The lamp was never consumed, so the `UseLampEvent` blocking event re-queued indefinitely and the `BlockingEventManager` script-pause gate never released — freezing every other running plugin. The continue dialogue is now dismissed (bounded waits) before checking consumption, so the event clears and scripts resume cleanly.
- Rename the plugin display name (`@PluginDescriptor`) and overlay title to **Random Event Handler**. The `@ConfigGroup("EventDismiss")` storage key is intentionally unchanged to preserve existing user settings.
- Bump version `2.1.0` → `2.1.1`.

## Test plan
- `./gradlew build -PpluginList=EventDismissPlugin` — compiles, produces `EventDismissPlugin-2.1.1.jar`.
- Live: trigger a Genie/stray lamp, confirm the skill, and verify the award dialogue is dismissed, the lamp is consumed, and other plugins resume.