### PR TITLE
fix(birdhouse): invoke Rs2Walker and hardcode mushtree transport

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsPlugin.java
@@ -26,7 +26,7 @@ import java.awt.*;
 )
 @Slf4j
 public class FornBirdhouseRunsPlugin extends Plugin {
-    final static String version = "1.1.3";
+    final static String version = "1.1.4";
     @Provides
     FornBirdhouseRunsConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(FornBirdhouseRunsConfig.class);

--- a/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/birdhouseruns/FornBirdhouseRunsScript.java
@@ -22,6 +22,7 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.shortestpath.Restriction;
 import net.runelite.client.plugins.microbot.shortestpath.ShortestPathPlugin;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 
@@ -42,6 +43,8 @@ public class FornBirdhouseRunsScript extends Script {
     private static final WorldPoint birdhouseLocation3 = new WorldPoint(3677, 3882, 0);
     private static final WorldPoint birdhouseLocation4 = new WorldPoint(3679, 3815, 0);
     private static final WorldPoint SOUTH_ROWBOAT = new WorldPoint(3724, 3807, 0);
+    private static final WorldPoint VERDANT_MUSHTREE = new WorldPoint(3757, 3757, 0);
+    private static final int MUSHTREE_OBJECT_ID = 30924;
     // Each location maps to a BIRDHOUSE_TRANSMIT_* varp. See isEmpty/isBuilt/isSeeded
     // below for the canonical state decoding (matches RuneLite's BirdHouseState).
     private static final int VARP_HOUSE_1 = VarPlayerID.BIRDHOUSE_TRANSMIT_D; // Verdant SW
@@ -176,6 +179,7 @@ public class FornBirdhouseRunsScript extends Script {
                     switch (botStatus) {
                         case TELEPORTING:
                         case VERDANT_TELEPORT:
+                            Rs2Walker.walkTo(birdhouseLocation1);
                             botStatus = states.DISMANTLE_HOUSE_1;
                             advanced = true;
                             break;
@@ -216,6 +220,10 @@ public class FornBirdhouseRunsScript extends Script {
                             }
                             break;
                         case MUSHROOM_TELEPORT:
+                            Rs2GameObject.interact(MUSHTREE_OBJECT_ID, "Use");
+                            sleepUntil(() -> Rs2Widget.findWidget("Mycelium Transportation System") != null, 5000);
+                            Rs2Widget.clickWidget("Mushroom Meadow");
+                            sleepUntil(() -> Rs2Player.distanceTo(birdhouseLocation3) < 20, 10000);
                             botStatus = states.DISMANTLE_HOUSE_3;
                             advanced = true;
                             break;


### PR DESCRIPTION
## Summary
- **TELEPORTING state** was a no-op that skipped straight to DISMANTLE_HOUSE_1 without invoking Rs2Walker, so the player never left the bank. Now calls `Rs2Walker.walkTo(birdhouseLocation1)` which routes via digsite pendant to Fossil Island.
- **MUSHROOM_TELEPORT state** was also a no-op that relied on Rs2Walker to route through the mushtree, which sometimes detoured to the bank. Replaced with direct mushtree interaction: Use object → select Mushroom Meadow from widget → wait for arrival.
- Version bump 1.1.3 → 1.1.4

## Test plan
- [ ] Start plugin at a bank on the mainland — verify it gears up, then Rs2Walker routes to Fossil Island via digsite pendant
- [ ] After houses 1 & 2, verify mushtree interaction fires and player arrives at Mushroom Meadow
- [ ] Complete full 4-house run end to end