### PR TITLE
fix(HouseThieving): repair thieving/banking broken by isInteracting; add shine-bonus handling

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingConfig.java
@@ -21,6 +21,7 @@ public interface HouseThievingConfig extends Config {
     String foodEatPercentage = "foodEatPercentage";
     String useDodgyNecklace = "useDodgyNecklace";
     String dodgyNecklaceAmount = "dodgyNecklaceAmount";
+    String onlyPickpocketDistracted = "onlyPickpocketDistracted";
     String worldHopForDistractedCitizens = "worldHopForDistractedCitizens";
     String worldHopWaitTime = "worldHopWaitTime";
 
@@ -109,10 +110,21 @@ public interface HouseThievingConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = onlyPickpocketDistracted,
+            name = "Only Pickpocket Distracted",
+            description = "Only pickpocket when a distraction event is active (no food needed)",
+            position = 8,
+            section = generalSection
+    )
+    default boolean onlyPickpocketDistracted() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = worldHopForDistractedCitizens,
             name = "World Hop For Distracted Citizens",
-            description = "World hop for Aurelia distracted citizen event",
-            position = 8,
+            description = "World hop if no distraction event within wait time",
+            position = 9,
             section = generalSection
     )
     default boolean worldHopForDistractedCitizens() {
@@ -122,8 +134,8 @@ public interface HouseThievingConfig extends Config {
     @ConfigItem(
             keyName = worldHopWaitTime,
             name = "World Hop Wait Time",
-            description = "How long to wait before world hopping for distracted ctizens",
-            position = 9,
+            description = "How long to wait before world hopping for distracted citizens",
+            position = 10,
             section = generalSection
     )
     default int worldHopWaitTime() {

--- a/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingConstants.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingConstants.java
@@ -33,4 +33,8 @@ public class HouseThievingConstants {
     public final static WorldPoint BANKING_TILE_LOCATION = new WorldPoint(1648, 3119, 0);
 
     public final static int LOCKED_DOOR_ID = 51998;
+
+    // Searchable valuables inside the houses: wardrobes, chests, glass case, jewellery case (ObjectID 52002-52011).
+    // Windows (52000-52001) and staircases (52012-52013) are deliberately excluded.
+    public final static int[] VALUABLES_OBJECT_IDS = {52002, 52003, 52004, 52005, 52006, 52007, 52008, 52009, 52010, 52011};
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingOverlay.java
@@ -10,11 +10,13 @@ import javax.inject.Inject;
 import java.awt.*;
 
 public class HouseThievingOverlay extends OverlayPanel {
+    private final HouseThievingPlugin plugin;
     private final HouseThievingConfig config;
 
     @Inject
     HouseThievingOverlay(HouseThievingPlugin plugin, HouseThievingConfig config) {
         super(plugin);
+        this.plugin = plugin;
         this.config = config;
         setPosition(OverlayPosition.TOP_LEFT);
         setNaughty();
@@ -36,7 +38,7 @@ public class HouseThievingOverlay extends OverlayPanel {
                     .build());
 
             panelComponent.getChildren().add(LineComponent.builder()
-                    .left("State: " + HouseThievingScript.state)
+                    .left("State: " + (plugin.houseThievingScript != null ? plugin.houseThievingScript.state : "N/A"))
                     .build());
 
         } catch (Exception ex) {

--- a/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingPlugin.java
@@ -2,7 +2,9 @@ package net.runelite.client.plugins.microbot.housethieving;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.PluginConstants;
@@ -26,7 +28,7 @@ import java.awt.*;
 )
 @Slf4j
 public class HouseThievingPlugin extends Plugin {
-    public final static String version = "1.0.3";
+    public final static String version = "1.1.0";
     @Inject
     private HouseThievingConfig config;
 
@@ -40,7 +42,7 @@ public class HouseThievingPlugin extends Plugin {
     @Inject
     private HouseThievingOverlay houseThievingOverlay;
 
-    private HouseThievingScript houseThievingScript;
+    HouseThievingScript houseThievingScript;
 
     @Override
     protected void startUp() throws AWTException {
@@ -53,7 +55,15 @@ public class HouseThievingPlugin extends Plugin {
     }
 
     protected void shutDown() {
-        houseThievingScript.shutdown();
+        new Thread(() -> houseThievingScript.shutdown()).start();
         overlayManager.remove(houseThievingOverlay);
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage event) {
+        // "You can't spot anything else worth taking from the <furniture>." => current piece is emptied, switch.
+        if (houseThievingScript != null && event.getMessage().toLowerCase().contains("worth taking")) {
+            houseThievingScript.onValuablesExhausted();
+        }
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/housethieving/HouseThievingScript.java
@@ -5,6 +5,7 @@ import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.TileObject;
 import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
@@ -43,11 +44,19 @@ public class HouseThievingScript extends Script {
         BANKING
     }
 
-    public static State state = State.PICKPOCKETING;
-    private Rs2TileObjectModel currentThievingObject = null;
-    private Long lastThievingSearch = null;
+    State state = State.PICKPOCKETING;
     private ThievingHouse currentThievingHouse = null;
     private Rs2NpcModel pickpocketNpc = null;
+    private boolean clickedThisDistraction = false;
+    // Furniture we last searched, and the piece the game told us is emptied ("nothing else worth taking").
+    // We skip the emptied piece so we switch to another instead of spam-clicking it; it refills while we loot elsewhere.
+    private volatile WorldPoint lastSearchedValuables = null;
+    private volatile WorldPoint exhaustedValuables = null;
+    // True once a search has started auto-looting a piece. One click loots a piece for ~50-60s with no further
+    // input, so we leave it alone until the game reports the piece is emptied (onValuablesExhausted) - the same
+    // "click once, the game auto-repeats" mechanic as a distracted pickpocket. Gating on animation is wrong here:
+    // the auto-loot has long stretches with no animation, so any isAnimating() window goes false mid-loot and re-clicks.
+    private volatile boolean searchingPiece = false;
     private final static String HOUSE_KEYS = "House keys";
     private final static String DODGY_NECKLACE = "Dodgy necklace";
     private final static String COIN_POUCH = "Coin pouch";
@@ -59,13 +68,6 @@ public class HouseThievingScript extends Script {
         initialPlayerLocation = null;
         Rs2Antiban.resetAntibanSettings();
         Rs2AntibanSettings.naturalMouse = true;
-
-        var childrenOfTheSunComplete = Rs2Player.getQuestState(Quest.CHILDREN_OF_THE_SUN) == QuestState.FINISHED;
-        if (!childrenOfTheSunComplete) {
-            Microbot.showMessage("Children of the Sun quest is required to be complete to use this plugin.");
-            shutdown();
-            return false;
-        }
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -89,7 +91,6 @@ public class HouseThievingScript extends Script {
                 if (currentThievingHouse == null)
                     currentThievingHouse = getThievingHouse();
 
-                var houseNpc = Microbot.getRs2NpcCache().query().withName(currentThievingHouse.npcName).nearestOnClientThread();
                 switch (state) {
                     case PICKPOCKETING:
                         handlePickPocketing(config);
@@ -98,6 +99,7 @@ public class HouseThievingScript extends Script {
                         handleFindingHouse(config);
                         break;
                     case THIEVING_HOUSES:
+                        var houseNpc = Microbot.getRs2NpcCache().query().withName(currentThievingHouse.npcName).nearestOnClientThread();
                         handleThievingHouse(houseNpc);
                         break;
                     case BANKING:
@@ -114,10 +116,7 @@ public class HouseThievingScript extends Script {
     }
 
     private void handlePickPocketing(HouseThievingConfig config) {
-        if (Rs2Player.isInteracting()) {
-            Microbot.log("Player is already interacting with an NPC, waiting for interaction to finish", Level.DEBUG);
-            return;
-        }
+        if (Rs2Player.isAnimating()) return;
         var hasFood = !Rs2Inventory.getInventoryFood().isEmpty();
         var hasDodgyNecklaceInv = getDodgyNecklaceAmount() > 0;
         var hasDodgyNecklaceEquipped = Rs2Equipment.isWearing(DODGY_NECKLACE);
@@ -129,7 +128,7 @@ public class HouseThievingScript extends Script {
             Microbot.log("Have enough house keys, thieving houses", Level.INFO);
             state = State.FINDING_HOUSE;
             return;
-        } else if (!hasMaxHouseKeys(config) && (!hasFood || (!hasDodgyNecklaceInv && !hasDodgyNecklaceEquipped && config.useDodgyNecklace())) && !config.worldHopForDistractedCitizens()) {
+        } else if (!hasMaxHouseKeys(config) && (!hasFood || (!hasDodgyNecklaceInv && !hasDodgyNecklaceEquipped && config.useDodgyNecklace())) && !config.worldHopForDistractedCitizens() && !config.onlyPickpocketDistracted() && config.pickpocketFoodAmount() > 0) {
             Microbot.log("Need food or dodgy necklace to keep pickpocketing, withdrawing from bank", Level.INFO);
             state = State.BANKING;
             return;
@@ -151,6 +150,7 @@ public class HouseThievingScript extends Script {
             if (coinPouches.getQuantity() > 27) {
                 Rs2Inventory.interact(coinPouches, "Open-all");
                 Rs2Random.waitEx(200.0, 200.0);
+                clickedThisDistraction = false; // opening pouches interrupts auto-pickpocket; re-click needed
             }
         }
 
@@ -162,11 +162,14 @@ public class HouseThievingScript extends Script {
                 distractedWealthyCitizen = getDistractedWealthyCitizen(aureliaNpc);
                 if (distractedWealthyCitizen != null)
                     pickpocketNpc = null;
-            } else if (pickpocketNpc == null) {
-                var nearbyWealthyCitizens = Microbot.getRs2NpcCache().query().withName(WEALTHY_CITIZEN).toListOnClientThread().stream();
-                var aureliaLocation = aureliaNpc.getWorldLocation();
-                var closestWealthyCitizen = nearbyWealthyCitizens.min(Comparator.comparingInt(a -> a.getWorldLocation().distanceTo(aureliaLocation)));
-                closestWealthyCitizen.ifPresent(rs2NpcModel -> pickpocketNpc = rs2NpcModel);
+            } else {
+                clickedThisDistraction = false; // distraction ended; allow a click when the next one starts
+                if (pickpocketNpc == null) {
+                    var nearbyWealthyCitizens = Microbot.getRs2NpcCache().query().withName(WEALTHY_CITIZEN).toListOnClientThread().stream();
+                    var aureliaLocation = aureliaNpc.getWorldLocation();
+                    var closestWealthyCitizen = nearbyWealthyCitizens.min(Comparator.comparingInt(a -> a.getWorldLocation().distanceTo(aureliaLocation)));
+                    closestWealthyCitizen.ifPresent(rs2NpcModel -> pickpocketNpc = rs2NpcModel);
+                }
             }
             if (config.worldHopForDistractedCitizens()) {
                 Microbot.log(String.format("Waiting %s seconds for Aurelia pickpocket", config.worldHopWaitTime()), Level.INFO);
@@ -180,24 +183,31 @@ public class HouseThievingScript extends Script {
             }
         }
 
-        var targetWealthyCitizen = distractedWealthyCitizen != null ? distractedWealthyCitizen : pickpocketNpc;
-        if (targetWealthyCitizen != null) {
-            if (distractedWealthyCitizen == null) { // Regular pickpocketing
-                if (Rs2Inventory.getInventoryFood().isEmpty()) {
-                    state = State.BANKING;
-                    return;
-                }
-                if (Rs2Player.getHealthPercentage() <= config.foodEatPercentage()) {
-                    Rs2Player.useFood();
-                    Rs2Inventory.waitForInventoryChanges(600);
-                }
-            }
+        if (config.onlyPickpocketDistracted() && distractedWealthyCitizen == null)
+            return;
 
-            if (Rs2Player.isStunned() && distractedWealthyCitizen == null)
+        if (distractedWealthyCitizen != null) {
+            if (clickedThisDistraction)
+                return; // already pickpocketing this distraction; the game auto-repeats for ~24s
+            distractedWealthyCitizen.click("Pickpocket");
+            clickedThisDistraction = true;
+            return;
+        }
+
+        if (pickpocketNpc != null) {
+            if (Rs2Inventory.getInventoryFood().isEmpty()) {
+                state = State.BANKING;
+                return;
+            }
+            if (Rs2Player.getHealthPercentage() <= config.foodEatPercentage()) {
+                Rs2Player.useFood();
+                Rs2Inventory.waitForInventoryChanges(600);
+            }
+            if (Rs2Player.isStunned())
                 sleepUntil(() -> !Rs2Player.isStunned(), 600);
-            targetWealthyCitizen.click("Pickpocket");
+            pickpocketNpc.click("Pickpocket");
             Rs2Random.waitEx(600.0, 200.0);
-            sleepUntil(() -> !Rs2Player.isInteracting() && !Rs2Player.isAnimating(), 10000);
+            sleepUntil(() -> !Rs2Player.isAnimating(), 10000);
         }
 
         if (distractedWealthyCitizen != null && config.worldHopForDistractedCitizens()) {
@@ -219,11 +229,10 @@ public class HouseThievingScript extends Script {
 
     @Nullable
     private static Rs2NpcModel getDistractedWealthyCitizen(Rs2NpcModel aureliaNpc) {
-        return Microbot.getRs2NpcCache().query().where(npc ->
-                npc.getWorldLocation().distanceTo(aureliaNpc.getWorldLocation()) <= 5 &&
-                        npc.getName() != null && npc.getName().equalsIgnoreCase(WEALTHY_CITIZEN) &&
-                        npc.isInteractingWithPlayer()
-        ).toList().stream().findFirst().orElse(null);
+        var aureliaLoc = aureliaNpc.getWorldLocation();
+        return Microbot.getRs2NpcCache().query()
+                .withName(WEALTHY_CITIZEN)
+                .nearestOnClientThread(aureliaLoc, 5);
     }
 
     private void handleFindingHouse(HouseThievingConfig config) {
@@ -232,12 +241,10 @@ public class HouseThievingScript extends Script {
             return;
         }
 
-        if (Rs2Inventory.hasItem(HOUSE_KEYS)) {
-            var houseKeys = Rs2Inventory.get(HOUSE_KEYS);
-            if (houseKeys != null && houseKeys.getQuantity() < config.minHouseKeys()) {
-                state = State.PICKPOCKETING;
-                return;
-            }
+        var houseKeys = Rs2Inventory.get(HOUSE_KEYS);
+        if (houseKeys == null || houseKeys.getQuantity() < config.minHouseKeys()) {
+            state = State.PICKPOCKETING;
+            return;
         }
 
         var distanceToScout = Rs2Player.getWorldLocation().distanceTo(currentThievingHouse.scoutPosition);
@@ -261,14 +268,15 @@ public class HouseThievingScript extends Script {
                 if (!Rs2Tile.isTileReachable(currentThievingHouse.houseCenter)) {
                     Microbot.getRs2TileObjectCache().query().withId(wallObject.getId()).interact();
                     Rs2Random.waitEx(2000.0, 100.0);
-                    sleepUntil(() -> !Rs2Player.isInteracting() && !Rs2Player.isAnimating(600));
+                    sleepUntil(() -> !Rs2Player.isAnimating(600));
                     Rs2Random.waitEx(2000.0, 100.0);
                     sleepUntil(() -> Rs2Tile.isTileReachable(currentThievingHouse.houseCenter), 10000);
                     Microbot.log("Entered " + currentThievingHouse.npcName + " house", Level.INFO);
                 }
                 if (Rs2Tile.isTileReachable(currentThievingHouse.houseCenter)) {
-                    currentThievingObject = null;
-                    lastThievingSearch = null;
+                    lastSearchedValuables = null;
+                    exhaustedValuables = null;
+                    searchingPiece = false;
                     state = State.THIEVING_HOUSES;
                     Microbot.log("Starting thieving in " + currentThievingHouse.npcName + " house.", Level.INFO);
                     return;
@@ -317,40 +325,75 @@ public class HouseThievingScript extends Script {
             }
         }
 
-        var hintArrow = Microbot.getClient().getHintArrowPoint();
-        var elapsedTime = lastThievingSearch == null ? null : System.currentTimeMillis() - lastThievingSearch;
-        if (hintArrow == null) {
-            if (currentThievingObject == null) {
-                var tileObject = Rs2Tile.getTile(currentThievingHouse.initialThievingChest.getX(), currentThievingHouse.initialThievingChest.getY());
-                if (tileObject != null) {
-                    currentThievingObject = Microbot.getRs2TileObjectCache().query().nearest(currentThievingHouse.initialThievingChest, 3);
-                    if (!Rs2Camera.isTileOnScreen(currentThievingObject.getLocalLocation())) {
-                        Rs2Camera.turnTo(currentThievingObject);
-                    }
-                    currentThievingObject.click("Search");
-                }
-                currentThievingObject = Microbot.getRs2TileObjectCache().query().nearest(currentThievingHouse.initialThievingChest, 3);
-            }
-
-            if (currentThievingObject != null && (lastThievingSearch == null || (elapsedTime != null && elapsedTime > 50000))) {
-                if (!Rs2Camera.isTileOnScreen(currentThievingObject.getLocalLocation())) {
-                    Rs2Camera.turnTo(currentThievingObject);
-                }
-                currentThievingObject.click("Search");
-                lastThievingSearch = System.currentTimeMillis();
-                Rs2Random.waitEx(1000.0, 200.0);
-            }
-        } else {
-            currentThievingObject = Microbot.getRs2TileObjectCache().query().nearest(hintArrow, 3);
-            if (!Rs2Player.isInteracting() || lastThievingSearch == null || (elapsedTime != null && elapsedTime > 50000)) {
-                if (!Rs2Camera.isTileOnScreen(currentThievingObject.getLocalLocation())) {
-                    Rs2Camera.turnTo(currentThievingObject);
-                }
-                currentThievingObject.click("Search");
-                lastThievingSearch = System.currentTimeMillis();
-                Rs2Random.waitEx(1000.0, 200.0);
+        // A flashing hint arrow ("You notice something shine somewhere else in the house") marks a piece that
+        // grants a one-time bonus (+14 valuables, +630 xp) for switching to it. Claim it even mid-loot - the
+        // game rewards the switch. The arrow clears ~7s after we search it, and we skip it once we're already on
+        // that piece, so this fires once per highlight rather than spam-clicking.
+        var hintArrow = Microbot.getClientThread().runOnClientThreadOptional(() -> Microbot.getClient().getHintArrowPoint()).orElse(null);
+        if (hintArrow != null && (lastSearchedValuables == null || lastSearchedValuables.distanceTo(hintArrow) > 2)) {
+            if (Rs2Player.isMoving())
+                return; // en route to the bonus piece
+            var bonusPiece = Microbot.getRs2TileObjectCache().query()
+                    .withIds(VALUABLES_OBJECT_IDS)
+                    .nearestOnClientThread(hintArrow, 2);
+            if (bonusPiece != null) {
+                lastSearchedValuables = bonusPiece.getWorldLocation();
+                exhaustedValuables = null; // the arrow can re-highlight a refilled piece we'd otherwise skip
+                if (!Rs2Camera.isTileOnScreen(bonusPiece.getLocalLocation()))
+                    Rs2Camera.turnTo(bonusPiece);
+                bonusPiece.click("Search");
+                searchingPiece = sleepUntil(() -> Rs2Player.isAnimating(), 5000);
+                return;
             }
         }
+
+        // Already auto-looting a piece: one click keeps looting for ~50-60s, so don't touch it. We only act
+        // again when the game tells us the piece is emptied (onValuablesExhausted clears searchingPiece below).
+        if (searchingPiece)
+            return;
+
+        // Walking to the piece we just clicked - let the click register instead of firing another.
+        if (Rs2Player.isMoving())
+            return;
+
+        // Search the nearest piece of furniture, skipping the one the game just told us is emptied so we move
+        // on instead of spam-clicking it. It refills while we loot another piece.
+        var valuables = Microbot.getRs2TileObjectCache().query()
+                .withIds(VALUABLES_OBJECT_IDS)
+                .where(o -> exhaustedValuables == null || !exhaustedValuables.equals(o.getWorldLocation()))
+                .nearestOnClientThread();
+        if (valuables == null) {
+            exhaustedValuables = null; // nothing else within reach; let the emptied piece refill and retry it
+            return;
+        }
+        lastSearchedValuables = valuables.getWorldLocation();
+        if (!Rs2Camera.isTileOnScreen(valuables.getLocalLocation()))
+            Rs2Camera.turnTo(valuables);
+        valuables.click("Search");
+        // Confirm the search actually started (covers the walk to the piece) before marking it active; if it
+        // never starts we retry next loop instead of standing idle. This is a timeout, not a state-modeling cooldown.
+        searchingPiece = sleepUntil(() -> Rs2Player.isAnimating(), 5000);
+    }
+
+    /** True if the tile object exposes a "Bank" menu action (mirrors how Rs2TileObjectModel.click resolves it). */
+    private static boolean hasBankAction(Rs2TileObjectModel object) {
+        var comp = object.getObjectComposition();
+        if (comp == null)
+            return false;
+        var actions = (comp.getImpostorIds() != null && comp.getImpostor() != null)
+                ? comp.getImpostor().getActions() : comp.getActions();
+        if (actions == null)
+            return false;
+        for (var action : actions)
+            if ("Bank".equalsIgnoreCase(action))
+                return true;
+        return false;
+    }
+
+    /** Called when the game reports the current piece of furniture is emptied ("nothing else worth taking"). */
+    void onValuablesExhausted() {
+        exhaustedValuables = lastSearchedValuables;
+        searchingPiece = false; // auto-loot ended; let the loop search a different, non-exhausted piece
     }
 
     private boolean exitHouse() {
@@ -363,8 +406,7 @@ public class HouseThievingScript extends Script {
                 }
                 Microbot.getRs2TileObjectCache().query().withId(windowTileWallObject.getId()).interact("Exit-window");
                 Rs2Random.waitEx(5000.0, 200.0);
-                currentThievingObject = null;
-                lastThievingSearch = null;
+                searchingPiece = false;
                 setNextThievingHouse();
                 state = State.FINDING_HOUSE;
                 return true;
@@ -389,7 +431,7 @@ public class HouseThievingScript extends Script {
             return;
         }
 
-        if (!hasMaxHouseKeys(config) && ((hasFood && dodgyNecklaceReqsMet) || config.worldHopForDistractedCitizens())) {
+        if (!hasMaxHouseKeys(config) && ((hasFood && dodgyNecklaceReqsMet) || config.worldHopForDistractedCitizens() || config.onlyPickpocketDistracted())) {
             state = State.PICKPOCKETING;
             return;
         }
@@ -399,12 +441,18 @@ public class HouseThievingScript extends Script {
         }
 
         if (!Rs2Bank.isOpen() && Rs2Player.distanceTo(BANKING_LOCATION) <= 3) {
-            var bankingTile = Microbot.getRs2TileObjectCache().query().nearest(BANKING_TILE_LOCATION, 3);
-            if (bankingTile != null)
-                Rs2Bank.openBank(bankingTile);
+            // Resolve the actual bank object near the counter. The previous unfiltered nearest() grabbed whatever
+            // tile object was closest - often a floor/decoration with no "Bank" option - so click() fell back to
+            // that object's first menu entry ("Walk here") and the bank never opened. Filter to an object that
+            // actually has a "Bank" action (this counter's id isn't in Rs2Bank's known-bank set, so the no-arg
+            // openBank() can't find it either). openBank(object) waits internally for the bank to open.
+            var bankObject = Microbot.getRs2TileObjectCache().query()
+                    .where(HouseThievingScript::hasBankAction)
+                    .nearestOnClientThread(BANKING_TILE_LOCATION, 5);
+            if (bankObject != null)
+                Rs2Bank.openBank(bankObject);
             else
                 Rs2Bank.openBank();
-            sleepUntil(Rs2Bank::isOpen, 2);
         }
 
         if (Rs2Bank.isOpen()) {
@@ -415,7 +463,7 @@ public class HouseThievingScript extends Script {
             Rs2Inventory.waitForInventoryChanges(600);
 
             if (!hasMaxHouseKeys(config)) {
-                if (!hasFood && !config.worldHopForDistractedCitizens()) {
+                if (!hasFood && !config.worldHopForDistractedCitizens() && !config.onlyPickpocketDistracted()) {
                     if (!Rs2Bank.hasItem(config.foodSelection().getId())) {
                         Microbot.showMessage("No food found in bank!");
                         shutdown();
@@ -424,7 +472,7 @@ public class HouseThievingScript extends Script {
                     Rs2Bank.withdrawX(config.foodSelection().getId(), config.pickpocketFoodAmount());
                     Rs2Inventory.waitForInventoryChanges(600);
                 }
-                if (config.useDodgyNecklace() && !config.worldHopForDistractedCitizens()) {
+                if (config.useDodgyNecklace() && !config.worldHopForDistractedCitizens() && !config.onlyPickpocketDistracted()) {
                     if (!Rs2Bank.hasItem(DODGY_NECKLACE)) {
                         Microbot.showMessage("No dodgy necklace found in bank!");
                         shutdown();


### PR DESCRIPTION
## Summary

`Rs2Player.isInteracting()` stopped reporting interaction during actions, which broke the House Thieving plugin's pickpocket, house-thieving, and banking flows (the bot would stand idle or spam-click). This reworks each flow to derive state from observable game signals instead of `isInteracting`.

## Changes

- **Pickpocket** — click once per distraction event; the game auto-repeats pickpocketing until the citizen is no longer distracted. Re-click only after opening coin pouches (which interrupts the auto-loop). No more re-clicks while already pickpocketing a distracted citizen.
- **House thieving** — click a piece once; it auto-loots for ~50–60s with no further input. A `searchingPiece` flag holds until the game reports the piece emptied (`"...worth taking..."`, handled in `onChatMessage`), at which point it switches to a different, non-exhausted piece. Animation-timing gating was unworkable here because the auto-loot has long no-animation stretches mid-loot — any `isAnimating(ms)` window goes false and re-clicks.
- **Shine / hint-arrow bonus** — when the game highlights a piece ("You notice something shine..."), switch to it via `getHintArrowPoint()` to claim the one-time bonus (+14 valuables, +630 xp), then leave it alone.
- **Banking** — resolve the bank by an object that actually exposes a `"Bank"` menu action, instead of the previous unfiltered nearest tile-object lookup (which returned a floor decoration; `click()` then fell back to its first menu option and never opened the bank). Removed the buggy 2ms `openBank` wait (`openBank(object)` already waits internally).

Version bumped `1.0.3 → 1.1.0`.

## Testing

Verified live in a debug client:
- House thieving: clicks a piece once, loots ~58s with **zero re-clicks**, then cleanly switches to a different piece on the depletion message.
- Pickpocket: single click per distraction, auto-repeats as expected.
- Banking fix verified to compile; resolves via the `"Bank"`-action filter.

## Known follow-up

- `shutDown()` offloads `script.shutdown()` to a `new Thread(...)` to avoid blocking the Swing EDT. The residual canvas freeze on stop was diagnosed as framework-level (pathfinder mutex contention) and is left as a separate follow-up.