### PR TITLE
feat(dailytasks): add Rake Miscellania task

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTask.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTask.java
@@ -1,14 +1,19 @@
 package net.runelite.client.plugins.microbot.dailytasks;
 
 import lombok.Getter;
+import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
+import net.runelite.api.ObjectComposition;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
@@ -161,6 +166,18 @@ public enum DailyTask {
                 Rs2Keyboard.enter();
             },
             config -> false
+    ),
+
+    RAKE_MISCELLANIA(
+            "Rake Miscellania",
+            new WorldPoint(2527, 3851, 0),
+            // Gate only on the quest being done — NOT on KINGDOM_APPROVAL, which can read a stale
+            // "maxed" value on login. We travel and try to rake regardless, deciding we are finished
+            // from the live on-island signals instead.
+            () -> Microbot.getClient().getVarpValue(VarPlayer.THRONE_OF_MISCELLANIA) > 0,
+            DailyTask::rakeMiscellania,
+            DailyTasksConfig::rakeMiscellania,
+            true
     );
 
     @Getter
@@ -171,14 +188,26 @@ public enum DailyTask {
     private final Runnable executeTask;
     @Getter
     private final Function<DailyTasksConfig, Boolean> configEnabled;
+    private final boolean handlesOwnTravel;
 
     DailyTask(String name, WorldPoint location, BooleanSupplier isAvailable,
               Runnable executeTask, Function<DailyTasksConfig, Boolean> configEnabled) {
+        this(name, location, isAvailable, executeTask, configEnabled, false);
+    }
+
+    DailyTask(String name, WorldPoint location, BooleanSupplier isAvailable,
+              Runnable executeTask, Function<DailyTasksConfig, Boolean> configEnabled, boolean handlesOwnTravel) {
         this.name = name;
         this.location = location;
         this.isAvailable = isAvailable;
         this.executeTask = executeTask;
         this.configEnabled = configEnabled;
+        this.handlesOwnTravel = handlesOwnTravel;
+    }
+
+    /** When true, the script skips its generic pre-walk and the task navigates itself (e.g. bank then fairy ring). */
+    public boolean handlesOwnTravel() {
+        return handlesOwnTravel;
     }
 
     public boolean isAvailable() {
@@ -201,5 +230,120 @@ public enum DailyTask {
 
     public boolean isInRange() {
         return Rs2Player.distanceTo(location) < 20;
+    }
+
+    // ---- Rake Miscellania ---------------------------------------------------------------------
+
+    /**
+     * Backup max-favour signal, set by {@link DailyTasksPlugin}'s chat subscriber when Gardener
+     * Gunnhild tells us to stop. The KINGDOM_APPROVAL varbit ({@link #MAX_APPROVAL}) is authoritative.
+     */
+    public static volatile boolean gunnhildMaxFavor = false;
+
+    private static final WorldPoint MISCELLANIA_PATCHES = new WorldPoint(2527, 3851, 0);
+    private static final int MISCELLANIA_REGION = 10044;
+    private static final int MAX_APPROVAL = 127;
+
+    /** KINGDOM_APPROVAL at max, via the event-maintained player-state cache (thread-safe, no spurious 0). */
+    private static boolean approvalAtMax() {
+        return Microbot.getVarbitValue(Varbits.KINGDOM_APPROVAL) >= MAX_APPROVAL;
+    }
+
+    private static boolean hasRakeAction(Rs2TileObjectModel object) {
+        if (object == null) return false;
+        ObjectComposition comp = object.getObjectComposition();
+        if (comp == null || comp.getActions() == null) return false;
+        for (String action : comp.getActions()) {
+            if (action != null && action.toLowerCase().contains("rake")) return true;
+        }
+        return false;
+    }
+
+    /** Nearest patch around the field that still offers a "Rake" action (name-agnostic, weed-stage proof). */
+    private static Rs2TileObjectModel rakeablePatch() {
+        return Microbot.getRs2TileObjectCache().query()
+                .within(MISCELLANIA_PATCHES, 12)
+                .where(DailyTask::hasRakeAction)
+                .nearest(MISCELLANIA_PATCHES, 12);
+    }
+
+    private static void rakeMiscellania() {
+        gunnhildMaxFavor = false;
+
+        // Fairy-ring access needs a Dramen or Lunar staff equipped — UNLESS the Elite Lumbridge &
+        // Draynor Diary is complete, which removes the staff requirement entirely. (Varbit read must
+        // run on the client thread.)
+        boolean fairyRingItemless = Microbot.getClientThread()
+                .runOnClientThreadOptional(() -> Microbot.getClient().getVarbitValue(Varbits.DIARY_LUMBRIDGE_ELITE) == 1)
+                .orElse(false);
+        boolean fairyStaffEquipped = Rs2Equipment.isWearing(ItemID.DRAMEN_STAFF) || Rs2Equipment.isWearing(ItemID.LUNAR_STAFF);
+        boolean fairyStaffInInv = Rs2Inventory.hasItem(ItemID.DRAMEN_STAFF) || Rs2Inventory.hasItem(ItemID.LUNAR_STAFF);
+
+        // 1. Ensure a rake (and a fairy-ring staff only if one is actually needed) — bank when something is missing.
+        boolean needRake = !Rs2Inventory.hasItem(ItemID.RAKE);
+        boolean needStaff = !fairyRingItemless && !fairyStaffEquipped && !fairyStaffInInv;
+        if (needRake || needStaff) {
+            if (!Rs2Bank.walkToBankAndUseBank()) return;
+            sleepUntil(Rs2Bank::isOpen, 10000);
+            if (needRake) Rs2Bank.withdrawOne(ItemID.RAKE);
+            if (needStaff) {
+                Rs2Bank.withdrawOne(ItemID.DRAMEN_STAFF);
+                sleepUntil(() -> Rs2Inventory.hasItem(ItemID.DRAMEN_STAFF), 2000);
+                if (!Rs2Inventory.hasItem(ItemID.DRAMEN_STAFF)) Rs2Bank.withdrawOne(ItemID.LUNAR_STAFF);
+            }
+            sleepUntil(() -> Rs2Inventory.hasItem(ItemID.RAKE), 5000);
+            Rs2Bank.closeBank();
+        }
+        if (!Rs2Inventory.hasItem(ItemID.RAKE)) {
+            Microbot.log("Rake Miscellania: no rake in inventory or bank — skipping.");
+            return;
+        }
+
+        // 2. Ensure fairy-ring access: equip a Dramen/Lunar staff if one is needed and not already worn.
+        if (!fairyRingItemless && !Rs2Equipment.isWearing(ItemID.DRAMEN_STAFF) && !Rs2Equipment.isWearing(ItemID.LUNAR_STAFF)) {
+            if (Rs2Inventory.hasItem(ItemID.DRAMEN_STAFF)) {
+                Rs2Inventory.equip(ItemID.DRAMEN_STAFF);
+            } else if (Rs2Inventory.hasItem(ItemID.LUNAR_STAFF)) {
+                Rs2Inventory.equip(ItemID.LUNAR_STAFF);
+            } else {
+                Microbot.log("Rake Miscellania: no Dramen/Lunar staff and no Elite Lumbridge diary — cannot reach Miscellania, skipping.");
+                return;
+            }
+            sleepUntil(() -> Rs2Equipment.isWearing(ItemID.DRAMEN_STAFF) || Rs2Equipment.isWearing(ItemID.LUNAR_STAFF), 3000);
+        }
+
+        // 3. Travel to the patches; the walker routes through the CIP fairy ring (staff equipped, or diary done).
+        if (Rs2Player.getWorldLocation().getRegionID() != MISCELLANIA_REGION) {
+            Rs2Walker.walkTo(MISCELLANIA_PATCHES, 5);
+            sleepUntil(() -> Rs2Player.getWorldLocation().getRegionID() == MISCELLANIA_REGION, 60000);
+        }
+        if (Rs2Player.getWorldLocation().getRegionID() != MISCELLANIA_REGION) {
+            Microbot.log("Rake Miscellania: failed to reach Miscellania — skipping.");
+            return;
+        }
+        if (Rs2Player.distanceTo(MISCELLANIA_PATCHES) > 6) Rs2Walker.walkTo(MISCELLANIA_PATCHES, 3);
+
+        // 4. Rake every weed on both patches, then decide whether we are finished. We never stop part-way:
+        //    while any patch still offers a "Rake" action we keep raking (waitForAnimation blocks until each
+        //    rake finishes, so we never spam-click a patch we are already raking). Only once nothing is left
+        //    to rake do we check whether favour is maxed — Gardener Gunnhild's "stop" line (chat subscriber)
+        //    or the KINGDOM_APPROVAL varbit. If neither, the patches simply have not regrown yet, so we wait
+        //    for them and keep raking. Because we always clear the weeds first, a stale login-time approval
+        //    value can never make us skip real raking.
+        while (Microbot.isLoggedIn() && Microbot.isPluginEnabled(DailyTasksPlugin.class)) {
+            if (gunnhildMaxFavor) break;                       // Gunnhild told us to stop = definitively maxed
+
+            Rs2TileObjectModel patch = rakeablePatch();
+            if (patch != null) {
+                patch.click("Rake");
+                Rs2Player.waitForAnimation(3000);             // rake to completion; never re-click mid-rake
+                continue;
+            }
+
+            // Nothing left to rake right now.
+            if (approvalAtMax()) break;                        // raked everything available and favour is maxed
+            // Not maxed yet — wait (event-derived) for the weeds to regrow, then keep raking.
+            sleepUntil(() -> gunnhildMaxFavor || rakeablePatch() != null || approvalAtMax(), 70000);
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTasksConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTasksConfig.java
@@ -124,4 +124,15 @@ public interface DailyTasksConfig extends Config {
     default boolean handleMiscellania() {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "rakeMiscellania",
+            name = "Rake Miscellania",
+            description = "Rake the Miscellania flax & herb patches until kingdom favor is maxed (members; needs Throne of Miscellania + a Dramen staff)",
+            position = 10,
+            section = tasksSection
+    )
+    default boolean rakeMiscellania() {
+        return false;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTasksPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTasksPlugin.java
@@ -2,6 +2,8 @@ package net.runelite.client.plugins.microbot.dailytasks;
 
 import com.google.inject.Inject;
 import com.google.inject.Provides;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -9,6 +11,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.PluginConstants;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.Text;
 
 import static net.runelite.client.plugins.PluginDescriptor.Mocrosoft;
 
@@ -25,7 +28,7 @@ import static net.runelite.client.plugins.PluginDescriptor.Mocrosoft;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class DailyTasksPlugin extends Plugin {
-    public static final String version = "1.0.1";
+    public static final String version = "1.1.0";
     static final String CONFIG_GROUP = "dailytasks";
     static String currentState = "";
 
@@ -53,5 +56,21 @@ public class DailyTasksPlugin extends Plugin {
     protected void shutDown() throws Exception {
         overlayManager.remove(dailyTasksOverlay);
         dailyTasksScript.shutdown();
+    }
+
+    /**
+     * Backup max-favour detector for the Rake Miscellania task: Gardener Gunnhild tells the player to
+     * stop ("don't trouble yourself...") once approval is maxed. The KINGDOM_APPROVAL varbit is the
+     * authoritative signal; this is a safety net since the exact wording isn't documented.
+     */
+    @Subscribe
+    public void onChatMessage(ChatMessage event) {
+        ChatMessageType type = event.getType();
+        if (type != ChatMessageType.GAMEMESSAGE && type != ChatMessageType.MESBOX && type != ChatMessageType.DIALOG) {
+            return;
+        }
+        if (Text.removeTags(event.getMessage()).toLowerCase().contains("trouble")) {
+            DailyTask.gunnhildMaxFavor = true;
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTasksScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/dailytasks/DailyTasksScript.java
@@ -83,7 +83,7 @@ public class DailyTasksScript extends Script {
             }
 
             System.out.println("Current task: " + currentTask.getName());
-            if (Rs2Player.distanceTo(currentTask.getLocation()) > 5) {
+            if (!currentTask.handlesOwnTravel() && Rs2Player.distanceTo(currentTask.getLocation()) > 5) {
                 DailyTasksPlugin.currentState = "Walking to: " + currentTask.getName();
                 Rs2Walker.walkTo(currentTask.getLocation(), 5);
             }


### PR DESCRIPTION
## Summary
Adds an opt-in **Rake Miscellania** daily task (disabled by default).

When enabled, it self-provisions a rake (and a Dramen/Lunar staff if the fairy ring needs one — skipped when the Elite Lumbridge & Draynor diary is done), travels to Miscellania via the CIP fairy ring, and rakes the flax and herb patches until kingdom favour is maxed.

## Behaviour
- Rakes every weed on both patches before checking favour; waits for weeds to regrow and keeps raking when one pass is not enough; never re-clicks a patch mid-rake.
- Stops on the KINGDOM_APPROVAL varbit at max (player-state cache read), with Gardener Gunnhild's chat line as a backup.
- Availability gates only on Throne of Miscellania, so a stale login-time approval value cannot skip the task.
- New handlesOwnTravel flag lets the task bank before island travel instead of being dragged across by the script's generic pre-walk.

## Testing
Live-tested end-to-end on a members world: banked for a rake on Fossil Island, travelled via fairy ring to Miscellania, raked both patches, and auto-stopped at max favour with no errors.

Version bumped 1.0.1 -> 1.1.0.