### PR TITLE
fix: Vale Totems carve reliability (v1.0.14)

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/ValeTotemPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/ValeTotemPlugin.java
@@ -27,7 +27,7 @@ import java.awt.*;
 )
 @Slf4j
 public class ValeTotemPlugin extends Plugin {
-    static final String version = "1.0.10";
+    static final String version = "1.0.13";
 
     @Inject
     private ValeTotemConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/ValeTotemPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/ValeTotemPlugin.java
@@ -27,7 +27,7 @@ import java.awt.*;
 )
 @Slf4j
 public class ValeTotemPlugin extends Plugin {
-    static final String version = "1.0.13";
+    static final String version = "1.0.14";
 
     @Inject
     private ValeTotemConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/enums/SpiritAnimal.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/enums/SpiritAnimal.java
@@ -2,14 +2,16 @@ package net.runelite.client.plugins.microbot.valetotems.enums;
 
 /**
  * Enum representing the spirit animals that can be carved into totems
- * Each animal has an associated NPC ID and keyboard key for carving
+ * Each animal has an associated NPC ID and keyboard key for carving.
+ * Declaration order matters: ordinal + 1 is the game's animal id, used by the
+ * carve dialog keys (1-5) and the per-site animal/segment varbits.
  */
 public enum SpiritAnimal {
-    BUFFALO(14, '1', 14589, "Buffalo spirit"),
-    JAGUAR(15, '2', 14590, "Jaguar spirit"),
-    EAGLE(16, '3', 14591, "Eagle/Griffin spirit"),
-    SNAKE(17, '4', 14592, "Snake spirit"),
-    SCORPION(18, '5', 14593, "Scorpion spirit");
+    BUFFALO(15, '1', 14589, "Buffalo spirit"),
+    JAGUAR(16, '2', 14590, "Jaguar spirit"),
+    EAGLE(17, '3', 14591, "Eagle/Griffin spirit"),
+    SNAKE(18, '4', 14592, "Snake spirit"),
+    SCORPION(19, '5', 14593, "Scorpion spirit");
 
     private final int widgetChildId;
     private final char keyNumber;
@@ -74,5 +76,18 @@ public enum SpiritAnimal {
      */
     public static boolean isSpiritAnimal(int npcId) {
         return getByNpcId(npcId) != null;
+    }
+
+    /**
+     * Get spirit animal by the game's animal id (1-5), as used by the per-site
+     * ent_totems varbits (animal_1..3 and the low/mid/top carved segments)
+     * @param value the varbit animal value
+     * @return corresponding SpiritAnimal enum, or null if out of range
+     */
+    public static SpiritAnimal getByVarbitValue(int value) {
+        if (value < 1 || value > values().length) {
+            return null;
+        }
+        return values()[value - 1];
     }
 } 

--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/handlers/TotemHandler.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/handlers/TotemHandler.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.valetotems.handlers;
 import net.runelite.api.Actor;
 import net.runelite.api.GameObject;
 import net.runelite.api.NPC;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
@@ -38,6 +39,39 @@ public class TotemHandler {
     private static final int ANIMAL_SEARCH_RADIUS = 17;
     private static final long INTERACTION_TIMEOUT_MS = 5000; // 5 seconds
     private static final long CARVING_DELAY_MS = 1500; // Delay between key presses for carving
+
+    // Vale Totems per-site game data. Each of the 8 sites has a block of locs
+    // (ent_totems_site_N_base/low/mid/top/offerings/decoration) and a block of
+    // varbits (ent_totems_site_N_base ... all_multianimals). The totem loc id
+    // found in the scene identifies the site, which gives the varbit block.
+    private static final int SITE_1_TOTEM_LOC_ID = 57016; // ent_totems_site_1_base
+    private static final int LOCS_PER_SITE = 6;
+    private static final int TOTAL_SITES = 8;
+    private static final int SITE_1_VARBIT_BASE = 17611;  // ent_totems_site_1_base
+    private static final int VARBITS_PER_SITE = 18;
+    // Varbit offsets within a site's block:
+    // +0 base (wood type), +1 base_carved (1 = ready for decoration),
+    // +3/+4/+5 low/mid/top segments (wood value = uncarved, 9 + animal id = carved),
+    // +6 decorations, +7/+8/+9 the site's three required animals (1-5)
+    private static final int VB_OFFSET_BASE_CARVED = 1;
+    private static final int VB_OFFSET_SEGMENT_LOW = 3;
+    private static final int VB_OFFSET_ANIMAL_1 = 7;
+    private static final int CARVED_SEGMENT_ANIMAL_OFFSET = 9;
+
+    /**
+     * Resolve the base varbit id of the site's varbit block from the totem loc
+     * id present in the scene.
+     * @param totemLocation the totem location
+     * @return the site's base varbit id, or -1 if the totem loc id is unknown
+     */
+    private static int getSiteVarbitBase(TotemLocation totemLocation) {
+        int locId = GameObjectUtils.getTotemObjectId(totemLocation.getLocation());
+        int siteOffset = locId - SITE_1_TOTEM_LOC_ID;
+        if (siteOffset < 0 || siteOffset >= TOTAL_SITES * LOCS_PER_SITE || siteOffset % LOCS_PER_SITE != 0) {
+            return -1;
+        }
+        return SITE_1_VARBIT_BASE + (siteOffset / LOCS_PER_SITE) * VARBITS_PER_SITE;
+    }
 
     /**
      * Waits until the current totem is ready for new construction.
@@ -163,9 +197,31 @@ public class TotemHandler {
     public static boolean identifySpiritAnimals(TotemLocation totemLocation, TotemProgress progress) {
         try {
             WorldPoint location = totemLocation.getLocation();
-            
+
             System.out.println("Identifying spirit animals around " + totemLocation.getDescription());
-            
+
+            // The site's required animals are tracked in varbits - exact and
+            // immune to spirits wandering out of range or being reshuffled
+            int varbitBase = getSiteVarbitBase(totemLocation);
+            if (varbitBase > 0) {
+                progress.clearIdentifiedAnimals();
+                for (int i = 0; i < 3; i++) {
+                    SpiritAnimal animal = SpiritAnimal.getByVarbitValue(
+                            Microbot.getVarbitValue(varbitBase + VB_OFFSET_ANIMAL_1 + i));
+                    if (animal != null) {
+                        progress.addIdentifiedAnimal(animal);
+                        System.out.println("Identified: " + animal.getDescription());
+                    }
+                }
+                if (progress.areAllAnimalsIdentified()) {
+                    Microbot.log("Identified all 3 spirit animals from totem varbits");
+                    printIdentifiedAnimals(progress);
+                    return true;
+                }
+                progress.clearIdentifiedAnimals();
+                Microbot.log("Totem animal varbits not populated - falling back to NPC scan");
+            }
+
             // Retry loop for identifying spirit animals
             boolean allIdentified = false;
             int maxAttempts = 5;
@@ -246,41 +302,83 @@ public class TotemHandler {
 
             Microbot.log("Carving animals into totem");
 
+            // A leftover totem from a previous attempt may already hold carves;
+            // the segment varbits say exactly which, so they are never re-attempted
+            // (the game rejects duplicates: "You may only select animals you have
+            // not already carved.")
+            int varbitBase = getSiteVarbitBase(totemLocation);
+            if (varbitBase > 0) {
+                if (Microbot.getVarbitValue(varbitBase + VB_OFFSET_BASE_CARVED) == 1) {
+                    System.out.println("Totem is already fully carved");
+                    return true;
+                }
+                for (int i = 0; i < 3; i++) {
+                    int segmentValue = Microbot.getVarbitValue(varbitBase + VB_OFFSET_SEGMENT_LOW + i);
+                    SpiritAnimal carved = SpiritAnimal.getByVarbitValue(segmentValue - CARVED_SEGMENT_ANIMAL_OFFSET);
+                    if (carved != null && !progress.getCarvedAnimals().contains(carved)) {
+                        progress.addCarvedAnimal(carved);
+                        System.out.println("Totem already has " + carved.getDescription()
+                                + " carved (leftover from a previous attempt)");
+                    }
+                }
+            }
+
             sleepGaussian(400,300);
 
-            // Carve each identified animal
-            for (SpiritAnimal animal : progress.getIdentifiedAnimals()) {
-                if (!progress.getCarvedAnimals().contains(animal)) {
+            int maxCarveRounds = 2;
+            for (int round = 1; round <= maxCarveRounds; round++) {
+                // Carve each identified animal
+                for (SpiritAnimal animal : progress.getIdentifiedAnimals()) {
+                    if (progress.getCarvedAnimals().contains(animal)) {
+                        continue;
+                    }
+
+                    // A leftover carve from a previous attempt may fill the totem
+                    // before finishing the list
+                    if (checkTotemState(totemLocation) == GameObjectId.TOTEM_READY_FOR_DECORATION) {
+                        System.out.println("Successfully carved all animals");
+                        return true;
+                    }
+
                     // Add humanlike random hover over on spirit animal
                     hoverOverSpiritAnimal(animal);
                     if (carveAnimalIntoTotem(animal)) {
                         progress.addCarvedAnimal(animal);
-                        System.out.println("Carved: " + animal.getDescription() + " (Key " + animal.getWidgetChildId() + ")");
-                        
+                        System.out.println("Carved: " + animal.getDescription() + " (Key " + animal.getKeyNumber() + ")");
+
                         // Delay between carvings
                         sleep((int)CARVING_DELAY_MS);
                     } else {
-                        System.err.println("Failed to carve: " + animal.getDescription());
+                        // The game rejects carving an animal that is already on the
+                        // totem (e.g. left over from a previous attempt at this site),
+                        // which looks identical to a swallowed input: no xp. Skip it
+                        // and let the remaining animals fill the open slots - the
+                        // totem state below is the real completion check.
+                        System.err.println("Carve not accepted for " + animal.getDescription()
+                                + " - skipping (may already be on the totem)");
+                    }
+                }
+
+                // Wait for totem to become ready for decoration
+                if (GameObjectUtils.waitForTotemStateAtLocation(
+                        GameObjectId.TOTEM_READY_FOR_DECORATION, location, INTERACTION_TIMEOUT_MS)) {
+                    System.out.println("Successfully carved all animals");
+                    return true;
+                }
+
+                if (round < maxCarveRounds) {
+                    // An ent may have reshuffled the spirits mid-carve; re-scan and
+                    // fill the remaining slots instead of hard-failing into recovery.
+                    // Keep carved marks - those are xp-verified on the totem.
+                    System.err.println("Totem not ready after carving - re-scanning spirit animals and retrying");
+                    if (!identifySpiritAnimals(totemLocation, progress)) {
                         return false;
                     }
                 }
             }
 
-            boolean allCarved = progress.areAllAnimalsCarved();
-            if (allCarved) {
-                System.out.println("Successfully carved all animals");
-                
-                // Wait for totem to become ready for decoration
-                boolean readyForDecoration = GameObjectUtils.waitForTotemStateAtLocation(
-                        GameObjectId.TOTEM_READY_FOR_DECORATION, location, INTERACTION_TIMEOUT_MS);
-
-                if (!readyForDecoration) {
-                    System.err.println("Totem did not become ready for decoration");
-                    return false;
-                }
-            }
-
-            return allCarved;
+            System.err.println("Totem did not become ready for decoration");
+            return false;
 
         } catch (Exception e) {
             System.err.println("Error carving animals: " + e.getMessage());
@@ -295,34 +393,66 @@ public class TotemHandler {
      */
     private static boolean carveAnimalIntoTotem(SpiritAnimal animal) {
         try {
-            if (!sleepUntil(() -> Rs2Widget.hasWidgetText("What animal would you like to carve?",270,5, false), 5000)) {
-                Microbot.getClientThread().invoke(() ->
-                        Microbot.getRs2TileObjectCache().query().withNameContains(GameObjectId.EMPTY_TOTEM.getSearchTerm()).interact("Carve"));
-                if (!sleepUntil(() -> Rs2Widget.hasWidgetText("What animal would you like to carve?",270,5, false), 5000)) {
-                    System.err.println("Failed to carve animal");
+            int maxAttempts = 2;
+            for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+                if (!ensureCarveDialogOpen()) {
+                    System.err.println("Failed to open carve dialog");
                     return false;
                 }
+
+                //Humanlike delay
+                sleepGaussian(300,200);
+
+                int xpBefore = Microbot.getClient().getSkillExperience(Skill.FLETCHING);
+
+                // Small 2% change to mouse click to avoid detection
+                boolean inputSent = false;
+                int mouseClickChange = RandomUtils.nextInt(1,100);
+                if (mouseClickChange <= 2) {
+                    inputSent = Rs2Widget.clickWidget(270,animal.getWidgetChildId());
+                }
+                if (!inputSent) {
+                    // Press the corresponding number key
+                    Rs2Keyboard.keyPress(animal.getKeyNumber());
+                }
+
+                // A carve is a 2-tick action awarding Fletching xp; no xp means the
+                // input was swallowed or the game rejected the carve
+                if (sleepUntil(() -> Microbot.getClient().getSkillExperience(Skill.FLETCHING) > xpBefore, 3600)) {
+                    return true;
+                }
+
+                // A rejected carve (e.g. animal already on the totem) responds with a
+                // dialogue instead of xp - capture and dismiss it
+                if (Rs2Dialogue.isInDialogue()) {
+                    System.err.println("Carve rejected for " + animal.getDescription()
+                            + " - game response: " + Rs2Dialogue.getDialogueText());
+                    Rs2Dialogue.clickContinue();
+                    return false;
+                }
+
+                System.err.println("Carve input did not register for " + animal.getDescription()
+                        + " (attempt " + attempt + "/" + maxAttempts + ")");
             }
 
-            //Humanlike delay
-            sleepGaussian(300,200);
-
-            // Small 2% change to mouse click to avoid detection
-            int mouseClickChange = RandomUtils.nextInt(1,100);
-            if (mouseClickChange <= 2) {
-                // Press the corresponding number key
-                Rs2Widget.clickWidget(270,animal.getWidgetChildId());
-                return true;
-            }
-
-            // Press the corresponding number key
-            Rs2Keyboard.keyPress(animal.getKeyNumber());
-
-            return true;
+            return false;
         } catch (Exception e) {
             System.err.println("Error carving animal " + animal.getDescription() + ": " + e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Ensure the carve selection dialog is open, re-interacting with the totem if needed
+     * @return true if the dialog is open
+     */
+    private static boolean ensureCarveDialogOpen() {
+        if (sleepUntil(() -> Rs2Widget.hasWidgetText("What animal would you like to carve?",270,5, false), 5000)) {
+            return true;
+        }
+        Microbot.getClientThread().invoke(() ->
+                Microbot.getRs2TileObjectCache().query().withNameContains(GameObjectId.EMPTY_TOTEM.getSearchTerm()).interact("Carve"));
+        return sleepUntil(() -> Rs2Widget.hasWidgetText("What animal would you like to carve?",270,5, false), 5000);
     }
 
     /**
@@ -418,7 +548,7 @@ public class TotemHandler {
     private static void printIdentifiedAnimals(TotemProgress progress) {
         System.out.println("Identified animals:");
         for (SpiritAnimal animal : progress.getIdentifiedAnimals()) {
-            System.out.println("  - " + animal.getDescription() + " (Key " + animal.getWidgetChildId() + ")");
+            System.out.println("  - " + animal.getDescription() + " (Key " + animal.getKeyNumber() + ")");
         }
     }
 
@@ -445,6 +575,7 @@ public class TotemHandler {
     public static void resetTotemConstruction(TotemProgress progress) {
         progress.setBaseBuilt(false);
         progress.clearIdentifiedAnimals();
+        progress.clearCarvedAnimals();
         progress.setDecorated(false);
         System.out.println("Totem construction state reset");
     }

--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/handlers/TotemHandler.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/handlers/TotemHandler.java
@@ -403,7 +403,7 @@ public class TotemHandler {
                 //Humanlike delay
                 sleepGaussian(300,200);
 
-                int xpBefore = Microbot.getClient().getSkillExperience(Skill.FLETCHING);
+                int xpBefore = getFletchingXp();
 
                 // Small 2% change to mouse click to avoid detection
                 boolean inputSent = false;
@@ -418,7 +418,7 @@ public class TotemHandler {
 
                 // A carve is a 2-tick action awarding Fletching xp; no xp means the
                 // input was swallowed or the game rejected the carve
-                if (sleepUntil(() -> Microbot.getClient().getSkillExperience(Skill.FLETCHING) > xpBefore, 3600)) {
+                if (sleepUntil(() -> getFletchingXp() > xpBefore, 3600)) {
                     return true;
                 }
 
@@ -440,6 +440,15 @@ public class TotemHandler {
             System.err.println("Error carving animal " + animal.getDescription() + ": " + e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Read current Fletching xp on the client thread
+     * @return the player's Fletching experience
+     */
+    private static int getFletchingXp() {
+        return Microbot.getClientThread().invoke(() ->
+                Microbot.getClient().getSkillExperience(Skill.FLETCHING));
     }
 
     /**

--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/models/TotemProgress.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/models/TotemProgress.java
@@ -88,6 +88,10 @@ public class TotemProgress {
         }
     }
 
+    public void clearCarvedAnimals() {
+        carvedAnimals.clear();
+    }
+
     public void setDecorated(boolean decorated) {
         this.decorated = decorated;
     }

--- a/src/main/java/net/runelite/client/plugins/microbot/valetotems/utils/GameObjectUtils.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/valetotems/utils/GameObjectUtils.java
@@ -324,11 +324,11 @@ public class GameObjectUtils {
     }
 
     /**
-     * Check what type of totem site/state exists at a location using string search
+     * Find the totem tile object at a location (fast ID path with name-based discovery fallback)
      * @param location the world point to check
-     * @return the GameObjectId enum for the totem state, or null if no totem found
+     * @return the totem object model, or null if no totem found
      */
-    public static GameObjectId getTotemStateAtLocation(WorldPoint location) {
+    private static Rs2TileObjectModel findTotemModelAtLocation(WorldPoint location) {
         var totemModel = Microbot.getRs2TileObjectCache().query()
                 .where(obj -> GameObjectId.isTotemObject(obj.getId()) || discoveredTotemIds.contains(obj.getId()))
                 .nearest(location, 10);
@@ -344,6 +344,28 @@ public class GameObjectUtils {
                         + " name='" + totemModel.getName() + "' — future lookups will use fast ID path");
             }
         }
+
+        return totemModel;
+    }
+
+    /**
+     * Get the loc id of the totem object at a location. The id encodes the game's
+     * site number (ent_totems_site_N_base), which drives the per-site varbits.
+     * @param location the world point to check
+     * @return the totem loc id, or -1 if no totem found
+     */
+    public static int getTotemObjectId(WorldPoint location) {
+        var totemModel = findTotemModelAtLocation(location);
+        return totemModel != null ? totemModel.getId() : -1;
+    }
+
+    /**
+     * Check what type of totem site/state exists at a location using string search
+     * @param location the world point to check
+     * @return the GameObjectId enum for the totem state, or null if no totem found
+     */
+    public static GameObjectId getTotemStateAtLocation(WorldPoint location) {
+        var totemModel = findTotemModelAtLocation(location);
 
         if (totemModel == null) {
             return null;


### PR DESCRIPTION
## Summary

Fixes the recurring `Failed to carve animals` -> emergency-bank-recovery loop in Vale Totems. Root causes found by inspecting a live client (widget tree + per-site varbits):

- **Fix off-by-one carve dialog widget ids** - the animal options are children 15-19 of interface 270, not 14-18, so the occasional randomized widget-click input either clicked dead space (carve silently lost, totem never became decoratable) or carved the previous animal in the list (wrong carve, later rejected as a duplicate).
- **Verify every carve via fletching xp** and re-send swallowed inputs instead of assuming the key press landed.
- **Identify the site's three required animals from the per-site varbits** (`ent_totems_site_N_animal_1..3`), with the NPC scan kept as a fallback - immune to spirits wandering out of scan range or ents reshuffling animals mid-carve. The site's varbit block (`17611 + 18*(N-1)`) is derived from the totem loc id (`57016 + 6*(N-1)`) found in the scene, so nothing is hardcoded per site.
- **Detect leftover carves on a partially-carved totem** from the low/mid/top segment varbits and skip them - the game rejects duplicates ("You may only select animals you have not already carved."), which previously locked the bot in a fail-retry-bank loop.
- On a rejected/unregistered carve, skip that animal and let the remaining ones fill the slots (totem state is the completion check), and re-scan once before entering error recovery.

## Testing

- `./gradlew build -PpluginList=ValeTotemPlugin`
- Sideloaded on a live account: 20+ minutes, multiple full banking rounds, zero carve errors (previously errored every few rounds), including correct recovery on a leftover partially-carved totem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
