### PR TITLE
Fix QoL special attack handling

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/QoLPlugin.java
@@ -91,7 +91,7 @@ import static net.runelite.client.plugins.microbot.util.Global.awaitExecutionUnt
 )
 @Slf4j
 public class QoLPlugin extends Plugin implements KeyListener {
-    public static final String version = "1.8.15";
+    public static final String version = "1.8.16";
     public static final List<NewMenuEntry> bankMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> furnaceMenuEntries = new LinkedList<>();
     public static final List<NewMenuEntry> anvilMenuEntries = new LinkedList<>();

--- a/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/scripts/SpecialAttackScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/qualityoflife/scripts/SpecialAttackScript.java
@@ -4,16 +4,13 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.qualityoflife.QoLConfig;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
-import net.runelite.client.plugins.microbot.api.npc.models.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class SpecialAttackScript extends Script {
 
     public boolean run(QoLConfig config) {
-        AtomicReference<Rs2NpcModel> npc = new AtomicReference<>();
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!Microbot.isLoggedIn()) return;
@@ -21,14 +18,7 @@ public class SpecialAttackScript extends Script {
                 if (!config.useSpecWeapon()) return;
                 if (Rs2Equipment.all("guthan's").count() == 4) return;
                 if (Rs2Player.isInteracting()) {
-                    var interacting = Rs2Player.getInteracting();
-                    if (interacting instanceof net.runelite.api.NPC) {
-                        var targetNpc = Microbot.getRs2NpcCache().query().where(n -> n.getNpc().equals(interacting)).nearest();
-                        npc.set(targetNpc);
-                    }
-                    if (npc.get() != null && Microbot.getSpecialAttackConfigs().useSpecWeapon()) {
-                        npc.get().click("Attack");
-                    }
+                    Microbot.getSpecialAttackConfigs().useSpecWeapon();
                 }
             } catch (Exception ex) {
                 Microbot.logStackTrace(this.getClass().getSimpleName(), ex);


### PR DESCRIPTION
## Summary
- align QoL special attack execution with the working AIO Fighter flow
- stop caching/re-querying the current NPC and re-clicking Attack after attempting a spec
- call `Microbot.getSpecialAttackConfigs().useSpecWeapon()` whenever QoL spec weapon is enabled, the player is not in full Guthan's, and the player is already interacting
- bump QoLPlugin to 1.8.16

## Testing
- Confirmed in-game that QoL now swaps to the configured special attack weapon and activates special attack.
- `javac --release 11 -cp C:\Users\lobit\.microbot\microbot-2.6.19.jar;C:\Users\lobit\.runelite\microbot-plugins\QoLPlugin.jar ... SpecialAttackScript.java`
- `javac --release 11 -cp C:\Users\lobit\.microbot\microbot-2.6.19.jar;C:\Users\lobit\.runelite\microbot-plugins\QoLPlugin.jar;<lombok-1.18.30.jar> ... PluginConstants.java QoLPlugin.java`
- Full Gradle build was not run locally because this Windows environment does not have the required Adoptium JDK 11 toolchain installed.