### PR TITLE
fix: prioritize marks of grace while moving

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,12 @@ dependencies {
         microbotRuntime "com.microbot:microbot:${microbotClientVersion}@jar"
         testImplementation "com.microbot:microbot:${microbotClientVersion}@jar"
     }
+
+    testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }
 
 application {

--- a/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/agility/AgilityScript.java
@@ -39,6 +39,11 @@ import java.util.stream.Collectors;
 
 public class AgilityScript extends Script
 {
+	enum MarkPickupPhase
+	{
+		DETECTED,
+		INTERACTION_PENDING
+	}
 
 	final MicroAgilityPlugin plugin;
 	final MicroAgilityConfig config;
@@ -435,7 +440,8 @@ public class AgilityScript extends Script
 			{
 				clearPendingMarkOfGrace();
 			}
-			else if (Rs2Player.isMoving() || Rs2Player.isAnimating())
+			else if (shouldWaitForMarkPickup(MarkPickupPhase.INTERACTION_PENDING,
+				Rs2Player.isMoving(), Rs2Player.isAnimating()))
 			{
 				return true;
 			}
@@ -480,7 +486,8 @@ public class AgilityScript extends Script
 			return false;
 		}
 
-		if (Rs2Player.isMoving() || Rs2Player.isAnimating())
+		if (shouldWaitForMarkPickup(MarkPickupPhase.DETECTED,
+			Rs2Player.isMoving(), Rs2Player.isAnimating()))
 		{
 			return true;
 		}
@@ -514,6 +521,11 @@ public class AgilityScript extends Script
 			clearPendingMarkOfGrace();
 		}
 		return true;
+	}
+
+	static boolean shouldWaitForMarkPickup(MarkPickupPhase phase, boolean playerMoving, boolean playerAnimating)
+	{
+		return phase == MarkPickupPhase.INTERACTION_PENDING && (playerMoving || playerAnimating);
 	}
 
 	private boolean markPickupResolved()

--- a/src/main/java/net/runelite/client/plugins/microbot/agility/MicroAgilityPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/agility/MicroAgilityPlugin.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class MicroAgilityPlugin extends Plugin
 {
-	public static final String version = "1.3.1";
+	public static final String version = "1.3.2";
 	@Inject
 	private MicroAgilityConfig config;
 	@Inject

--- a/src/test/java/net/runelite/client/plugins/microbot/agility/AgilityScriptTest.java
+++ b/src/test/java/net/runelite/client/plugins/microbot/agility/AgilityScriptTest.java
@@ -1,0 +1,30 @@
+package net.runelite.client.plugins.microbot.agility;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgilityScriptTest
+{
+	@Test
+	void detectedMarkIsNotDeferredWhilePlayerIsMoving()
+	{
+		assertFalse(AgilityScript.shouldWaitForMarkPickup(
+			AgilityScript.MarkPickupPhase.DETECTED, true, false));
+	}
+
+	@Test
+	void detectedMarkIsNotDeferredWhilePlayerIsAnimating()
+	{
+		assertFalse(AgilityScript.shouldWaitForMarkPickup(
+			AgilityScript.MarkPickupPhase.DETECTED, false, true));
+	}
+
+	@Test
+	void pendingInteractionKeepsCoursePausedWhilePlayerIsMoving()
+	{
+		assertTrue(AgilityScript.shouldWaitForMarkPickup(
+			AgilityScript.MarkPickupPhase.INTERACTION_PENDING, true, false));
+	}
+}


### PR DESCRIPTION
## Summary
- prioritize a newly detected Mark of Grace even while the player is moving or animating
- preserve the existing course pause while a pickup interaction is already pending
- bump MicroAgilityPlugin from 1.3.1 to 1.3.2
- add regression coverage for moving, animating, and pending-interaction states

## Root cause
The script returned before issuing the Take interaction or recording pending pickup state. The following loop could then hit the 750 ms scan throttle and continue to the next obstacle, walking past the Mark.

## Verification
- Fresh MicroAgilityPlugin build against Microbot 2.6.20: passed (18 tasks)
- Regression tests: 3 passed, 0 failed
- Live Seers Village rooftop run: confirmed Marks of Grace are picked up after the patch