### PR TITLE
fix(jewelrycrafter): prevent camera stall

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/crafting/CraftingPlugin.java
@@ -29,7 +29,7 @@ import java.awt.*;
 @Slf4j
 public class CraftingPlugin extends Plugin {
 
-    static final String version = "1.0.1";
+    static final String version = "1.0.2";
 
     private final DefaultScript defaultScript = new DefaultScript();
     private final GemsScript gemsScript = new GemsScript();

--- a/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/JewelryPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/JewelryPlugin.java
@@ -22,7 +22,7 @@ import java.awt.*;
 )
 public class JewelryPlugin extends Plugin {
 
-    static final String version = "1.0.1";
+    static final String version = "1.0.2";
 
 
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/JewelryScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/crafting/jewelry/JewelryScript.java
@@ -407,11 +407,6 @@ public class JewelryScript extends Script {
             Rs2Camera.setPitch(383);
             changed = true;
         }
-        int yaw = Rs2Camera.getYaw();
-        if (yaw > 16 && yaw < 2032) {
-            Rs2Camera.setYaw(0);
-            changed = true;
-        }
         return changed;
     }
 


### PR DESCRIPTION
## Summary

- stop forcing the camera north every script tick
- allow furnace-facing camera movement to persist
- release Crafting and Jewelry Crafter as 1.0.2

## Cause

At Edgeville, the crafting state turned the camera toward the furnace and returned. On the next tick, `setFullView()` reset the camera north, creating an endless loop where the player remained at the bank.

## Testing

- source-level forced-yaw regression check
- `./gradlew compileCraftingJava -PmicrobotClientVersion=2.6.19`
- `./gradlew clean build -PpluginList=CraftingPlugin -PmicrobotClientVersion=2.6.19`
- verified `CraftingPlugin-1.0.2.jar` manifest version