### PR TITLE
fix: correct cooking item data (botanical pie typo, uncooked egg ids)

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/cooking/AutoCookingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cooking/AutoCookingPlugin.java
@@ -30,7 +30,7 @@ import static net.runelite.client.plugins.PluginDescriptor.Mocrosoft;
 )
 @Slf4j
 public class AutoCookingPlugin extends Plugin {
-    public final static String version = "1.1.4";
+    public final static String version = "1.1.5";
     @Inject
     AutoCookingScript autoCookingScript;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/cooking/enums/CookingItem.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cooking/enums/CookingItem.java
@@ -48,7 +48,7 @@ public enum CookingItem
 	UNCOOKED_APPLE_PIE("uncooked apple pie", ItemID.UNCOOKED_APPLE_PIE, 30, "apple pie", ItemID.APPLE_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
 	RAW_GARDEN_PIE("raw garden pie", ItemID.UNCOOKED_GARDEN_PIE, 34, "garden pie", ItemID.GARDEN_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
 	RAW_FISH_PIE("raw fish pie", ItemID.UNCOOKED_FISH_PIE, 47, "fish pie", ItemID.FISH_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
-	UNCOOKED_BOTANICAL_PIE("uncooked batanical pie", ItemID.UNCOOKED_BOTANICAL_PIE, 52, "botanical pie", ItemID.BOTANICAL_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
+	UNCOOKED_BOTANICAL_PIE("uncooked botanical pie", ItemID.UNCOOKED_BOTANICAL_PIE, 52, "botanical pie", ItemID.BOTANICAL_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
 	UNCOOKED_MUSHROOM_PIE("uncooked mushroom pie", ItemID.UNCOOKED_MUSHROOM_PIE, 60, "mushroom pie", ItemID.MUSHROOM_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
 	RAW_ADMIRAL_PIE("raw admiral pie", ItemID.UNCOOKED_ADMIRAL_PIE, 70, "admiral pie", ItemID.ADMIRAL_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
 	UNCOOKED_DRAGONFRUIT_PIE("uncooked dragonfruit pie", ItemID.UNCOOKED_DRAGONFRUIT_PIE, 73, "dragonfruit pie", ItemID.DRAGONFRUIT_PIE, "burnt pie", ItemID.BURNT_PIE, CookingAreaType.RANGE),
@@ -63,7 +63,7 @@ public enum CookingItem
 	UNCOOKED_CAKE("uncooked cake", ItemID.UNCOOKED_CAKE, 40, "cake", ItemID.CAKE, "burnt cake", ItemID.BURNT_CAKE, CookingAreaType.RANGE),
 	// Vegetable
 	POTATO("potato", ItemID.POTATO, 7, "baked potato", ItemID.POTATO_BAKED, "burnt potato", ItemID.POTATO_BURNT, CookingAreaType.RANGE),
-	UNCOOKED_EGG("uncooked egg", ItemID.SCRAMBLED_EGG, 13, "scrambled egg", ItemID.SCRAMBLED_EGG, "burnt egg", ItemID.BOWL_EGG_BURNT, CookingAreaType.BOTH),
+	UNCOOKED_EGG("uncooked egg", ItemID.BOWL_EGG_RAW, 13, "scrambled egg", ItemID.BOWL_EGG_SCRAMBLED, "burnt egg", ItemID.BOWL_EGG_BURNT, CookingAreaType.RANGE),
 	SWEETCORN("sweetcorn", ItemID.SWEETCORN, 28, "cooked sweetcorn", ItemID.SWEETCORN_COOKED, "burnt sweetcorn", ItemID.SWEETCORN_BURNT, CookingAreaType.BOTH),
 	;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/cooking/enums/CookingItem.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/cooking/enums/CookingItem.java
@@ -63,7 +63,7 @@ public enum CookingItem
 	UNCOOKED_CAKE("uncooked cake", ItemID.UNCOOKED_CAKE, 40, "cake", ItemID.CAKE, "burnt cake", ItemID.BURNT_CAKE, CookingAreaType.RANGE),
 	// Vegetable
 	POTATO("potato", ItemID.POTATO, 7, "baked potato", ItemID.POTATO_BAKED, "burnt potato", ItemID.POTATO_BURNT, CookingAreaType.RANGE),
-	UNCOOKED_EGG("uncooked egg", ItemID.BOWL_EGG_RAW, 13, "scrambled egg", ItemID.BOWL_EGG_SCRAMBLED, "burnt egg", ItemID.BOWL_EGG_BURNT, CookingAreaType.RANGE),
+	UNCOOKED_EGG("uncooked egg", ItemID.BOWL_EGG_RAW, 13, "scrambled egg", ItemID.BOWL_EGG_SCRAMBLED, "burnt egg", ItemID.BOWL_EGG_BURNT, CookingAreaType.BOTH),
 	SWEETCORN("sweetcorn", ItemID.SWEETCORN, 28, "cooked sweetcorn", ItemID.SWEETCORN_COOKED, "burnt sweetcorn", ItemID.SWEETCORN_BURNT, CookingAreaType.BOTH),
 	;
 


### PR DESCRIPTION
## Summary

Two data bugs in `cooking/enums/CookingItem.java`:

1. The raw display name for botanical pie is misspelled ("uncooked batanical pie"). The script gates inventory and bank checks on exact name matching, so the plugin can never recognize the item and stops with "no raw food found" when this food is selected.
2. The `UNCOOKED_EGG` entry uses `ItemID.SCRAMBLED_EGG` as both the raw and the cooked item id, so the cook action targets the wrong item and the entry can never cook.

## Fix

- Corrected the display name to "uncooked botanical pie".
- Pointed `UNCOOKED_EGG` at the real item ids from gameval: raw `BOWL_EGG_RAW` (7076), cooked `BOWL_EGG_SCRAMBLED` (7078), burnt `BOWL_EGG_BURNT` (7090). The cooking area stays BOTH (the wiki confirms scrambled egg can be made on a range or a fire).
- Bumped the plugin patch version per the repo version policy.

## Testing

- `./gradlew clean build` green on JDK 11 (Temurin), matching CI.
- Loaded the plugin locally: uncooked botanical pie is now recognized in inventory and bank by the name-based checks, and the uncooked egg entry resolves the correct raw item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
