### PR TITLE
fix(geflipper): stop relying on Copilot keybind

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -23,7 +23,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.4";
+    public static final String version = "1.2.5";
     @Inject
     private Client client;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -392,32 +392,25 @@ public class FlipperScript extends Script {
 
 		// If it's time to set price/quantity
 
-		Widget setPriceWidget = Rs2Widget.findWidget("Set a price for each item:", null, true);
-		Widget setQuantityWidget = Rs2Widget.findWidget("How many do you wish to ", null, false);
-		boolean settingPrice = setPriceWidget != null && Rs2Widget.isWidgetVisible(setPriceWidget.getId());
-		boolean settingQuantity = setQuantityWidget != null && Rs2Widget.isWidgetVisible(setQuantityWidget.getId());
+		Widget chatbox = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_LAYER);
+		if (chatbox == null) return false;
+		Widget copilotAction = Rs2Widget.findWidget("Set price", List.of(chatbox), true);
+		if (copilotAction == null) copilotAction = Rs2Widget.findWidget("Set quantity", List.of(chatbox), true);
+		if (copilotAction == null) return false;
 
-        if (settingPrice || settingQuantity) {
-			Widget chatbox = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_LAYER);
-			Widget copilotAction = chatbox == null ? null : Rs2Widget.findWidget(settingPrice ? "Set price" : "Set quantity", List.of(chatbox), true);
-			if (copilotAction == null) return false;
-
-			log.info("Using Copilot action for chat widget '{}'.", settingPrice ? setPriceWidget.getId() : setQuantityWidget.getId());
-			Rs2Widget.clickWidget(copilotAction);
-			if (!sleepUntil(() -> {
-				Widget input = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_TEXT2);
-				return input != null && input.getText() != null && input.getText().endsWith("*");
-			})) {
-				log.warn("Copilot did not populate the price/quantity input.");
-				return true;
-			}
-			Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
-			lastActionTime = System.currentTimeMillis();
-			actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+		log.info("Using Copilot action widget '{}'.", copilotAction.getId());
+		Rs2Widget.clickWidget(copilotAction);
+		if (!sleepUntil(() -> {
+			Widget input = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_TEXT2);
+			return input != null && input.getText() != null && input.getText().endsWith("*");
+		})) {
+			log.warn("Copilot did not populate the price/quantity input.");
 			return true;
-        }
-
-		return false;
+		}
+		Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
+		lastActionTime = System.currentTimeMillis();
+		actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+		return true;
     }
 
     private boolean checkAndClickHighlightedWidgets()

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -45,8 +45,6 @@ public class FlipperScript extends Script {
 	private static final int INTERACTION_TIMEOUT_VARIANCE = 11000;
 	private static final int INVENTORY_WAIT_TIMEOUT = 5000;
 	private static final int SCHEDULE_INTERVAL_MS = 600;
-	private static final int KEY_PRESS_DELAY_MIN = 250;
-	private static final int KEY_PRESS_DELAY_MAX = 400;
 
 	private final WorldArea grandExchangeArea = new WorldArea(3136, 3465, 61, 54, 0);
     State state = State.GOING_TO_GE;
@@ -396,13 +394,23 @@ public class FlipperScript extends Script {
 
 		Widget setPriceWidget = Rs2Widget.findWidget("Set a price for each item:", null, true);
 		Widget setQuantityWidget = Rs2Widget.findWidget("How many do you wish to ", null, false);
+		boolean settingPrice = setPriceWidget != null && Rs2Widget.isWidgetVisible(setPriceWidget.getId());
+		boolean settingQuantity = setQuantityWidget != null && Rs2Widget.isWidgetVisible(setQuantityWidget.getId());
 
-        if ((setPriceWidget != null && Rs2Widget.isWidgetVisible(setPriceWidget.getId())) || 
-		(setQuantityWidget != null && Rs2Widget.isWidgetVisible(setQuantityWidget.getId()))) {
-			// 3. Press E then Enter (setting price/quantity)
-			log.info("Found chat widget (price/quantity) '{}'.", setPriceWidget != null ? setPriceWidget.getId() : setQuantityWidget.getId());
-			Rs2Keyboard.keyPress(KeyEvent.VK_E);
-			sleep(KEY_PRESS_DELAY_MIN, KEY_PRESS_DELAY_MAX);
+        if (settingPrice || settingQuantity) {
+			Widget chatbox = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_LAYER);
+			Widget copilotAction = chatbox == null ? null : Rs2Widget.findWidget(settingPrice ? "Set price" : "Set quantity", List.of(chatbox), true);
+			if (copilotAction == null) return false;
+
+			log.info("Using Copilot action for chat widget '{}'.", settingPrice ? setPriceWidget.getId() : setQuantityWidget.getId());
+			Rs2Widget.clickWidget(copilotAction);
+			if (!sleepUntil(() -> {
+				Widget input = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_TEXT2);
+				return input != null && input.getText() != null && input.getText().endsWith("*");
+			})) {
+				log.warn("Copilot did not populate the price/quantity input.");
+				return true;
+			}
 			Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
 			lastActionTime = System.currentTimeMillis();
 			actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);


### PR DESCRIPTION
## Summary

- invoke Flipping Copilot's exact `Set price` or `Set quantity` chatbox action instead of a hardcoded keybind
- wait for Copilot to populate the input before submitting it
- release GE Flipper as 1.2.5

## Cause

GE Flipper pressed a hardcoded `E` and immediately submitted whenever a native price or quantity prompt appeared. Flipping Copilot's quick-set key is configurable and its action can populate asynchronously, so the prompt could remain open and be rediscovered every tick.

## Testing

- `git diff --check`
- `./gradlew build -PpluginList=FlipperPlugin -PmicrobotClientPath=/Users/caleb/Documents/microbot-unified/Microbot/runelite-client/build/libs/client-1.12.34.1-shaded.jar`
