### PR TITLE
Fix combat zone detection loop and replace deprecated Rs2GroundItem

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/sulphurnaguafigther/SulphurNaguaPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sulphurnaguafigther/SulphurNaguaPlugin.java
@@ -20,7 +20,7 @@ import java.time.Instant;
         tags = {"combat", "pvm", "nagua", "varlamore", "microbot"},
         authors = { "VIP" },
         version = SulphurNaguaPlugin.version,
-        minClientVersion = "1.9.8",
+        minClientVersion = "2.6.12",
         cardUrl = "https://chsami.github.io/Microbot-Hub/SulphurNaguaPlugin/assets/card.png",
         iconUrl = "https://chsami.github.io/Microbot-Hub/SulphurNaguaPlugin/assets/icon.png",
         isExternal = PluginConstants.IS_EXTERNAL,
@@ -29,7 +29,7 @@ import java.time.Instant;
 @Slf4j
 public class SulphurNaguaPlugin extends Plugin {
 
-    public static final String version = "2.0.1";
+    public static final String version = "2.0.2";
 
     @Inject
     SulphurNaguaScript sulphurNaguaScript;

--- a/src/main/java/net/runelite/client/plugins/microbot/sulphurnaguafigther/SulphurNaguaScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sulphurnaguafigther/SulphurNaguaScript.java
@@ -16,7 +16,6 @@ import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.antiban.enums.Activity;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.dialogues.Rs2Dialogue;
-import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -35,11 +34,11 @@ public class SulphurNaguaScript extends Script {
     @RequiredArgsConstructor
     public enum NaguaLocation {
         CIVITAS_ILLA_FORTIS_WEST("West",
-                new WorldArea(1344, 9553, 25, 25, 0),
+                new WorldArea(1372, 9553, 8, 14, 0),
                 new WorldPoint(1376, 9712, 0)),
 
         CIVITAS_ILLA_FORTIS_EAST("East",
-                new WorldArea(1371, 9557, 10, 10, 0),
+                new WorldArea(1351, 9549, 10, 25, 0),
                 new WorldPoint(1376, 9712, 0));
 
         private final String name;
@@ -98,7 +97,6 @@ public class SulphurNaguaScript extends Script {
 
     private Set<Integer> dynamicLootIds = new HashSet<>();
 
-
     private final int MOONLIGHT_GRUB_ID = 29078;
     private final int MOONLIGHT_GRUB_PASTE_ID = 29079;
     private final Set<Integer> MOONLIGHT_POTION_IDS = Set.of(29080, 29081, 29082, 29083);
@@ -108,7 +106,6 @@ public class SulphurNaguaScript extends Script {
     public WorldArea getNaguaCombatArea() {
         return (selectedLocation != null) ? selectedLocation.getCombatArea() : null;
     }
-
 
     private void updateDynamicLootIds(SulphurNaguaConfig config) {
         dynamicLootIds.clear();
@@ -136,7 +133,16 @@ public class SulphurNaguaScript extends Script {
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-                if (!Microbot.isLoggedIn() || !super.run()) return;
+                if (!Microbot.isLoggedIn() || !super.run() || Microbot.pauseAllScripts.get()) {
+                    return;
+                }
+
+                if (Rs2AntibanSettings.antibanEnabled) {
+                    Rs2Antiban.actionCooldown();
+                    if (Rs2AntibanSettings.takeMicroBreaks && Rs2Antiban.takeMicroBreakByChance()) {
+                        return;
+                    }
+                }
 
                 if (!hasInitialized) {
                     startTotalExp = Microbot.getClient().getOverallExperience();
@@ -190,13 +196,23 @@ public class SulphurNaguaScript extends Script {
         Rs2Antiban.resetAntibanSettings();
     }
 
+    private int getEffectiveTargetPotions(SulphurNaguaConfig config) {
+        int fixedItems = countFixedItems();
+        int maxPossiblePotions = 28 - fixedItems;
+        return Math.min(config.moonlightPotionsMinimum(), maxPossiblePotions);
+    }
+
+    private boolean isInCombatArea() {
+        WorldArea combatArea = getNaguaCombatArea();
+        WorldPoint playerLoc = Rs2Player.getWorldLocation();
+        return combatArea != null && playerLoc != null && combatArea.contains(playerLoc);
+    }
+
     private void determineState(SulphurNaguaConfig config) {
 
         updateDynamicLootIds(config);
 
-        int fixedItems = countFixedItems();
-        int maxPossiblePotions = 28 - fixedItems;
-        int targetPotions = Math.min(config.moonlightPotionsMinimum(), maxPossiblePotions);
+        int targetPotions = getEffectiveTargetPotions(config);
 
         boolean hasPotionsInInventory = countMoonlightPotions() > 0;
         int totalOwnedPotions = countMoonlightPotions() + potionsToPickup;
@@ -206,8 +222,7 @@ public class SulphurNaguaScript extends Script {
             currentState = Rs2Bank.isNearBank(10) ? SulphurNaguaState.BANKING : SulphurNaguaState.WALKING_TO_BANK;
             return;
         }
-        boolean inCombatZone = isAtLocation(selectedLocation.getFightAreaCenter());
-
+        boolean inCombatZone = isInCombatArea();
         if (potionsToPickup > 0 && pickupReady) {
             if (Rs2Inventory.isFull()) {
                 Microbot.log("Inventory is full, cannot pick up remaining potions. Starting to fight.");
@@ -232,7 +247,6 @@ public class SulphurNaguaScript extends Script {
             currentState = SulphurNaguaState.LOOTING;
             return;
         }
-
 
         if ((currentState == SulphurNaguaState.FIGHTING || currentState == SulphurNaguaState.WALKING_TO_FIGHT || (currentState == SulphurNaguaState.IDLE && inCombatZone) || currentState == SulphurNaguaState.LOOTING) && hasPotionsInInventory) {
             currentState = inCombatZone ? SulphurNaguaState.FIGHTING : SulphurNaguaState.WALKING_TO_FIGHT;
@@ -264,7 +278,7 @@ public class SulphurNaguaScript extends Script {
             return;
         }
 
-        int targetPotions = config.moonlightPotionsMinimum();
+        int targetPotions = getEffectiveTargetPotions(config);
         int currentPotions = countMoonlightPotions();
         int totalOwnedPotions = currentPotions + potionsToPickup;
 
@@ -280,7 +294,6 @@ public class SulphurNaguaScript extends Script {
         int freeSlots = Rs2Inventory.emptySlotCount();
         int vialsInInv = Rs2Inventory.count(VIAL_OF_WATER_ID);
         int grubsInInv = Rs2Inventory.count(MOONLIGHT_GRUB_ID);
-
 
         if (vialsInInv > 0) {
             int grubsToGet = vialsInInv;
@@ -304,9 +317,9 @@ public class SulphurNaguaScript extends Script {
             return;
         }
 
-
         if (freeSlots > 0) {
-            int vialsToGet = Math.min(neededPotionsTotal, freeSlots);
+            int reservedForVials = Math.max(1, freeSlots / 2);
+            int vialsToGet = Math.min(neededPotionsTotal, reservedForVials);
             getSupplies(VIAL_OF_WATER_ID, vialsInInv + vialsToGet);
         } else {
             int potionsToDrop = Math.min(neededPotionsTotal, currentPotions);
@@ -375,7 +388,6 @@ public class SulphurNaguaScript extends Script {
         }
     }
 
-
     private void dropPotions(int count) {
         if (count <= 0) return;
         if (dropLocation == null) dropLocation = Rs2Player.getWorldLocation();
@@ -411,10 +423,11 @@ public class SulphurNaguaScript extends Script {
 
         boolean foundPotion = false;
         for (int potionId : MOONLIGHT_POTION_IDS) {
-            if (Rs2GroundItem.exists(potionId, 8)) {
+            if (Microbot.getRs2TileItemCache().query().withId(potionId).within(8).first() != null) {
                 foundPotion = true;
                 int potionsBefore = countMoonlightPotions();
-                if (Rs2GroundItem.interact(potionId, "Take", 8)) {
+
+                if (Microbot.getRs2TileItemCache().query().withId(potionId).within(8).interact("Take")) {
                     if (sleepUntil(() -> countMoonlightPotions() > potionsBefore, 3000)) {
                         potionsToPickup--;
                     }
@@ -431,7 +444,6 @@ public class SulphurNaguaScript extends Script {
             resetPreparationState();
         }
     }
-
 
     private int countMoonlightPotions() {
         return MOONLIGHT_POTION_IDS.stream().mapToInt(Rs2Inventory::count).sum();
@@ -520,17 +532,35 @@ public class SulphurNaguaScript extends Script {
         boolean needsNewTarget = !Rs2Player.isInCombat() || Rs2Player.getInteracting() == null;
 
         if (needsNewTarget) {
-            if (getNaguaCombatArea() != null && getNaguaCombatArea().contains(Rs2Player.getWorldLocation())) {
-                var nagua = Microbot.getRs2NpcCache().query()
+            WorldArea combatArea = getNaguaCombatArea();
+
+            if (combatArea != null && combatArea.contains(Rs2Player.getWorldLocation())) {
+
+                var attackingNagua = Microbot.getRs2NpcCache().query()
                         .withName("Sulphur Nagua")
                         .where(n -> !n.isDead())
-                        .firstOnClientThread();
+                        .where(n -> n.getInteracting() != null && n.getInteracting().equals(client.getLocalPlayer()))
+                        .nearest();
 
-                if (nagua != null) {
-                    if (nagua.click("Attack")) {
-                        sleepUntil(Rs2Player::isInCombat, 3000);
-                        totalNaguaKills++;
-                    }
+                boolean attackInitiated = false;
+
+                if (attackingNagua != null) {
+                    Microbot.log("Attacking the Nagua that is attacking us!");
+                    attackInitiated = attackingNagua.click("Attack");
+                } else {
+                    attackInitiated = Microbot.getRs2NpcCache().query()
+                            .withName("Sulphur Nagua")
+                            .where(n -> !n.isDead())
+                            .where(n -> combatArea.contains(n.getWorldLocation()))
+                            .where(n -> n.getInteracting() == null || n.getInteracting().equals(client.getLocalPlayer()))
+                            .interact("Attack");
+                }
+
+                if (attackInitiated) {
+                    sleepUntil(Rs2Player::isInCombat, 3000);
+                    totalNaguaKills++;
+                } else {
+                    Microbot.log("Waiting for Sulphur Nagua in the zone...");
                 }
             } else {
                 Microbot.log("Outside combat zone, walking back to center...");
@@ -539,7 +569,6 @@ public class SulphurNaguaScript extends Script {
             }
         }
     }
-
 
     private void applyAntiBanSettings() {
         Rs2AntibanSettings.actionCooldownActive = true;
@@ -552,18 +581,10 @@ public class SulphurNaguaScript extends Script {
         Rs2AntibanSettings.nonLinearIntervals = true;
         Rs2AntibanSettings.simulateMistakes = false;
         Rs2AntibanSettings.naturalMouse = true;
-        Rs2AntibanSettings.moveMouseOffScreen = true;
-        Rs2AntibanSettings.moveMouseRandomly = true;
         Rs2AntibanSettings.dynamicIntensity = true;
-        Rs2AntibanSettings.takeMicroBreaks = true;
-        Rs2AntibanSettings.microBreakDurationLow = 2;
-        Rs2AntibanSettings.microBreakDurationHigh = 5;
         Rs2AntibanSettings.actionCooldownChance = 0.05;
-        Rs2AntibanSettings.microBreakChance = 0.08;
-        Rs2AntibanSettings.moveMouseRandomlyChance = 0.08;
-        Rs2AntibanSettings.moveMouseOffScreenChance = 0.05;
-
-
+        Rs2AntibanSettings.moveMouseRandomlyChance = 0.02;
+        Rs2AntibanSettings.moveMouseOffScreenChance = 0.01;
     }
 
     private void handleBanking(SulphurNaguaConfig config) {
@@ -634,40 +655,46 @@ public class SulphurNaguaScript extends Script {
     }
 
     private boolean isAtLocation(WorldPoint worldPoint) {
-        return Rs2Player.getWorldLocation().distanceTo(worldPoint) < 10;
+        WorldPoint playerLoc = Rs2Player.getWorldLocation();
+        return playerLoc != null && playerLoc.distanceTo(worldPoint) < 10;
     }
 
-
     private boolean isSulphurBladeNearby() {
-        return Rs2GroundItem.exists(SULPHUR_BLADE_ID, 8);
+        return Microbot.getRs2TileItemCache().query()
+                .withId(SULPHUR_BLADE_ID)
+                .within(8)
+                .first() != null;
     }
 
     private boolean isStackableLootNearby() {
         for (int itemId : dynamicLootIds) {
-            if (Rs2GroundItem.exists(itemId, 8)) {
+            if (Microbot.getRs2TileItemCache().query()
+                    .withId(itemId)
+                    .within(8)
+                    .first() != null) {
                 return true;
             }
         }
         return false;
     }
 
-
     private void handleLooting() {
         Microbot.log("Looting items...");
 
-        if (isSulphurBladeNearby()) {
+        if (Microbot.getRs2TileItemCache().query().withId(SULPHUR_BLADE_ID).within(8).first() != null) {
             int itemsBefore = Rs2Inventory.count(SULPHUR_BLADE_ID);
-            if (Rs2GroundItem.interact(SULPHUR_BLADE_ID, "Take", 8)) {
+
+            if (Microbot.getRs2TileItemCache().query().withId(SULPHUR_BLADE_ID).within(8).interact("Take")) {
                 sleepUntil(() -> Rs2Inventory.count(SULPHUR_BLADE_ID) > itemsBefore, 3000);
             }
             return;
         }
 
-
         for (int itemId : dynamicLootIds) {
-            if (Rs2GroundItem.exists(itemId, 8)) {
+            if (Microbot.getRs2TileItemCache().query().withId(itemId).within(8).first() != null) {
                 int itemsBefore = Rs2Inventory.count(itemId);
-                if (Rs2GroundItem.interact(itemId, "Take", 8)) {
+
+                if (Microbot.getRs2TileItemCache().query().withId(itemId).within(8).interact("Take")) {
                     sleepUntil(() -> Rs2Inventory.count(itemId) > itemsBefore, 3000);
                 }
                 return;


### PR DESCRIPTION
- Fix combat zone check: added isInCombatArea() helper that uses WorldArea.contains(), and use it consistently in determineState() so it matches the check in handleFighting().
- Replace Rs2GroundItem (deprecated since 2.1.0, forRemoval = true) with Rs2TileItemCache/Rs2TileItemQuery for all ground-item lookups (loot, potion pickup).
- Restore combat priority: attack the Nagua that is currently targeting the player before attacking any other Nagua in the zone.
- Cap potion target by inventory space: added getEffectiveTargetPotions() so the configured potion minimum is clamped to available inventory slots; used in both determineState() and handlePreparation().
- Preparation tweak: reserve half of free slots for vials instead of using all free slots, to avoid overfilling with vials.
- Restore antiban gating: re-added action-cooldown and micro-break checks in the main loop.
- Restored original West/East combat area bound
