### PR TITLE
feat(WineMaker): stop-before-99 option and session overlay stats

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineConfig.java
@@ -3,7 +3,6 @@ package net.runelite.client.plugins.microbot.natewinemaker;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Range;
 
 
 @ConfigGroup("WineMaker")
@@ -12,21 +11,10 @@ public interface WineConfig extends Config {
     @ConfigItem(
             keyName = "stopBeforeMax",
             name = "Stop before 99",
-            description = "Log out and stop the plugin just before 99 Cooking so you can craft the final wines yourself",
+            description = "Log out and stop once 99 Cooking is within one batch (14 wines), leaving the final batch for you to craft",
             position = 0
     )
     default boolean stopBeforeMax() {
         return false;
-    }
-
-    @Range(min = 1, max = 14)
-    @ConfigItem(
-            keyName = "winesToLeave",
-            name = "Wines to leave",
-            description = "How many wines to leave for you to craft manually (each jug of wine is 200 xp)",
-            position = 1
-    )
-    default int winesToLeave() {
-        return 2;
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineConfig.java
@@ -2,9 +2,31 @@ package net.runelite.client.plugins.microbot.natewinemaker;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 
-@ConfigGroup("PieMaking")
+@ConfigGroup("WineMaker")
 public interface WineConfig extends Config {
 
+    @ConfigItem(
+            keyName = "stopBeforeMax",
+            name = "Stop before 99",
+            description = "Log out and stop the plugin just before 99 Cooking so you can craft the final wines yourself",
+            position = 0
+    )
+    default boolean stopBeforeMax() {
+        return false;
+    }
+
+    @Range(min = 1, max = 14)
+    @ConfigItem(
+            keyName = "winesToLeave",
+            name = "Wines to leave",
+            description = "How many wines to leave for you to craft manually (each jug of wine is 200 xp)",
+            position = 1
+    )
+    default int winesToLeave() {
+        return 2;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineOverlay.java
@@ -8,6 +8,8 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 import javax.inject.Inject;
 import java.awt.*;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 
 public class WineOverlay extends OverlayPanel {
@@ -33,9 +35,26 @@ public class WineOverlay extends OverlayPanel {
                     .right("version: " + WinePlugin.version)
                     .build());
 
+            NumberFormat fmt = NumberFormat.getIntegerInstance(Locale.ENGLISH);
+
             panelComponent.getChildren().add(LineComponent.builder()
                     .left("Wines made:")
-                    .right(String.valueOf(WineScript.getWinesMade()))
+                    .right(fmt.format(WineScript.getWinesMade()))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("XP to 99:")
+                    .right(fmt.format(WineScript.getXpToMax()))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Wines to 99:")
+                    .right(fmt.format(WineScript.getWinesToMax()))
+                    .build());
+
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Est. time to 99:")
+                    .right(WineScript.getTimeToMax())
                     .build());
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineOverlay.java
@@ -33,6 +33,11 @@ public class WineOverlay extends OverlayPanel {
                     .right("version: " + WinePlugin.version)
                     .build());
 
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Wines made:")
+                    .right(String.valueOf(WineScript.getWinesMade()))
+                    .build());
+
 
         } catch (Exception ex) {
             Microbot.logStackTrace(this.getClass().getSimpleName(), ex);

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WinePlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WinePlugin.java
@@ -30,7 +30,7 @@ import java.awt.*;
 )
 @Slf4j
 public class WinePlugin extends Plugin {
-    public final static String version = "1.2.0";
+    public final static String version = "1.3.0";
 
     @Inject
     private Client client;

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
@@ -20,10 +20,24 @@ public class WineScript extends Script {
     private static final int WINE_XP = 200; // xp per jug of wine
     private static final int BATCH_SIZE = 14; // wines per inventory batch
 
+    // Cooking xp at session start; -1 until the first logged-in tick.
+    // Static fields leak across plugin restarts, so run() resets it.
+    private static int startXp = -1;
+
     private WineConfig config;
+
+    /**
+     * Wines made this session, derived from cooking xp gained (200 xp each).
+     * Safe to call from the overlay (client thread).
+     */
+    public static int getWinesMade() {
+        if (startXp < 0 || !Microbot.isLoggedIn()) return 0;
+        return Math.max(0, (Microbot.getClient().getSkillExperience(Skill.COOKING) - startXp) / WINE_XP);
+    }
 
     public boolean run(WineConfig config) {
         this.config = config;
+        startXp = -1;
         // Apply the cooking template as a baseline, then overlay the user's saved
         // antiban panel settings so anything toggled there wins over the template.
         Rs2Antiban.resetAntibanSettings();
@@ -34,6 +48,7 @@ public class WineScript extends Script {
             try {
 				if (!super.run()) return;
 				if (!Microbot.isLoggedIn()) return;
+                if (startXp < 0) startXp = Microbot.getClient().getSkillExperience(Skill.COOKING);
                 if (Rs2AntibanSettings.actionCooldownActive) return;
                 if (Rs2AntibanSettings.microBreakActive) return;
                 if (config.stopBeforeMax() && isMaxWithinOneBatch()) {

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
@@ -25,21 +25,35 @@ public class WineScript extends Script {
     private static int startXp = -1;
     private static long startTimeMillis = -1;
 
+    // Wines mixed this session, counted at mix time. Wine xp does NOT drop per
+    // wine: the fermentation timer is global and resets to ~13s on every mix, so
+    // while crafting continuously the xp for ALL pending wines arrives in one
+    // burst 13s after the last mix. Counting mixes keeps the overlay live and
+    // lets the stop-before-99 gate project xp that hasn't dropped yet.
+    private static int winesMixed = 0;
+
     private WineConfig config;
 
     /**
-     * Wines made this session, derived from cooking xp gained (200 xp each).
-     * Safe to call from the overlay (client thread).
+     * Cooking xp including wines that are mixed but not yet fermented (the xp for
+     * those is guaranteed but deferred by the global 13s fermentation timer).
+     * Uses max() so fermentation bursts and manual wines never regress the value.
      */
-    public static int getWinesMade() {
-        if (startXp < 0 || !Microbot.isLoggedIn()) return 0;
-        return Math.max(0, (Microbot.getClient().getSkillExperience(Skill.COOKING) - startXp) / WINE_XP);
+    private static int projectedXp() {
+        int current = Microbot.getClient().getSkillExperience(Skill.COOKING);
+        if (startXp < 0) return current;
+        return Math.max(current, startXp + winesMixed * WINE_XP);
     }
 
-    /** Cooking xp remaining to 99, or 0 when maxed. */
+    /** Wines mixed this session. Safe to call from the overlay (client thread). */
+    public static int getWinesMade() {
+        return winesMixed;
+    }
+
+    /** Cooking xp remaining to 99 (counting pending unfermented wines), or 0 when maxed. */
     public static int getXpToMax() {
         if (!Microbot.isLoggedIn()) return 0;
-        return Math.max(0, MAX_XP - Microbot.getClient().getSkillExperience(Skill.COOKING));
+        return Math.max(0, MAX_XP - projectedXp());
     }
 
     /** Wines remaining to 99 (rounded up), or 0 when maxed. */
@@ -48,16 +62,16 @@ public class WineScript extends Script {
     }
 
     /**
-     * Estimated time to 99 based on this session's xp rate (includes breaks and
-     * cooldowns, which is what makes the projection honest). "-" until there is
-     * enough data to project from.
+     * Estimated time to 99 based on this session's mixing rate (includes breaks
+     * and cooldowns, which is what makes the projection honest). "-" until there
+     * is enough data to project from.
      */
     public static String getTimeToMax() {
         if (startXp < 0 || !Microbot.isLoggedIn()) return "-";
         int xpToMax = getXpToMax();
         if (xpToMax == 0) return "Maxed!";
         long elapsed = System.currentTimeMillis() - startTimeMillis;
-        int xpGained = Microbot.getClient().getSkillExperience(Skill.COOKING) - startXp;
+        int xpGained = projectedXp() - startXp;
         if (xpGained <= 0 || elapsed < 60_000) return "-"; // need a minute of data
         long msLeft = (long) (xpToMax / ((double) xpGained / elapsed));
         long totalMinutes = msLeft / 60_000;
@@ -73,6 +87,7 @@ public class WineScript extends Script {
         this.config = config;
         startXp = -1;
         startTimeMillis = -1;
+        winesMixed = 0;
         // Apply the cooking template as a baseline, then overlay the user's saved
         // antiban panel settings so anything toggled there wins over the template.
         Rs2Antiban.resetAntibanSettings();
@@ -94,6 +109,7 @@ public class WineScript extends Script {
                     return;
                 }
                 if (Rs2Inventory.count("grapes") > 0 && (Rs2Inventory.count("jug of water") > 0)) {
+                    int jugsBefore = Rs2Inventory.count("jug of water");
                     Rs2Inventory.combine("jug of water", "grapes");
                     sleepUntil(() -> Rs2Widget.getWidget(17694734) != null);
                     Rs2Keyboard.keyPress('1');
@@ -106,6 +122,7 @@ public class WineScript extends Script {
                         Rs2Antiban.takeMicroBreakByChance();
                     }
                     sleepUntil(() -> !Rs2Inventory.hasItem("jug of water"),25000);
+                    winesMixed += Math.max(0, jugsBefore - Rs2Inventory.count("jug of water"));
                 } else {
                     bank();
                 }
@@ -119,10 +136,11 @@ public class WineScript extends Script {
     /**
      * True once 99 Cooking is reachable within a single 14-wine batch, i.e. the
      * script should stop and leave the final batch for the user to craft.
+     * Uses projected xp: raw xp can lag hundreds of wines behind because the
+     * fermentation timer resets on every mix, and gating on it would overshoot.
      */
     private boolean isMaxWithinOneBatch() {
-        int xp = Microbot.getClient().getSkillExperience(Skill.COOKING);
-        return xp >= MAX_XP - BATCH_SIZE * WINE_XP;
+        return projectedXp() >= MAX_XP - BATCH_SIZE * WINE_XP;
     }
 
     private void bank(){

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
@@ -18,6 +18,7 @@ public class WineScript extends Script {
 
     private static final int MAX_XP = 13_034_431; // 99 Cooking
     private static final int WINE_XP = 200; // xp per jug of wine
+    private static final int BATCH_SIZE = 14; // wines per inventory batch
 
     private WineConfig config;
 
@@ -35,18 +36,11 @@ public class WineScript extends Script {
 				if (!Microbot.isLoggedIn()) return;
                 if (Rs2AntibanSettings.actionCooldownActive) return;
                 if (Rs2AntibanSettings.microBreakActive) return;
-                if (config.stopBeforeMax() && winesLeftToCraft() <= 0) {
-                    logoutAndStop("close enough to 99 Cooking - " + config.winesToLeave() + " wine(s) left for you");
+                if (config.stopBeforeMax() && isMaxWithinOneBatch()) {
+                    logoutAndStop("99 Cooking is within one batch - the final wines are yours");
                     return;
                 }
                 if (Rs2Inventory.count("grapes") > 0 && (Rs2Inventory.count("jug of water") > 0)) {
-                    // Make-all crafts every pair in the inventory, so if the inventory
-                    // holds more pairs than the 99 budget allows, rebalance via the bank
-                    int pairs = Math.min(Rs2Inventory.count("grapes"), Rs2Inventory.count("jug of water"));
-                    if (pairs > winesLeftToCraft()) {
-                        bank();
-                        return;
-                    }
                     Rs2Inventory.combine("jug of water", "grapes");
                     sleepUntil(() -> Rs2Widget.getWidget(17694734) != null);
                     Rs2Keyboard.keyPress('1');
@@ -70,17 +64,12 @@ public class WineScript extends Script {
     }
 
     /**
-     * How many wines the script may still craft before it should hand over to the
-     * user. Unlimited when the stop-before-99 option is off. Batches are controlled
-     * at withdraw time (make-all crafts everything in the inventory), so this caps
-     * the final withdraw and triggers the stop once the budget is spent.
+     * True once 99 Cooking is reachable within a single 14-wine batch, i.e. the
+     * script should stop and leave the final batch for the user to craft.
      */
-    private int winesLeftToCraft() {
-        if (!config.stopBeforeMax()) return Integer.MAX_VALUE;
+    private boolean isMaxWithinOneBatch() {
         int xp = Microbot.getClient().getSkillExperience(Skill.COOKING);
-        if (xp >= MAX_XP) return 0;
-        int winesToMax = (MAX_XP - xp + WINE_XP - 1) / WINE_XP; // ceil - wines until 99
-        return Math.max(0, winesToMax - config.winesToLeave());
+        return xp >= MAX_XP - BATCH_SIZE * WINE_XP;
     }
 
     private void bank(){
@@ -89,23 +78,19 @@ public class WineScript extends Script {
             Rs2Bank.depositAll();
             int jugsInBank = Rs2Bank.count("jug of water");
             int grapesInBank = Rs2Bank.count("grapes");
-            // Withdraw up to 14 of each, capped by what is left in the bank (final
-            // partial batch) and by the stop-before-99 budget (final batch before 99)
-            int amount = Math.min(14, Math.min(jugsInBank, grapesInBank));
-            amount = Math.min(amount, winesLeftToCraft());
-            if (amount > 0) {
+            if (jugsInBank > 0 && grapesInBank > 0) {
+                // Withdraw up to 14 of each, or whatever is left for a final partial batch
+                int amount = Math.min(BATCH_SIZE, Math.min(jugsInBank, grapesInBank));
                 Rs2Bank.withdrawDeficit("jug of water", amount);
                 sleepUntil(() -> Rs2Inventory.hasItem("jug of water"));
                 Rs2Bank.withdrawDeficit("grapes", amount);
                 sleepUntil(() -> Rs2Inventory.hasItem("grapes"));
-            } else if (jugsInBank <= 0 || grapesInBank <= 0) {
+            } else {
                 // Out of grapes or jugs of water: log out and stop the plugin
                 Microbot.getNotifier().notify("Run out of Materials");
                 logoutAndStop("out of grapes or jugs of water");
                 return;
             }
-            // amount == 0 with materials available means the 99 gate stops us on the
-            // next loop tick - just close the bank and let the loop handle it
         }
         Rs2Bank.closeBank();
         sleepUntil(() -> !Rs2Bank.isOpen());

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
@@ -20,9 +20,10 @@ public class WineScript extends Script {
     private static final int WINE_XP = 200; // xp per jug of wine
     private static final int BATCH_SIZE = 14; // wines per inventory batch
 
-    // Cooking xp at session start; -1 until the first logged-in tick.
-    // Static fields leak across plugin restarts, so run() resets it.
+    // Cooking xp / wall clock at session start; -1 until the first logged-in tick.
+    // Static fields leak across plugin restarts, so run() resets them.
     private static int startXp = -1;
+    private static long startTimeMillis = -1;
 
     private WineConfig config;
 
@@ -35,9 +36,43 @@ public class WineScript extends Script {
         return Math.max(0, (Microbot.getClient().getSkillExperience(Skill.COOKING) - startXp) / WINE_XP);
     }
 
+    /** Cooking xp remaining to 99, or 0 when maxed. */
+    public static int getXpToMax() {
+        if (!Microbot.isLoggedIn()) return 0;
+        return Math.max(0, MAX_XP - Microbot.getClient().getSkillExperience(Skill.COOKING));
+    }
+
+    /** Wines remaining to 99 (rounded up), or 0 when maxed. */
+    public static int getWinesToMax() {
+        return (getXpToMax() + WINE_XP - 1) / WINE_XP;
+    }
+
+    /**
+     * Estimated time to 99 based on this session's xp rate (includes breaks and
+     * cooldowns, which is what makes the projection honest). "-" until there is
+     * enough data to project from.
+     */
+    public static String getTimeToMax() {
+        if (startXp < 0 || !Microbot.isLoggedIn()) return "-";
+        int xpToMax = getXpToMax();
+        if (xpToMax == 0) return "Maxed!";
+        long elapsed = System.currentTimeMillis() - startTimeMillis;
+        int xpGained = Microbot.getClient().getSkillExperience(Skill.COOKING) - startXp;
+        if (xpGained <= 0 || elapsed < 60_000) return "-"; // need a minute of data
+        long msLeft = (long) (xpToMax / ((double) xpGained / elapsed));
+        long totalMinutes = msLeft / 60_000;
+        long days = totalMinutes / (24 * 60);
+        long hours = (totalMinutes / 60) % 24;
+        long minutes = totalMinutes % 60;
+        if (days > 0) return days + "d " + hours + "h";
+        if (hours > 0) return hours + "h " + minutes + "m";
+        return Math.max(1, minutes) + "m";
+    }
+
     public boolean run(WineConfig config) {
         this.config = config;
         startXp = -1;
+        startTimeMillis = -1;
         // Apply the cooking template as a baseline, then overlay the user's saved
         // antiban panel settings so anything toggled there wins over the template.
         Rs2Antiban.resetAntibanSettings();
@@ -48,7 +83,10 @@ public class WineScript extends Script {
             try {
 				if (!super.run()) return;
 				if (!Microbot.isLoggedIn()) return;
-                if (startXp < 0) startXp = Microbot.getClient().getSkillExperience(Skill.COOKING);
+                if (startXp < 0) {
+                    startXp = Microbot.getClient().getSkillExperience(Skill.COOKING);
+                    startTimeMillis = System.currentTimeMillis();
+                }
                 if (Rs2AntibanSettings.actionCooldownActive) return;
                 if (Rs2AntibanSettings.microBreakActive) return;
                 if (config.stopBeforeMax() && isMaxWithinOneBatch()) {

--- a/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/natewinemaker/WineScript.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.microbot.natewinemaker;
 
+import net.runelite.api.Skill;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
@@ -15,7 +16,13 @@ import java.util.concurrent.TimeUnit;
 
 public class WineScript extends Script {
 
+    private static final int MAX_XP = 13_034_431; // 99 Cooking
+    private static final int WINE_XP = 200; // xp per jug of wine
+
+    private WineConfig config;
+
     public boolean run(WineConfig config) {
+        this.config = config;
         // Apply the cooking template as a baseline, then overlay the user's saved
         // antiban panel settings so anything toggled there wins over the template.
         Rs2Antiban.resetAntibanSettings();
@@ -28,7 +35,18 @@ public class WineScript extends Script {
 				if (!Microbot.isLoggedIn()) return;
                 if (Rs2AntibanSettings.actionCooldownActive) return;
                 if (Rs2AntibanSettings.microBreakActive) return;
+                if (config.stopBeforeMax() && winesLeftToCraft() <= 0) {
+                    logoutAndStop("close enough to 99 Cooking - " + config.winesToLeave() + " wine(s) left for you");
+                    return;
+                }
                 if (Rs2Inventory.count("grapes") > 0 && (Rs2Inventory.count("jug of water") > 0)) {
+                    // Make-all crafts every pair in the inventory, so if the inventory
+                    // holds more pairs than the 99 budget allows, rebalance via the bank
+                    int pairs = Math.min(Rs2Inventory.count("grapes"), Rs2Inventory.count("jug of water"));
+                    if (pairs > winesLeftToCraft()) {
+                        bank();
+                        return;
+                    }
                     Rs2Inventory.combine("jug of water", "grapes");
                     sleepUntil(() -> Rs2Widget.getWidget(17694734) != null);
                     Rs2Keyboard.keyPress('1');
@@ -51,38 +69,63 @@ public class WineScript extends Script {
         return true;
     }
 
+    /**
+     * How many wines the script may still craft before it should hand over to the
+     * user. Unlimited when the stop-before-99 option is off. Batches are controlled
+     * at withdraw time (make-all crafts everything in the inventory), so this caps
+     * the final withdraw and triggers the stop once the budget is spent.
+     */
+    private int winesLeftToCraft() {
+        if (!config.stopBeforeMax()) return Integer.MAX_VALUE;
+        int xp = Microbot.getClient().getSkillExperience(Skill.COOKING);
+        if (xp >= MAX_XP) return 0;
+        int winesToMax = (MAX_XP - xp + WINE_XP - 1) / WINE_XP; // ceil - wines until 99
+        return Math.max(0, winesToMax - config.winesToLeave());
+    }
+
     private void bank(){
         Rs2Bank.openBank();
         if(Rs2Bank.isOpen()){
             Rs2Bank.depositAll();
             int jugsInBank = Rs2Bank.count("jug of water");
             int grapesInBank = Rs2Bank.count("grapes");
-            if(jugsInBank > 0 && grapesInBank > 0) {
-                // Withdraw up to 14 of each, or whatever is left for a final partial batch
-                int amount = Math.min(14, Math.min(jugsInBank, grapesInBank));
+            // Withdraw up to 14 of each, capped by what is left in the bank (final
+            // partial batch) and by the stop-before-99 budget (final batch before 99)
+            int amount = Math.min(14, Math.min(jugsInBank, grapesInBank));
+            amount = Math.min(amount, winesLeftToCraft());
+            if (amount > 0) {
                 Rs2Bank.withdrawDeficit("jug of water", amount);
                 sleepUntil(() -> Rs2Inventory.hasItem("jug of water"));
                 Rs2Bank.withdrawDeficit("grapes", amount);
                 sleepUntil(() -> Rs2Inventory.hasItem("grapes"));
-            } else {
+            } else if (jugsInBank <= 0 || grapesInBank <= 0) {
                 // Out of grapes or jugs of water: log out and stop the plugin
                 Microbot.getNotifier().notify("Run out of Materials");
-                Microbot.status = "[Shutting down] - Reason: out of grapes or jugs of water.";
-                Rs2Bank.closeBank();
-                sleepUntil(() -> !Rs2Bank.isOpen());
-                Rs2Player.logout();
-                sleepUntil(() -> !Microbot.isLoggedIn(), 10000);
-                Plugin wineMakerPlugin = Microbot.getPluginManager().getPlugins().stream()
-                        .filter(x -> x.getClass().getName().equals(WinePlugin.class.getName()))
-                        .findFirst()
-                        .orElse(null);
-                Microbot.stopPlugin(wineMakerPlugin);
-                shutdown();
+                logoutAndStop("out of grapes or jugs of water");
                 return;
             }
+            // amount == 0 with materials available means the 99 gate stops us on the
+            // next loop tick - just close the bank and let the loop handle it
         }
         Rs2Bank.closeBank();
         sleepUntil(() -> !Rs2Bank.isOpen());
+    }
+
+    private void logoutAndStop(String reason) {
+        Microbot.status = "[Shutting down] - Reason: " + reason + ".";
+        Microbot.getNotifier().notify("Wine Maker stopping: " + reason);
+        if (Rs2Bank.isOpen()) {
+            Rs2Bank.closeBank();
+            sleepUntil(() -> !Rs2Bank.isOpen());
+        }
+        Rs2Player.logout();
+        sleepUntil(() -> !Microbot.isLoggedIn(), 10000);
+        Plugin wineMakerPlugin = Microbot.getPluginManager().getPlugins().stream()
+                .filter(x -> x.getClass().getName().equals(WinePlugin.class.getName()))
+                .findFirst()
+                .orElse(null);
+        Microbot.stopPlugin(wineMakerPlugin);
+        shutdown();
     }
 
     @Override


### PR DESCRIPTION
## Summary

Follow-up to #508 (these commits were pushed after it merged, so they need their own PR).

### Stop before 99 (new config option)
- Optional toggle: once 99 Cooking is reachable within a single 14-wine batch, the plugin logs out and stops, leaving the final batch for the user to craft the level manually

### Overlay session stats
- Wines made this session
- XP remaining to 99 (comma formatted)
- Wines remaining to 99
- Estimated time to 99, projected from the session's actual rate (includes breaks/cooldowns)

### Fermentation-aware tracking
Wine xp does not drop per wine: the fermentation timer is global and resets to ~13s on every mix, so xp for all pending wines arrives in one burst 13s after the last mix. The overlay therefore counts wines at mix time, and the stop-before-99 gate projects pending xp (`max(currentXp, startXp + winesMixed * 200)`) so deferred fermentation cannot make it overshoot the target.

### Version
- `1.2.0` → `1.3.0`

## Testing
- Built against a local `microbot-2.6.12.jar` and verified in-game: overlay counts update per batch, xp projection tracks through fermentation bursts