### PR TITLE
fix(motherlode): recover from logout interruptions

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMinePlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMinePlugin.java
@@ -29,7 +29,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 )
 public class MotherloadMinePlugin extends Plugin {
 
-	static final String version = "1.9.6";
+	static final String version = "1.9.7";
 
     @Inject
     private MotherloadMineConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/motherloadmine/MotherloadMineScript.java
@@ -92,6 +92,7 @@ public class MotherloadMineScript extends Script
 
 	private boolean shouldEmptySack = false;
 	private boolean shouldRepairWaterwheel = false;
+	private boolean emptySackWorkflowActive = false;
 	private long idleSince = 0;
 	private int idleThreshold = 0;
 	private boolean pickedUpHammer = false;
@@ -110,7 +111,7 @@ public class MotherloadMineScript extends Script
     {
         log.info("Starting MotherloadMine script");
         initialize();
-        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(this::executeTask, 0, 600, TimeUnit.MILLISECONDS);
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(this::executeTaskSafely, 0, 600, TimeUnit.MILLISECONDS);
         return true;
     }
 
@@ -123,57 +124,60 @@ public class MotherloadMineScript extends Script
         lastLoggedStatus = null;
         shouldEmptySack = false;
 		shouldRepairWaterwheel = false;
+		emptySackWorkflowActive = false;
+    }
+
+    private void executeTaskSafely()
+    {
+        try
+        {
+            executeTask();
+        }
+        catch (Exception ex)
+        {
+            log.error("Unhandled error in MLM main loop; resetting runtime state", ex);
+            abortCurrentWorkflow();
+        }
     }
 
     private void executeTask()
     {
-        // Guard the whole loop body: an unhandled exception on a single tick would otherwise
-        // silently cancel the scheduleWithFixedDelay task (JDK semantics), freezing the plugin
-        // on its last status with no log. Catching here lets the next 600ms tick recover state.
-        try
+        if (!super.run() || !isWorkflowRunnable())
         {
-            if (!super.run() || !Microbot.isLoggedIn())
-            {
-                resetMiningState(true);
-                return;
-            }
-
-            determineStatusFromInventory();
-            logStatusTransitionIfChanged();
-
-            switch (status)
-            {
-                case IDLE:
-                    break;
-                case MINING:
-                    Rs2Antiban.setActivityIntensity(Rs2Antiban.getActivity().getActivityIntensity());
-                    handleMining();
-                    break;
-                case EMPTY_SACK:
-                    if (Rs2Player.isAnimating()) return;
-                    Rs2Antiban.setActivityIntensity(ActivityIntensity.EXTREME);
-                    emptySack();
-                    break;
-                case FIXING_WATERWHEEL:
-                    if (Rs2Player.isAnimating()) return;
-                    fixWaterwheel();
-                    break;
-                case DEPOSIT_HOPPER:
-                    if (Rs2Player.isAnimating()) return;
-                    depositHopper();
-                    break;
-                case DROP_GEMS:
-                    if (Rs2Player.isAnimating()) return;
-                    dropGems();
-                    break;
-            }
+            abortCurrentWorkflow();
+            return;
         }
-        catch (Exception ex)
+
+        determineStatusFromInventory();
+        logStatusTransitionIfChanged();
+
+        switch (status)
         {
-            log.error("MLM executeTask error; recovering on next tick", ex);
+            case IDLE:
+                break;
+            case MINING:
+                Rs2Antiban.setActivityIntensity(Rs2Antiban.getActivity().getActivityIntensity());
+                handleMining();
+                break;
+            case EMPTY_SACK:
+                if (Rs2Player.isAnimating()) return;
+                Rs2Antiban.setActivityIntensity(ActivityIntensity.EXTREME);
+                emptySack();
+                break;
+            case FIXING_WATERWHEEL:
+                if (Rs2Player.isAnimating()) return;
+                fixWaterwheel();
+                break;
+            case DEPOSIT_HOPPER:
+                if (Rs2Player.isAnimating()) return;
+                depositHopper();
+                break;
+            case DROP_GEMS:
+                if (Rs2Player.isAnimating()) return;
+                dropGems();
+                break;
         }
     }
