### PR TITLE
fix(TitheFarming): use instance-aware walking for deposit sack

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/tithefarming/TitheFarmingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/tithefarming/TitheFarmingScript.java
@@ -511,8 +511,21 @@ public class TitheFarmingScript extends Script {
     private boolean depositSack() {
         if (Rs2Inventory.hasItem(TitheFarmMaterial.getSeedForLevel().getFruitId())) {
             Microbot.log("Storing fruits into sack for experience...");
-            interactWithObject(ObjectID.TITHE_SACK_OF_FRUIT_EMPTY, null);
-            Rs2Player.waitForWalking();
+            Rs2TileObjectModel sack = Microbot.getRs2TileObjectCache().query()
+                    .withId(ObjectID.TITHE_SACK_OF_FRUIT_EMPTY)
+                    .nearest();
+            if (sack == null) {
+                Microbot.log("Sack not found in scene");
+                return true;
+            }
+            WorldPoint sackLoc = sack.getWorldLocation();
+            WorldPoint playerLoc = Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation());
+            if (sackLoc.distanceTo2D(playerLoc) > DISTANCE_THRESHOLD_MINIMAP_WALK) {
+                Rs2Walker.walkMiniMap(sackLoc, 1);
+                sleepUntil(Rs2Player::isMoving);
+                sleepUntil(() -> sackLoc.distanceTo2D(Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation())) < DISTANCE_THRESHOLD_MINIMAP_WALK);
+            }
+            sack.click();
             Rs2Player.waitForAnimation();
             return true;
         }


### PR DESCRIPTION
## Bug

When the deposit fruit threshold is reached inside the Tithe Farm minigame, the character teleports out instead of depositing fruits into the sack.

## Root Cause

`depositSack()` called `interactWithObject(ObjectID.TITHE_SACK_OF_FRUIT_EMPTY, null)` which uses raw `WorldLocation` coordinates for its distance check. Inside the instanced Tithe Farm, the sack's world coordinates are ~12,542 tiles away from the player's actual position. This causes the 51-tile distance threshold in `interactWithObject()` to fail, which then calls `Rs2Walker.walkTo()` — a web-walker that route-plans the character out of the minigame via teleport.

Logs showing the issue:
```
Storing fruits into sack for experience...
Object id 27431 is 12542 tiles away, walking...
[WebWalk] goal=WorldPoint(x=11116, y=16036, plane=0) at=WorldPoint(x=1814, y=3494, plane=0)
```

## Fix

Replace `interactWithObject()` with the same instance-safe pattern already used by `walkToBarrel()` and `coreLoop()`:
- Query the sack object
- Check `distanceTo2D` against the player's actual world location
- Use `walkMiniMap()` for local movement (stays within the instance)
- Click the sack directly