### PR TITLE
Fix Animated Armour food handling and armoury navigation

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/animatedarmour/AnimatedArmourPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/animatedarmour/AnimatedArmourPlugin.java
@@ -26,7 +26,7 @@ import java.awt.*;
 @Slf4j
 public class AnimatedArmourPlugin extends Plugin {
 
-    static final String version = "1.0.1";
+    static final String version = "1.0.2";
     @Inject
     private AnimatedArmourConfig config;
 

--- a/src/main/java/net/runelite/client/plugins/microbot/animatedarmour/AnimatedArmourScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/animatedarmour/AnimatedArmourScript.java
@@ -1,11 +1,13 @@
 package net.runelite.client.plugins.microbot.animatedarmour;
 
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -20,6 +22,16 @@ public class AnimatedArmourScript extends Script {
 
     public static boolean test = false;
 
+    // Armoury entrance double-door (plane 0). From the shortest-path transport data:
+    //   2855 3546 0 <-> 2855 3545 0  (Open;Door;24309)
+    //   2854 3546 0 <-> 2854 3545 0  (Open;Door;24306)
+    // These are already in the walker's transport graph, so pathfinding opens them
+    // automatically; the explicit interact below is only a fallback when the walker
+    // stalls on the wrong side of the door.
+    private static final int[] ARMOURY_DOOR_IDS = {24309, 24306};
+    // Armour stand object tile (unchanged from the original plugin).
+    private static final WorldPoint ARMOUR_STAND_TILE = new WorldPoint(2851, 3536, 0);
+
     public boolean run(AnimatedArmourConfig config) {
         Microbot.enableAutoRunOn = false;
 
@@ -32,17 +44,25 @@ public class AnimatedArmourScript extends Script {
                 boolean hasArmorPieces = Rs2Inventory.contains(item -> item.getName().contains("platebody")) &&
                         Rs2Inventory.contains(item -> item.getName().contains("platelegs")) &&
                         Rs2Inventory.contains(item -> item.getName().contains("full helm"));
-                if (Rs2Inventory.getInventoryFood().isEmpty() && config.foodAmount() > 0) {
-                    Rs2Bank.walkToBank(BankLocation.WARRIORS_GUILD);
-                    Rs2Bank.openBank();
-                    Rs2Bank.withdrawX(config.food().getId(), config.foodAmount());
-                    Rs2Walker.walkTo(2855, 3540, 0);
-                }
+
                 if (hasArmorPieces) {
-                    animateArmor();
+                    // Never bank mid-kill. Only restock food before animating the next
+                    // suit, when fewer than two food remain.
+                    if (Rs2Inventory.getInventoryFood().size() < 2 && config.foodAmount() > 0) {
+                        bankForFood(config);
+                    } else {
+                        animateArmor(config);
+                    }
                 } else {
-                    Rs2Player.eatAt(Rs2Random.randomGaussian(30, 3));
-                    loot();
+                    Rs2Player.eatAt(Rs2Random.randomGaussian(60, 5));
+                    // Emergency only: if we ran dry mid-fight and are about to die,
+                    // abandon the kill and bank rather than dying.
+                    if (Rs2Inventory.getInventoryFood().isEmpty() && config.foodAmount() > 0
+                            && Rs2Player.getHealthPercentage() <= Rs2Random.randomGaussian(20, 3)) {
+                        bankForFood(config);
+                    } else {
+                        loot();
+                    }
                 }
 
                 long endTime = System.currentTimeMillis();
@@ -50,22 +70,69 @@ public class AnimatedArmourScript extends Script {
                 System.out.println("Total time for loop " + totalTime);
 
             } catch (Exception ex) {
+                // A stop/restart can interrupt a client-thread call mid-flight (e.g. the
+                // door-open fallback). Restore the flag and exit quietly instead of logging
+                // a misleading ERROR stack trace.
+                if (ex instanceof InterruptedException || ex.getCause() instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
                 Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
             }
         }, 0, 1000, TimeUnit.MILLISECONDS);
         return true;
     }
 
-    public void animateArmor() {
-        WorldPoint armorStandLocation = new WorldPoint(2851, 3536, 0);
-        Rs2TileObjectModel armorStand = Microbot.getRs2TileObjectCache().query().within(armorStandLocation, 0).nearest();
-        if (armorStand != null) {
-            armorStand.click();
-            Rs2Player.waitForAnimation();
-        }
-
+    private void bankForFood(AnimatedArmourConfig config) {
+        Rs2Bank.walkToBank(BankLocation.WARRIORS_GUILD);
+        Rs2Bank.openBank();
+        Rs2Bank.withdrawX(config.food().getId(), config.foodAmount());
+        Rs2Bank.closeBank();
+        walkToArmourRoom();
     }
 
+    private void walkToArmourRoom() {
+        // Walk with a distance tolerance instead of demanding the exact tile -- the
+        // exact-tile invocation is what made the short hop slow and prone to re-pathing.
+        Rs2Walker.walkTo(ARMOUR_STAND_TILE, 4);
+        // Fallback: if we stalled on the far side of the door, click it directly. The
+        // door is located by id once it has loaded, so no approach tile is hardcoded.
+        WorldPoint loc = Rs2Player.getWorldLocation();
+        if (loc != null && loc.distanceTo(ARMOUR_STAND_TILE) > 4) {
+            if (Rs2GameObject.interact(ARMOURY_DOOR_IDS, "Open")) {
+                sleepUntil(() -> !Rs2Player.isMoving(), 3000);
+                Rs2Walker.walkTo(ARMOUR_STAND_TILE, 4);
+            }
+        }
+    }
+
+    public void animateArmor(AnimatedArmourConfig config) {
+        // Make sure we actually reached the stand before trying to target it.
+        WorldPoint loc = Rs2Player.getWorldLocation();
+        if (loc == null || loc.distanceTo(ARMOUR_STAND_TILE) > 8) {
+            walkToArmourRoom();
+            return;
+        }
+        Rs2TileObjectModel armorStand = Microbot.getRs2TileObjectCache().query().within(ARMOUR_STAND_TILE, 0).nearest();
+        if (armorStand != null) {
+            armorStand.click();
+            // Eat one tick later, never on the same tick as the animate click (which
+            // would cancel it). This uses the idle animate delay to top up HP, but
+            // only when it won't be wasted (missing HP >= the food's heal amount).
+            sleepUntilNextTick();
+            eatDuringAnimateIfEfficient(config);
+            Rs2Player.waitForAnimation();
+        }
+    }
+
+    private void eatDuringAnimateIfEfficient(AnimatedArmourConfig config) {
+        if (Rs2Inventory.getInventoryFood().isEmpty()) return;
+        int missing = Rs2Player.getRealSkillLevel(Skill.HITPOINTS)
+                - Rs2Player.getBoostedSkillLevel(Skill.HITPOINTS);
+        if (missing >= config.food().getHeal()) {
+            Rs2Player.useFood();
+        }
+    }
 
     public void loot() {
         LootingParameters valueParams = new LootingParameters(


### PR DESCRIPTION
## Summary

Fixes food handling and armoury navigation in the Animated Armour plugin.

### Eating
- Raise the eat threshold from ~30% to ~60% HP (Gaussian-randomized) so the bot eats sooner.
- Eat opportunistically during the animate delay, one tick after the animate click (never same-tick, which would cancel the animate), and only when it won't overheal (missing HP >= the configured food's heal amount, e.g. Salmon = 9).

### Banking — no more lost suits
- The plugin previously walked to the bank when out of food, which could happen mid-kill and cost the suit. Now it only restocks **before** animating the next suit, when fewer than two food remain.
- Added an emergency mid-fight bank as a last resort only (food empty **and** HP <= ~20%) to avoid dying outright. This will abandon the current suit by design — death is the worse outcome.

### Armoury navigation
- Walk with a distance tolerance (`walkTo(stand, 4)`) instead of demanding the exact tile, which was the slow, re-pathing invocation.
- Explicit door-open fallback (door IDs `24309` / `24306`, from the shortest-path transport data) if the walker stalls on the wrong side of the armoury door.
- Guard armour-stand targeting on arrival distance so we re-walk rather than silently failing the lookup; null-guard `getWorldLocation()`.

### Housekeeping
- Bump plugin version `1.0.1` → `1.0.2`.
- Rebased onto current `main`; adopts the new queryable cache API (`Rs2TileObjectModel.click()`) for the armour stand, consistent with the upstream combat-plugin migration.

## Testing

- **Builds clean:** `./gradlew build -PpluginList=AnimatedArmourPlugin` → `BUILD SUCCESSFUL` (plugin compiles, `AnimatedArmourPlugin-1.0.2.jar` packaged, tests pass).
- In-game validation still recommended for the door-click fallback path and the eat-one-tick-after-animate timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)