### PR TITLE
fix(TitheFarming): release deposit sack fix as 1.1.14

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/tithefarming/TitheFarmingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/tithefarming/TitheFarmingPlugin.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class TitheFarmingPlugin extends Plugin {
 
-    final static String version = "1.1.13";
+    final static String version = "1.1.14";
 
     @Inject
     public TitheFarmingConfig config;


### PR DESCRIPTION
## Summary

- bump Tithe Farming from 1.1.13 to 1.1.14
- ensure existing installations receive the deposit sack fix from #499

## Testing

- `./gradlew build -PpluginList=TitheFarmingPlugin -PmicrobotClientVersion=latest`