### PR TITLE
Fix: RootEvent.java where

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/AutoWoodcuttingPlugin.java
@@ -50,7 +50,7 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 )
 @Slf4j
 public class AutoWoodcuttingPlugin extends Plugin {
-    public static final String version = "1.8.3";
+    public static final String version = "1.8.5";
     @Inject
     @Getter(AccessLevel.MODULE)
     public AutoWoodcuttingScript autoWoodcuttingScript;

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/RootEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/RootEvent.java
@@ -1,7 +1,6 @@
 package net.runelite.client.plugins.microbot.woodcutting.Forestry;
 
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Actor;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.client.plugins.microbot.BlockingEvent;
@@ -65,39 +64,27 @@ public class RootEvent implements BlockingEvent {
 
             // If special root is present
             if (specialRoot != null) {
-
-                // Check if the player is already interacting with the special root
-                if (Rs2Player.isInteracting() && Rs2Player.getInteracting() != null) {
-                    Actor interactingNpc = Microbot.getClient().getLocalPlayer().getInteracting();
-                    if (interactingNpc.getWorldLocation().equals(specialRoot.getWorldLocation())) {
-                        continue;
-                    }
-                }
                 // Interact with the special root
                 Microbot.log("RootEvent: Interacting with special root at " + specialRoot.getWorldLocation());
                 specialRoot.click("Chop down");
-                Rs2Player.waitForAnimation(5000);
-                sleepUntil(() -> !Rs2Player.isInteracting(), 40000);
+                waitForChoppingToFinish();
             }
             // If regular root is present
             else if (root != null) {
-
-                // Check if the player is already interacting with the root
-                if (Rs2Player.isInteracting() && Rs2Player.getInteracting() != null) {
-                    Actor interactingNpc = Microbot.getClient().getLocalPlayer().getInteracting();
-                    if (interactingNpc.getWorldLocation().equals(root.getWorldLocation())) {
-                        continue;
-                    }
-                }
                 // Interact with the regular root
                 Microbot.log("RootEvent: Interacting with regular root at " + root.getWorldLocation());
                 root.click("Chop down");
-                Rs2Player.waitForAnimation(5000);
-                sleepUntil(() -> !Rs2Player.isInteracting(), 40000);
+                waitForChoppingToFinish();
             }
         }
         plugin.incrementForestryEventCompleted();
         return true;
+    }
+
+    private void waitForChoppingToFinish() {
+        if (sleepUntil(Rs2Player::isAnimating, 5000)) {
+            sleepUntil(() -> !Rs2Player.isAnimating() || !this.validate(), 40000);
+        }
     }
 
     @Override


### PR DESCRIPTION
I noticed a bug where it would click the root every 5 seconds, even when already performing the woodcutting animation.
Replaced Rs2Player.isInteracting() with Rs2Player.isAnimating()

This ensures the loop blocks until the chopping animation stops or the root disappears.

Testing at the moment.
