### PR TITLE
fix: restore agility mark of grace looting

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -4,22 +4,20 @@ import net.runelite.api.Skill;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
-import net.runelite.client.plugins.agility.AgilityPlugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.agility.courses.BrimhavenSpikeCourse;
 import net.runelite.client.plugins.microbot.agility.courses.GnomeStrongholdCourse;
 import net.runelite.client.plugins.microbot.agility.courses.PrifddinasCourse;
 import net.runelite.client.plugins.microbot.agility.courses.WerewolfCourse;
+import net.runelite.client.plugins.microbot.api.tileitem.models.Rs2TileItemModel;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.camera.Rs2Camera;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
-import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 import net.runelite.client.plugins.microbot.util.magic.Rs2Magic;
-import net.runelite.client.plugins.microbot.util.models.RS2Item;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 
@@ -283,26 +281,31 @@ public class AgilityScript extends Script
 
 	private boolean lootMarksOfGrace()
 	{
-		final List<RS2Item> marksOfGrace = AgilityPlugin.getMarksOfGrace();
 		final int lootDistance = plugin.getCourseHandler().getLootDistance();
-		if (!marksOfGrace.isEmpty() && !Rs2Inventory.isFull())
+		if (Rs2Inventory.isFull() && !Rs2Inventory.contains(ItemID.GRACE))
 		{
-			for (RS2Item markOfGraceTile : marksOfGrace)
-			{
-				if (Microbot.getClient().getTopLevelWorldView().getPlane() != markOfGraceTile.getTile().getPlane())
-				{
-					continue;
-				}
-				if (!Rs2GameObject.canReach(markOfGraceTile.getTile().getWorldLocation(), lootDistance, lootDistance, lootDistance, lootDistance))
-				{
-					continue;
-				}
-				Rs2GroundItem.loot(markOfGraceTile.getItem().getId());
-				Rs2Player.waitForWalking();
-				return true;
-			}
+			return false;
 		}
-		return false;
+
+		Rs2TileItemModel markOfGrace = Microbot.getRs2TileItemCache().query()
+			.fromWorldView()
+			.withId(ItemID.GRACE)
+			.where(Rs2TileItemModel::isLootAble)
+			.where(item -> Rs2GameObject.canReach(item.getWorldLocation(), lootDistance, lootDistance, lootDistance, lootDistance))
+			.nearest(lootDistance);
+
+		if (markOfGrace == null)
+		{
+			return false;
+		}
+
+		if (!markOfGrace.pickup())
+		{
+			return false;
+		}
+
+		Rs2Player.waitForWalking();
+		return true;
 	}
 
 	private boolean handleFood()

--- a/src/main/java/net/runelite/client/plugins/microbot/agility/MicroAgilityPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/agility/MicroAgilityPlugin.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class MicroAgilityPlugin extends Plugin
 {
-	public static final String version = "1.2.6";
+	public static final String version = "1.2.7";
 	@Inject
 	private MicroAgilityConfig config;
 	@Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -91,7 +91,7 @@ import static net.runelite.client.plugins.microbot.util.Global.awaitExecutionUnt
 )
 @Slf4j
 public class QoLPlugin extends Plugin implements KeyListener {
-    public static final String version = "1.8.13";
+    public static final String version = "1.8.14";
     public static final List<NewMenuEntry> bankMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> furnaceMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> anvilMenuEntries = new LinkedList<>();
@@ -671,7 +671,7 @@ public class QoLPlugin extends Plugin implements KeyListener {
     @Subscribe
     public void onConfigChanged(ConfigChanged ev) {
         if ("smoothRotation".equals(ev.getKey()) && config.smoothCameraTracking() && Microbot.isLoggedIn()) {
-            previousCamera[YAW_INDEX] = Microbot.getClient().getMapAngle();
+            previousCamera[YAW_INDEX] = Microbot.getClient().getCameraYawTarget();
         }
         if (ev.getKey().equals("accentColor") || ev.getKey().equals("toggleButtonColor") || ev.getKey().equals("pluginLabelColor")) {
             updateUiElements();
@@ -807,7 +807,7 @@ public class QoLPlugin extends Plugin implements KeyListener {
 
 
     private void applySmoothingToAngle(int index) {
-        int currentAngle = index == YAW_INDEX ? Microbot.getClient().getMapAngle() : 0;
+        int currentAngle = index == YAW_INDEX ? Microbot.getClient().getCameraYawTarget() : 0;
         int newDeltaAngle = getSmallestAngle(previousCamera[index], currentAngle);
         deltaCamera[index] += newDeltaAngle;
 


### PR DESCRIPTION
## Summary
- Query the current tile item cache directly for marks of grace instead of depending on the built-in Agility plugin's static mark list.
- Pick up the exact reachable mark within the course loot distance using the current tile-item interaction API.
- Bump MicroAgilityPlugin to 1.2.7.
- Update QoL smooth camera tracking to use `Client#getCameraYawTarget()` and bump QoLPlugin to 1.8.14, fixing the CI compile break against Microbot client 2.6.9.

## Root Cause
The hub agility script depended on `AgilityPlugin.getMarksOfGrace()` and then reselected loot by item id through deprecated `Rs2GroundItem.loot(id)`. That path can miss marks when the built-in Agility plugin has not populated its static list, and it can target the wrong item because it re-resolves by id instead of clicking the specific reachable mark.

The PR build also exposed an unrelated existing compatibility break: `QoLPlugin` still called removed client API `Client#getMapAngle()`. The plugin already sets yaw through `setCameraYawTarget(...)`, so reading `getCameraYawTarget()` is the matching current API.

## Validation
- `./gradlew build -PpluginList=MicroAgilityPlugin -PmicrobotClientPath=/home/mimosa/IdeaProjects/microbot/Microbot/runelite-client/build/libs/microbot-2.6.7.jar`
- `./gradlew clean build -PmicrobotClientVersion=2.6.9` *(local Gradle still resolved the untracked local 2.6.7 jar via gradle.properties, but full compile/test/build passed)*