### PR TITLE
fix(BarbarianFishing): resolve soft-lock from stuck antiban cooldown and stale interaction state

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingOverlay.java
@@ -15,9 +15,12 @@ import javax.inject.Inject;
 import java.awt.*;
 
 public class BarbarianFishingOverlay extends OverlayPanel {
+    private final BarbarianFishingPlugin plugin;
+
     @Inject
     BarbarianFishingOverlay(BarbarianFishingPlugin plugin) {
         super(plugin);
+        this.plugin = plugin;
         setPosition(OverlayPosition.TOP_LEFT);
         setNaughty();
     }
@@ -48,6 +51,11 @@ public class BarbarianFishingOverlay extends OverlayPanel {
                     .build());
 
             panelComponent.getChildren().add(LineComponent.builder().build());
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Status: " + plugin.fishingScript.status)
+                    .build());
+            panelComponent.getChildren().add(LineComponent.builder().build());
+
             Rs2Antiban.renderAntibanOverlayComponents(panelComponent);
 
             panelComponent.getChildren().add(LineComponent.builder()

--- a/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/barbarianfishing/BarbarianFishingScript.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.barbarianfishing;
 
+import net.runelite.api.Skill;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.game.FishingSpot;
 import net.runelite.client.plugins.microbot.Microbot;
@@ -24,23 +25,43 @@ import static net.runelite.client.plugins.microbot.util.npc.Rs2Npc.validateInter
 public class BarbarianFishingScript extends Script {
     private long specReadyTime = 0;
     private boolean specActivated = false;
-    public static String version = "1.1.3";
+    public static String version = "1.1.4";
     public static int timeout = 0;
     private BarbarianFishingConfig config;
+
+    private long actionCooldownStartTime = 0;
+    private int lastFishingXp = -1;
+    private long interactingSince = 0;
+    private int lastInventoryCount = -1;
+    private static final long ACTION_COOLDOWN_MAX_MS = 30_000;
+    private static final long INTERACTING_STALE_MS = 15_000;
+
+    public String status = "";
 
     public boolean run(BarbarianFishingConfig config) {
         this.config = config;
         Rs2Antiban.resetAntibanSettings();
         Rs2Antiban.antibanSetupTemplates.applyFishingSetup();
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
-            if (!super.run() || !Microbot.isLoggedIn() || !Rs2Inventory.hasItem("feather") || !Rs2Inventory.hasItem("rod")) {
+            if (!super.run() || !Microbot.isLoggedIn()) {
+                return;
+            }
+
+            if (!Rs2Inventory.hasItem("feather")) {
+                status = "No feathers left";
+                Microbot.log("Barbarian Fisher: No feathers left in inventory.");
+                return;
+            }
+            if (!Rs2Inventory.hasItem("rod")) {
+                status = "No barbarian rod";
+                Microbot.log("Barbarian Fisher: No barbarian rod in inventory.");
                 return;
             }
 
             if (Rs2Equipment.isWearing(ItemID.DRAGON_HARPOON)) {
                 if (Rs2Combat.getSpecEnergy() == 1000) {
                     if (specReadyTime == 0) {
-                        double delay = Rs2Random.gaussRand(45000, 30000); // Delay in ms (mean 1200, stddev 200)
+                        double delay = Rs2Random.gaussRand(45000, 30000);
                         specReadyTime = System.currentTimeMillis() + (long) delay;
                     } else if (!specActivated && System.currentTimeMillis() >= specReadyTime) {
                         Rs2Combat.setSpecState(true);
@@ -52,18 +73,63 @@ public class BarbarianFishingScript extends Script {
                 }
             }
 
-            if (Rs2AntibanSettings.actionCooldownActive) return;
-
-            if (Rs2Player.isInteracting())
+            if (Rs2AntibanSettings.actionCooldownActive) {
+                if (actionCooldownStartTime == 0) {
+                    actionCooldownStartTime = System.currentTimeMillis();
+                    lastFishingXp = Microbot.getClientThread().invoke(() ->
+                            Microbot.getClient().getSkillExperience(Skill.FISHING));
+                } else {
+                    int currentFishingXp = Microbot.getClientThread().invoke(() ->
+                            Microbot.getClient().getSkillExperience(Skill.FISHING));
+                    if (currentFishingXp > lastFishingXp) {
+                        lastFishingXp = currentFishingXp;
+                        actionCooldownStartTime = System.currentTimeMillis();
+                    } else if (System.currentTimeMillis() - actionCooldownStartTime > ACTION_COOLDOWN_MAX_MS) {
+                        Microbot.log("Barbarian Fisher: Action cooldown stuck for >30s with no XP drop, resetting.");
+                        Rs2AntibanSettings.actionCooldownActive = false;
+                        Rs2Antiban.TIMEOUT = 0;
+                        actionCooldownStartTime = 0;
+                        lastFishingXp = -1;
+                    }
+                }
+                status = "Antiban cooldown";
                 return;
+            } else {
+                actionCooldownStartTime = 0;
+                lastFishingXp = -1;
+            }
+
+            if (Rs2Player.isInteracting()) {
+                if (interactingSince == 0) {
+                    interactingSince = System.currentTimeMillis();
+                    lastInventoryCount = Rs2Inventory.size();
+                } else {
+                    long interactDuration = System.currentTimeMillis() - interactingSince;
+                    int currentInventoryCount = Rs2Inventory.size();
+                    boolean inventoryChanged = currentInventoryCount != lastInventoryCount;
+                    if (inventoryChanged) {
+                        interactingSince = System.currentTimeMillis();
+                        lastInventoryCount = currentInventoryCount;
+                    } else if (interactDuration > INTERACTING_STALE_MS) {
+                        Microbot.log("Barbarian Fisher: Interacting state stuck for >15s with no inventory change, resetting.");
+                        interactingSince = 0;
+                    }
+                }
+                status = "Fishing";
+                return;
+            } else {
+                interactingSince = 0;
+            }
 
             if (Rs2Inventory.isFull()) {
+                status = "Dropping fish";
                 dropInventoryItems(config);
                 return;
             }
 
             Rs2NpcModel fishingspot = findFishingSpot();
             if (fishingspot == null) {
+                status = "No fishing spot found";
                 return;
             }
 
@@ -71,10 +137,11 @@ public class BarbarianFishingScript extends Script {
                 validateInteractable(fishingspot.getNpc());
             }
 
-            if(fishingspot.click("Use-rod")) {
+            if (fishingspot.click("Use-rod")) {
+                status = "Clicked fishing spot";
                 Rs2Antiban.actionCooldown();
                 Rs2Antiban.takeMicroBreakByChance();
-            };
+            }
 
         }, 0, 600, TimeUnit.MILLISECONDS);
         return true;
@@ -96,6 +163,10 @@ public class BarbarianFishingScript extends Script {
     }
 
     public void shutdown() {
+        actionCooldownStartTime = 0;
+        lastFishingXp = -1;
+        interactingSince = 0;
+        lastInventoryCount = -1;
         Rs2Antiban.resetAntibanSettings();
         super.shutdown();
     }


### PR DESCRIPTION
## Problem

The BarbarianFishingPlugin would silently stop working after running for a while — no crash, no logs, no action. The script loop would return early on every tick with zero visibility into *why*.

## Root Causes

### 1. Stuck antiban action cooldown
`Rs2AntibanSettings.actionCooldownActive` can get permanently stuck `true`. The antiban system decrements `TIMEOUT` tick-by-tick in `AntibanPlugin.performActionBreak()`, but **only if `category.isBusy()` returns false**. When the category stays "busy" (e.g. while fishing), `TIMEOUT` never decrements, and the script silently returns every 600ms forever.

### 2. Stale `isInteracting()` state  
If a fishing spot despawns/moves while the player is interacting, `Rs2Player.isInteracting()` can stay `true` indefinitely, causing the same silent return loop.

### 3. No diagnostics
Every early-return path had zero logging — no way to tell which condition was blocking execution.

## Fixes

- **XP-drop-based watchdog for action cooldown**: When `actionCooldownActive` is true, the script now snapshots Fishing XP. If XP increases (player is actively fishing), the 30s watchdog timer resets (giving the antiban cooldown time to resolve naturally). Only if **no XP drop for >30s** is the cooldown force-reset as truly stuck. This preserves legitimate antiban behavior while recovering from permanently stuck cooldowns.

- **Stale interaction timeout**: Tracks interaction duration and inventory changes. If `isInteracting()` returns true for >15s with no inventory change (no fish caught), the stale interaction state is reset so the script can re-click a fishing spot.

- **Status logging**: Every early-return path now sets a `status` string (shown in overlay) and key conditions log via `Microbot.log()`.

- **Overlay status display**: Shows current script state ("Fishing", "Antiban cooldown", "No fishing spot found", etc.) in the overlay panel.

## Files Changed
- `BarbarianFishingScript.java` — main fixes + version bump to 1.1.4
- `BarbarianFishingOverlay.java` — status display

## Testing
- Build passes: `./gradlew build -PpluginList=BarbarianFishingPlugin`
- Tested in-game: script runs continuously, antiban cooldowns resolve properly (no premature resets), and the 30s watchdog only fires on truly stuck cooldowns