### PR TITLE
QoL: auto-confirm the farming tree-removal payment dialogue

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLConfig.java
@@ -285,6 +285,18 @@ public interface QoLConfig extends Config {
         return true;
     }
 
+    // boolean to auto-confirm the farming tree-removal payment dialogue
+    @ConfigItem(
+            keyName = "autoPayTreeRemoval",
+            name = "Auto Pay Tree Removal",
+            description = "Automatically selects 'Yes.' on the farming \"Pay X Coins to have your tree chopped down?\" prompt, speeding up farm runs",
+            position = 2,
+            section = dialogueSection
+    )
+    default boolean autoPayTreeRemoval() {
+        return true;
+    }
+
     // boolean to enable Potion Manager
     @ConfigItem(
             keyName = "enablePotionManager",

--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLScript.java
@@ -77,6 +77,10 @@ public class QoLScript extends Script {
                     Rs2Dialogue.handleQuestOptionDialogueSelection();
                 }
 
+                if (config.autoPayTreeRemoval() && Rs2Dialogue.isInDialogue()) {
+                    handleTreeRemovalPayment();
+                }
+
 
             } catch (Exception ex) {
                 log.error("Error in QoLScript execution: {}", ex.getMessage(), ex);
@@ -153,6 +157,16 @@ public class QoLScript extends Script {
 
     private void handleAutoDrinkPrayPot(int points) {
         Rs2Player.drinkPrayerPotionAt(points);
+    }
+
+    // Auto-confirm the farming "Pay X Coins to have your tree chopped down?" prompt (tree removal
+    // after a check-health) so farm runs don't wait on a manual 'Yes.'. Matched on the question
+    // title so it never fires on unrelated Yes/No dialogues; amount-agnostic on purpose.
+    private void handleTreeRemovalPayment() {
+        if (Rs2Dialogue.hasQuestion("to have your tree chopped down")
+                && Rs2Dialogue.hasDialogueOption("Yes")) {
+            Rs2Dialogue.clickOption("Yes");
+        }
     }
 
     // handle dialogue continue


### PR DESCRIPTION
## What
Adds an **Auto Pay Tree Removal** toggle to the Quality of Life plugin (Dialogue section, default on). When enabled, it auto-selects "Yes." on the farming *"Pay X Coins to have your tree chopped down?"* prompt so farm runs don't stall on a manual click.

## How
- New `autoPayTreeRemoval()` config item in `QoLConfig` (Dialogue section, default on).
- `handleTreeRemovalPayment()` in `QoLScript` fires only when already in a dialogue and the question title matches `"to have your tree chopped down"`, then clicks the "Yes" option.
- Matched on the question title, so it never triggers on unrelated Yes/No dialogues. Amount-agnostic by design (works regardless of the coin cost).

## Testing
- Verified on a live farm run — the tree-removal prompt is auto-confirmed; no misfires observed on other dialogues.
- `./gradlew compileQualityoflifeJava` passes against client 2.6.12.

## Scope
Single feature, 2 files (`QoLConfig.java`, `QoLScript.java`), +26 lines. No behaviour change when the toggle is off.
