### PR TITLE
fix(motherloadmine): keep mining loop alive after a thrown tick

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMinePlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMinePlugin.java
@@ -29,7 +29,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 )
 public class MotherloadMinePlugin extends Plugin {
 
-	static final String version = "1.9.5";
+	static final String version = "1.9.6";
 
     @Inject
     private MotherloadMineConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
@@ -127,40 +127,50 @@ public class MotherloadMineScript extends Script
 
     private void executeTask()
     {
-        if (!super.run() || !Microbot.isLoggedIn())
+        // Guard the whole loop body: an unhandled exception on a single tick would otherwise
+        // silently cancel the scheduleWithFixedDelay task (JDK semantics), freezing the plugin
+        // on its last status with no log. Catching here lets the next 600ms tick recover state.
+        try
         {
-            resetMiningState(true);
-            return;
+            if (!super.run() || !Microbot.isLoggedIn())
+            {
+                resetMiningState(true);
+                return;
+            }
+
+            determineStatusFromInventory();
+            logStatusTransitionIfChanged();
+
+            switch (status)
+            {
+                case IDLE:
+                    break;
+                case MINING:
+                    Rs2Antiban.setActivityIntensity(Rs2Antiban.getActivity().getActivityIntensity());
+                    handleMining();
+                    break;
+                case EMPTY_SACK:
+                    if (Rs2Player.isAnimating()) return;
+                    Rs2Antiban.setActivityIntensity(ActivityIntensity.EXTREME);
+                    emptySack();
+                    break;
+                case FIXING_WATERWHEEL:
+                    if (Rs2Player.isAnimating()) return;
+                    fixWaterwheel();
+                    break;
+                case DEPOSIT_HOPPER:
+                    if (Rs2Player.isAnimating()) return;
+                    depositHopper();
+                    break;
+                case DROP_GEMS:
+                    if (Rs2Player.isAnimating()) return;
+                    dropGems();
+                    break;
+            }
         }
-
-        determineStatusFromInventory();
-        logStatusTransitionIfChanged();
-
-        switch (status)
+        catch (Exception ex)
         {
-            case IDLE:
-                break;
-            case MINING:
-                Rs2Antiban.setActivityIntensity(Rs2Antiban.getActivity().getActivityIntensity());
-                handleMining();
-                break;
-            case EMPTY_SACK:
-                if (Rs2Player.isAnimating()) return;
-                Rs2Antiban.setActivityIntensity(ActivityIntensity.EXTREME);
-                emptySack();
-                break;
-            case FIXING_WATERWHEEL:
-                if (Rs2Player.isAnimating()) return;
-                fixWaterwheel();
-                break;
-            case DEPOSIT_HOPPER:
-                if (Rs2Player.isAnimating()) return;
-                depositHopper();
-                break;
-            case DROP_GEMS:
-                if (Rs2Player.isAnimating()) return;
-                dropGems();
-                break;
+            log.error("MLM executeTask error; recovering on next tick", ex);
         }
     }
 


### PR DESCRIPTION
## Problem

The Motherlode Mine plugin can get permanently stuck on **IDLE**, sitting there doing nothing while the panel still reports the plugin as *running*. Stopping/restarting the plugin does not recover it.

## Root cause

`MotherloadMineScript.executeTask()` is scheduled with `scheduleWithFixedDelay(this::executeTask, 0, 600, MILLISECONDS)`. Per the JDK contract, **if any execution of a fixed-delay task throws, all subsequent executions are silently suppressed** — the loop is cancelled with no log and no crash. The RuneLite plugin stays *enabled*, so status endpoints/overlay keep showing the last `status` (`IDLE`) forever.

A blocking event — observed with EventDismiss accepting a stray Genie lamp and using it — runs on its own thread concurrently with MLM's `depositHopper()`/`emptySack()` workflow. The two threads driving dialogue/widgets at once left game state that made a later MLM tick throw, killing the loop. Because the throw was deterministic given that state, manual restarts re-threw on the first tick and also died.

Verified against a live stuck client: `pauseAllScripts=false`, no blocking event executing, no random-event NPC present — i.e. none of the `Script.run()` pause gates were active. The loop was simply gone.

## Fix

Wrap the `executeTask()` body in `try/catch` (mirroring the existing guard in `AutoMiningScript`) and log the stack trace via `log.error`. A transient per-tick exception now recovers on the next 600 ms tick instead of permanently killing the script — `determineStatusFromInventory()` re-runs and mining resumes on its own.

No behavioural change on the happy path, and no added clicks: the loop cadence is unchanged (600 ms fixed delay; the next run is still scheduled 600 ms *after* the previous finishes), and each action path keeps its existing gating.

Logging the stack trace also means the next occurrence of the underlying concurrency throw will finally be visible, so the trigger can be pinned down and fixed separately.

Version: `1.9.5` → `1.9.6`.

## Test plan
- [x] `./gradlew build -PpluginList=MotherloadMinePlugin` → `BUILD SUCCESSFUL`, `MotherloadMinePlugin-1.9.6.jar` produced.