### PR TITLE
Fix: Sapling Forestry event ingredient collection by distance instead of random.

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
@@ -50,7 +50,7 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 )
 @Slf4j
 public class AutoWoodcuttingPlugin extends Plugin {
-    public static final String version = "1.8.3";
+    public static final String version = "1.8.4";
     @Inject
     @Getter(AccessLevel.MODULE)
     public AutoWoodcuttingScript autoWoodcuttingScript;

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/StrugglingSaplingEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/StrugglingSaplingEvent.java
@@ -144,11 +144,20 @@ public class StrugglingSaplingEvent implements BlockingEvent {
                     break;
                 }
 
-                Microbot.log("StrugglingSaplingEvent: No known correct ingredient, collecting a random one.");
-                var randomIngredient = availableIngredients.get((int) (Math.random() * availableIngredients.size()));
-                Microbot.log("StrugglingSaplingEvent: Collecting random ingredient: " + randomIngredient.getWorldLocation());
-                randomIngredient.click("Collect");
-                triedIngredients.add(randomIngredient.getId());
+                Microbot.log("StrugglingSaplingEvent: No known correct ingredient, collecting the closest untried one.");
+                var closestIngredient = availableIngredients.get(0);
+                int closestDist = closestIngredient.getWorldLocation().distanceTo(Rs2Player.getWorldLocation());
+                for (var ingredient : availableIngredients) {
+                    int dist = ingredient.getWorldLocation().distanceTo(Rs2Player.getWorldLocation());
+                    if (dist < closestDist) {
+                        closestDist = dist;
+                        closestIngredient = ingredient;
+                    }
+                }
+
+                Microbot.log("StrugglingSaplingEvent: Collecting ingredient: " + closestIngredient.getWorldLocation());
+                closestIngredient.click("Collect");
+                triedIngredients.add(closestIngredient.getId());
                 Rs2Player.waitForAnimation();
             }
 


### PR DESCRIPTION
Updated Ingredient Collection to use closest first instead of Random Ingredient. Behavior is both more player-like and more efficient.