-
     private String[] SPEC_PICKAXES = {"dragon pickaxe", "crystal pickaxe", "infernal pickaxe"};
 
     private void handlePickaxeSpec() {
@@ -273,30 +277,87 @@ public class MotherloadMineScript extends Script
 
     private void emptySack()
 	{
-        log.info("Emptying sack workflow started");
-		ensureLowerFloor();
-
-		while ((Microbot.getVarbitValue(VarbitID.MOTHERLODE_SACK_TRANSMIT) > 0 || hasOreInInventory()) && isRunning())
+		if (!emptySackWorkflowActive)
 		{
-			if (hasOreInInventory())
-			{
-				useDepositBox();
-			}
-            else if (canDropPayDirt()) {
-                depositHopper();
-            }
-			else
-			{
-                rs2TileObjectCache.query().interact(ObjectID.MOTHERLODE_SACK);
-				sleepUntil(this::hasOreInInventory);
-			}
+			emptySackWorkflowActive = true;
+			log.info("Emptying sack workflow started");
 		}
 
+		if (!isWorkflowRunnable())
+		{
+			abortCurrentWorkflow();
+			return;
+		}
+
+		ensureLowerFloor();
+		if (!isWorkflowRunnable())
+		{
+			abortCurrentWorkflow();
+			return;
+		}
+
+		if (Microbot.getVarbitValue(VarbitID.MOTHERLODE_SACK_TRANSMIT) <= 0 && !hasOreInInventory())
+		{
+			completeEmptySackWorkflow();
+			return;
+		}
+
+		if (hasOreInInventory())
+		{
+			useDepositBox();
+			return;
+		}
+
+        if (canDropPayDirt())
+        {
+            depositHopper();
+            return;
+        }
+
+        rs2TileObjectCache.query().interact(ObjectID.MOTHERLODE_SACK);
+		sleepUntil(() -> !isWorkflowRunnable() || hasOreInInventory(), 10_000);
+	}
+
+	private void completeEmptySackWorkflow()
+	{
 		shouldEmptySack = false;
 		shouldRepairWaterwheel = false;
+		emptySackWorkflowActive = false;
 		Rs2Antiban.takeMicroBreakByChance();
 		status = MLMStatus.IDLE;
         log.info("Emptying sack workflow complete");
+	}
+
+	private boolean isWorkflowRunnable()
+	{
+		if (!Microbot.isLoggedIn() || Microbot.pauseAllScripts.get() || Thread.currentThread().isInterrupted())
+		{
+			return false;
+		}
+
+		try
+		{
+			return Microbot.getClientThread().runOnClientThreadOptional(() -> {
+				var player = Microbot.getClient().getLocalPlayer();
+				return player != null && player.getWorldView() != null;
+			}).orElse(false);
+		}
+		catch (RuntimeException ex)
+		{
+			log.debug("Player state unavailable during MLM lifecycle transition", ex);
+			return false;
+		}
+	}
+
+	private void abortCurrentWorkflow()
+	{
+		resetMiningState(true);
+		status = MLMStatus.IDLE;
+		idleSince = 0;
+		shouldEmptySack = false;
+		shouldRepairWaterwheel = false;
+		emptySackWorkflowActive = false;
+		pickedUpHammer = false;
 	}
 
     private boolean hasOreInInventory()


### PR DESCRIPTION
## Summary

This PR hardens Motherlode Mine against logout/break interruptions so the script does not remain enabled but silently idle after the player logs back in.

It builds on the recent upstream scheduler guard by adding the recovery pieces needed for the observed failure mode:

- reset transient MLM workflow state after an unhandled main-loop exception
- gate workflow execution on login, global script pause, thread interruption, local player, and `worldView` readiness
- make `EMPTY_SACK` resumable across scheduled ticks instead of a blocking loop
- abort/reset in-progress workflows cleanly when logout interrupts sack emptying or related sleeps
- bump Motherlode Mine to `1.9.7` because upstream already contains `1.9.6`

## Context

The original issue presented after scheduled BreakHandler logout/login cycles. MLM stayed marked active after login, but produced no further transitions until manually restarted. One captured failure included a null actor/world-view path during logout, and another occurred while the script was in `EMPTY_SACK` with no explicit MLM exception before it became silent.

Upstream `development` recently added a broad `try/catch` around the MLM loop, which prevents the scheduler from dying outright. This PR keeps that direction but adds explicit state reset and lifecycle checks so the next tick starts from a clean, valid runtime state instead of continuing with stale workflow flags.

## Test plan

- Rebased onto latest `chsami/Microbot-Hub:development` after upstream Motherlode changes and resolved the MLM conflict.
- Ran targeted build:

```text
./gradlew.bat clean build -PpluginList=MotherloadMinePlugin --console=plain
BUILD SUCCESSFUL in 2m 10s
```

- Ran full CI-equivalent Hub build:

```text
./gradlew.bat clean build --console=plain
BUILD SUCCESSFUL in 4m 51s
```

- Tested the patched JAR locally through roughly two days of uninterrupted Motherlode Mine runtime.
- Observed repeated normal `MINING`, `DEPOSIT_HOPPER`, `EMPTY_SACK`, and `FIXING_WATERWHEEL` transitions.
- Observed scheduled BreakHandler logout/login cycles without MLM becoming silent or requiring manual restart.

## Notes

This is intentionally scoped to the Motherlode Mine plugin. The separate QoL/Wintertodt null-player exceptions seen during logout are not addressed here.
