### PR TITLE
fix(barbarianfishing): replace isInteracting, add Rs2DropUtils

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingOverlay.java
@@ -2,7 +2,6 @@ package net.runelite.client.plugins.microbot.barbarianfishing;
 
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.barbarianfishing.BarbarianFishingPlugin;
-import net.runelite.client.plugins.microbot.barbarianfishing.BarbarianFishingScript;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -52,7 +51,7 @@ public class BarbarianFishingOverlay extends OverlayPanel {
 
             panelComponent.getChildren().add(LineComponent.builder()
                     .left(Microbot.status)
-                    .right("Version:" + BarbarianFishingScript.version)
+                    .right("Version:" + BarbarianFishingPlugin.version)
                     .build());
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingPlugin.java
@@ -1,16 +1,11 @@
 package net.runelite.client.plugins.microbot.barbarianfishing;
 
 import com.google.inject.Provides;
-import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.PluginConstants;
-import net.runelite.client.plugins.microbot.barbarianfishing.BarbarianFishingConfig;
-import net.runelite.client.plugins.microbot.barbarianfishing.BarbarianFishingOverlay;
-import net.runelite.client.plugins.microbot.barbarianfishing.BarbarianFishingScript;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
@@ -29,7 +24,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class BarbarianFishingPlugin extends Plugin {
-    public static final String version = "1.0.0";
+    public static final String version = "1.1.0";
     @Inject
     BarbarianFishingScript fishingScript;
     @Inject
@@ -53,13 +48,10 @@ public class BarbarianFishingPlugin extends Plugin {
         fishingScript.run(config);
     }
 
-    @Subscribe
-    public void onGameTick(GameTick tick) {
-        fishingScript.onGameTick();
-    }
-
     protected void shutDown() {
         fishingScript.shutdown();
-        overlayManager.remove(fishingOverlay);
+        if (overlayManager != null) {
+            overlayManager.remove(fishingOverlay);
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingScript.java
@@ -4,16 +4,15 @@ import net.runelite.api.gameval.ItemID;
 import net.runelite.client.game.FishingSpot;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
-import net.runelite.client.plugins.microbot.barbarianfishing.BarbarianFishingConfig;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.barbarianfishing.Rs2DropUtils;
 import net.runelite.client.plugins.microbot.util.inventory.InteractOrder;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
-import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
@@ -24,64 +23,69 @@ import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.validateInter
 public class BarbarianFishingScript extends Script {
     private long specReadyTime = 0;
     private boolean specActivated = false;
-    public static String version = "1.1.3";
-    public static int timeout = 0;
+    private int animationTimeout = 600;
     private BarbarianFishingConfig config;
 
     public boolean run(BarbarianFishingConfig config) {
         this.config = config;
+        specReadyTime = 0;
+        specActivated = false;
+        animationTimeout = 600;
         Rs2Antiban.resetAntibanSettings();
         Rs2Antiban.antibanSetupTemplates.applyFishingSetup();
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
-            if (!super.run() || !Microbot.isLoggedIn() || !Rs2Inventory.hasItem("feather") || !Rs2Inventory.hasItem("rod")) {
-                return;
-            }
-
-            if (Rs2Equipment.isWearing(ItemID.DRAGON_HARPOON)) {
-                if (Rs2Combat.getSpecEnergy() == 1000) {
-                    if (specReadyTime == 0) {
-                        double delay = Rs2Random.gaussRand(45000, 30000); // Delay in ms (mean 1200, stddev 200)
-                        specReadyTime = System.currentTimeMillis() + (long) delay;
-                    } else if (!specActivated && System.currentTimeMillis() >= specReadyTime) {
-                        Rs2Combat.setSpecState(true);
-                        specActivated = true;
-                    }
-                } else {
-                    specReadyTime = 0;
-                    specActivated = false;
+            try {
+                if (!super.run() || !Microbot.isLoggedIn() || !Rs2Inventory.hasItem("feather") || !Rs2Inventory.hasItem("Barbarian rod")) {
+                    return;
                 }
+
+                if (Rs2Equipment.isWearing(ItemID.DRAGON_HARPOON)) {
+                    if (Rs2Combat.getSpecEnergy() == 1000) {
+                        if (specReadyTime == 0) {
+                            double delay = Math.max(0, Rs2Random.gaussRand(45000, 30000));
+                            specReadyTime = System.currentTimeMillis() + (long) delay;
+                        } else if (!specActivated && System.currentTimeMillis() >= specReadyTime) {
+                            if (Rs2Combat.setSpecState(true)) {
+                                specActivated = true;
+                            }
+                        }
+                    } else {
+                        specReadyTime = 0;
+                        specActivated = false;
+                    }
+                }
+
+                if (Rs2Inventory.isFull()) {
+                    dropInventoryItems(config);
+                    return;
+                }
+
+                if (Rs2AntibanSettings.actionCooldownActive) return;
+
+                if (Rs2Player.isAnimating(animationTimeout) || Rs2Player.isMoving())
+                    return;
+
+                animationTimeout = (int) Rs2Random.truncatedGauss(600, 1200, 2.0);
+
+                Rs2NpcModel fishingspot = findFishingSpot();
+                if (fishingspot == null) {
+                    return;
+                }
+
+                if (!Rs2Camera.isTileOnScreen(fishingspot.getLocalLocation())) {
+                    validateInteractable(fishingspot.getNpc());
+                }
+
+                if (fishingspot.click("Use-rod")) {
+                    Rs2Antiban.actionCooldown();
+                    Rs2Antiban.takeMicroBreakByChance();
+                }
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
             }
-
-            if (Rs2AntibanSettings.actionCooldownActive) return;
-
-            if (Rs2Player.isInteracting())
-                return;
-
-            if (Rs2Inventory.isFull()) {
-                dropInventoryItems(config);
-                return;
-            }
-
-            Rs2NpcModel fishingspot = findFishingSpot();
-            if (fishingspot == null) {
-                return;
-            }
-
-            if (!Rs2Camera.isTileOnScreen(fishingspot.getLocalLocation())) {
-                validateInteractable(fishingspot.getNpc());
-            }
-
-            if(fishingspot.click("Use-rod")) {
-                Rs2Antiban.actionCooldown();
-                Rs2Antiban.takeMicroBreakByChance();
-            };
 
         }, 0, 600, TimeUnit.MILLISECONDS);
         return true;
-    }
-
-    public void onGameTick() {
-
     }
 
     private Rs2NpcModel findFishingSpot() {
@@ -92,7 +96,10 @@ public class BarbarianFishingScript extends Script {
 
     private void dropInventoryItems(BarbarianFishingConfig config) {
         InteractOrder dropOrder = config.dropOrder() == InteractOrder.RANDOM ? InteractOrder.random() : config.dropOrder();
-        Rs2Inventory.dropAll(x -> x.getName().toLowerCase().contains("leaping"), dropOrder);
+        Rs2DropUtils.dropAllHumanized(x -> {
+            String name = x.getName().toLowerCase();
+            return name.contains("leaping") || name.contains("roe") || name.contains("caviar");
+        }, dropOrder);
     }
 
     public void shutdown() {

--- a/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/Rs2DropUtils.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/Rs2DropUtils.java
@@ -1,0 +1,77 @@
+package net.runelite.client.plugins.microbot.barbarianfishing;
+
+import net.runelite.client.plugins.microbot.Microbot;
+
+import net.runelite.client.plugins.microbot.util.inventory.InteractOrder;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.math.Rs2Random;
+import net.runelite.client.plugins.microbot.util.mouse.naturalmouse.api.MouseMotionFactory;
+import net.runelite.client.plugins.microbot.util.mouse.naturalmouse.api.SpeedManager;
+import net.runelite.client.plugins.microbot.util.mouse.naturalmouse.support.DefaultSpeedManager;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+
+/**
+ * Humanized item dropping with fast natural mouse movement.
+ * Shared across all Hub plugins — included in each JAR during build.
+ */
+public final class Rs2DropUtils {
+
+    private static final long DROP_MOUSE_BASE_MS = 40;
+
+    private Rs2DropUtils() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Drop matching items with humanized timing and sped-up natural mouse.
+     * Each drop session rolls a pace seed (150-250ms), then jitters per drop.
+     */
+    public static void dropAllHumanized(Predicate<Rs2ItemModel> predicate, InteractOrder order) {
+        List<Rs2ItemModel> items = Rs2Inventory.calculateInteractOrder(
+                Rs2Inventory.items(predicate).collect(Collectors.toList()), order);
+
+        if (items.isEmpty()) return;
+
+        int pace = Rs2Random.fancyNormalSample(150, 250);
+
+        SpeedManager savedManager = speedUpMouse();
+        try {
+            for (int i = 0; i < items.size(); i++) {
+                Rs2Inventory.interact(items.get(i), "Drop");
+
+                if (i < items.size() - 1) {
+                    int delay = Rs2Random.logNormalBounded(
+                            (int) (pace * 0.7),
+                            (int) (pace * 1.3));
+                    sleep(delay);
+                }
+            }
+        } finally {
+            restoreMouse(savedManager);
+        }
+    }
+
+    private static SpeedManager speedUpMouse() {
+        if (Microbot.naturalMouse == null) return null;
+
+        MouseMotionFactory factory = Microbot.naturalMouse.getFactory();
+        SpeedManager original = factory.getSpeedManager();
+
+        DefaultSpeedManager fast = new DefaultSpeedManager();
+        fast.setMouseMovementBaseTimeMs(DROP_MOUSE_BASE_MS);
+        factory.setSpeedManager(fast);
+
+        return original;
+    }
+
+    private static void restoreMouse(SpeedManager original) {
+        if (Microbot.naturalMouse == null || original == null) return;
+        Microbot.naturalMouse.getFactory().setSpeedManager(original);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `Rs2Player.isInteracting()` with `isAnimating(timeout)` / `isMoving()` using randomized timeouts via `Rs2Random.truncatedGauss` for more reliable fishing state detection
- Add shared `Rs2DropUtils` utility with humanized item dropping — per-session pace seed, log-normal jitter, and sped-up natural mouse during drop sequences
- Fix stale state on plugin restart (reset `specReadyTime`, `specActivated`, `animationTimeout` in `run()`)
- Fix spec activation edge cases: clamp negative `gaussRand` delays, check `setSpecState` return value
- Fix inventory full detection: check `isFull()` before `actionCooldownActive` so drops aren't blocked by antiban cooldown
- Drop filter now includes roe and caviar byproducts
- Remove dead code: `onGameTick()` plumbing, duplicate `version` field, unused `timeout` field
- Add try-catch around scheduled executor lambda to prevent silent task death
- Add `shutDown()` null guard for overlay manager (symmetric with `startUp()`)
- Bump plugin version to 1.1.0

## Test plan
- [ ] Enable Barbarian Fisher plugin and verify fishing starts correctly
- [ ] Verify script recovers when fishing spot disappears (no stuck "busy" state)
- [ ] Verify inventory drops correctly when full (including roe/caviar)
- [ ] Verify drop speed is noticeably faster than stock with natural mouse still moving
- [ ] Stop and restart the plugin — verify no stale state issues
- [ ] Verify dragon harpoon special attack timing works correctly