### PR TITLE
fix: update QoL compatibility for recent RuneLite revisions

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -671,7 +671,7 @@ public class QoLPlugin extends Plugin implements KeyListener {
     @Subscribe
     public void onConfigChanged(ConfigChanged ev) {
         if ("smoothRotation".equals(ev.getKey()) && config.smoothCameraTracking() && Microbot.isLoggedIn()) {
-            previousCamera[YAW_INDEX] = Microbot.getClient().getCameraYawTarget();
+            previousCamera[YAW_INDEX] = Rs2Camera.getYaw();
         }
         if (ev.getKey().equals("accentColor") || ev.getKey().equals("toggleButtonColor") || ev.getKey().equals("pluginLabelColor")) {
             updateUiElements();
@@ -807,7 +807,7 @@ public class QoLPlugin extends Plugin implements KeyListener {
 
 
     private void applySmoothingToAngle(int index) {
-        int currentAngle = index == YAW_INDEX ? Microbot.getClient().getCameraYawTarget() : 0;
+        int currentAngle = index == YAW_INDEX ? Rs2Camera.getYaw() : 0;
         int newDeltaAngle = getSmallestAngle(previousCamera[index], currentAngle);
         deltaCamera[index] += newDeltaAngle;
 
@@ -816,7 +816,7 @@ public class QoLPlugin extends Plugin implements KeyListener {
 
         deltaCamera[index] -= deltaChange;
         if (index == YAW_INDEX) {
-            Microbot.getClient().setCameraYawTarget(changed);
+            Rs2Camera.setYawInstant((changed % FULL_ROTATION + FULL_ROTATION) % FULL_ROTATION);
         }
         previousCamera[index] += deltaChange;
     }

--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -91,7 +91,7 @@ import static net.runelite.client.plugins.microbot.util.Global.awaitExecutionUnt
 )
 @Slf4j
 public class QoLPlugin extends Plugin implements KeyListener {
-    public static final String version = "1.8.14";
+    public static final String version = "1.8.15";
     public static final List<NewMenuEntry> bankMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> furnaceMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> anvilMenuEntries = new LinkedList<>();

--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/scripts/wintertodt/WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/scripts/wintertodt/WintertodtScript.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.qualityoflife.scripts.wintertodt;
 
+import net.runelite.api.GameState;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
@@ -40,7 +41,18 @@ public class WintertodtScript extends Script {
     private QoLPlugin qolPlugin;
 
     public static boolean isInWintertodtRegion() {
-        var location = Rs2Player.getWorldLocation();
+        if (!Microbot.isLoggedIn()) {
+            return false;
+        }
+
+        var location = Microbot.getClientThread().runOnClientThreadOptional(() -> {
+            if (Microbot.getClient().getGameState() != GameState.LOGGED_IN || Microbot.getClient().getLocalPlayer() == null) {
+                return null;
+            }
+
+            return Microbot.getClient().getLocalPlayer().getWorldLocation();
+        }).orElse(null);
+
         return location != null && location.getRegionID() == 6462;
     }
 


### PR DESCRIPTION
## Summary
- Update QoL camera access for recent RuneLite client changes.
- Guard Wintertodt region checks during login/profile transitions so QoL does not call player-location helpers while the local player is unavailable.

## Validation
- `./gradlew.bat QoLPluginJar --console=plain`
- Local runtime smoke: QoL loads, client logs in, and the Wintertodt region check no longer produces the observed client-thread NPE during login/profile transition.

## Scope
- QoL plugin only.
- No client/RuneLite version bump changes are included in this Hub PR.
