### PR TITLE
feat(sailing): automate Tempor Tantrum rum transfers

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/sailing/MSailingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sailing/MSailingPlugin.java
@@ -31,7 +31,7 @@ import java.awt.*;
 @Slf4j
 public class MSailingPlugin extends Plugin {
 
-	static final String version = "2.2.56";
+	static final String version = "2.2.57";
 
     @Inject
     private SailingConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScript.java
@@ -38,6 +38,7 @@ public class TrialsScript {
     private final Set<Integer> DECORATION_ANIMS = Set.of(1071, 13537, 13538, 13539);
 
     private static final int VISIT_TOLERANCE = 15;
+    private static final int WAYPOINT_VISIT_TOLERANCE = 5;
 
     private static final int WIND_MOTE_INACTIVE_SPRITE_ID = 7076;
     private static final int WIND_MOTE_ACTIVE_SPRITE_ID = 7075;
@@ -135,11 +136,6 @@ public class TrialsScript {
                 return;
             }
 
-            if (!route.equals(activeRoute)) {
-                activeRoute = route;
-                currentWaypointIndex = 0;
-            }
-
             List<WorldPoint> routePoints = route.getInterpolatedPoints();
             if (routePoints == null || routePoints.isEmpty()) {
                 return;
@@ -154,14 +150,13 @@ public class TrialsScript {
                 return;
             }
 
-            WorldPoint target = routePoints.get(currentWaypointIndex);
-            int distance = boatPos.distanceTo(target);
-
-            if (distance <= 5) {
-                lastVisitedIndex = currentWaypointIndex;
-                currentWaypointIndex = (currentWaypointIndex + 1) % routePoints.size();
-                target = routePoints.get(currentWaypointIndex);
+            if (!route.equals(activeRoute)) {
+                activeRoute = route;
+                currentWaypointIndex = 0;
             }
+
+            currentWaypointIndex = getNextWaypointIndex(routePoints, currentWaypointIndex, boatPos);
+            WorldPoint target = routePoints.get(currentWaypointIndex);
 
             final WorldPoint hintTarget = target;
             Microbot.getClientThread().invoke(() -> client.setHintArrow(hintTarget));
@@ -182,6 +177,28 @@ public class TrialsScript {
             }
         }
         return null;
+    }
+
+    static int getNextWaypointIndex(List<WorldPoint> routePoints, int currentWaypointIndex, WorldPoint boatPosition) {
+        int currentDistance = boatPosition.distanceTo(routePoints.get(currentWaypointIndex));
+        if (currentDistance <= WAYPOINT_VISIT_TOLERANCE) {
+            return (currentWaypointIndex + 1) % routePoints.size();
+        }
+
+        int lastWaypointIndex = routePoints.size() - 1;
+        while (currentWaypointIndex < lastWaypointIndex
+                && hasPassedWaypoint(routePoints.get(currentWaypointIndex), routePoints.get(currentWaypointIndex + 1), boatPosition)) {
+            currentWaypointIndex++;
+        }
+        return currentWaypointIndex;
+    }
+
+    private static boolean hasPassedWaypoint(WorldPoint waypoint, WorldPoint nextWaypoint, WorldPoint boatPosition) {
+        long segmentX = nextWaypoint.getX() - waypoint.getX();
+        long segmentY = nextWaypoint.getY() - waypoint.getY();
+        long boatX = boatPosition.getX() - waypoint.getX();
+        long boatY = boatPosition.getY() - waypoint.getY();
+        return boatX * segmentX + boatY * segmentY > 0;
     }
 
     private WorldPoint getBoatPosition() {

--- a/src/main/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScript.java
@@ -169,7 +169,8 @@ public class TrialsScript {
             final WorldPoint hintTarget = target;
             Microbot.getClientThread().invoke(() -> client.setHintArrow(hintTarget));
 
-            if (config.autoNavigate() && client.getTickCount() != rumInteractionTick) {
+            int currentTick = Microbot.getClientThread().invoke(client::getTickCount);
+            if (config.autoNavigate() && currentTick != rumInteractionTick) {
                 navigateToWaypoint(target);
             }
 

--- a/src/main/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScript.java
@@ -14,6 +14,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.api.boat.Rs2BoatCache;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
 import net.runelite.client.plugins.microbot.sailing.SailingConfig;
 import net.runelite.client.plugins.microbot.sailing.features.trials.data.*;
 import net.runelite.client.plugins.microbot.sailing.features.trials.debug.BoatPathHelper;
@@ -29,9 +30,13 @@ public class TrialsScript {
     private final Client client;
     private final Rs2BoatCache boatCache;
     private final EventBus eventBus;
+    private final SailingConfig config;
 
     private int currentWaypointIndex = 0;
     private TrialRoute activeRoute = null;
+    private boolean rumActionPending;
+    private boolean expectedRumState;
+    private volatile int rumInteractionTick = -1;
 
     private final Set<Integer> TRIAL_CRATE_ANIMS = Set.of(8867);
     private final Set<Integer> SPEED_BOOST_ANIMS = Set.of(13159, 13160, 13163);
@@ -39,6 +44,8 @@ public class TrialsScript {
 
     private static final int VISIT_TOLERANCE = 15;
     private static final int WAYPOINT_VISIT_TOLERANCE = 5;
+    private static final int RUM_INTERACTION_DISTANCE = 15;
+    private static final int RUM_RETRY_TICKS = 2;
 
     private static final int WIND_MOTE_INACTIVE_SPRITE_ID = 7076;
     private static final int WIND_MOTE_ACTIVE_SPRITE_ID = 7075;
@@ -107,10 +114,11 @@ public class TrialsScript {
     private int boatAcceleration;
 
     @Inject
-    public TrialsScript(Client client, Rs2BoatCache boatCache, EventBus eventBus) {
+    public TrialsScript(Client client, Rs2BoatCache boatCache, EventBus eventBus, SailingConfig config) {
         this.client = client;
         this.boatCache = boatCache;
         this.eventBus = eventBus;
+        this.config = config;
     }
 
     public void register() {
@@ -161,7 +169,7 @@ public class TrialsScript {
             final WorldPoint hintTarget = target;
             Microbot.getClientThread().invoke(() -> client.setHintArrow(hintTarget));
 
-            if (config.autoNavigate()) {
+            if (config.autoNavigate() && client.getTickCount() != rumInteractionTick) {
                 navigateToWaypoint(target);
             }
 
@@ -228,6 +236,8 @@ public class TrialsScript {
     private void resetState() {
         currentWaypointIndex = 0;
         activeRoute = null;
+        rumActionPending = false;
+        rumInteractionTick = -1;
         lastVisitedIndex = -1;
         Microbot.getClientThread().invoke(() -> client.clearHintArrow());
     }
@@ -271,10 +281,67 @@ public class TrialsScript {
         if (boatLocation == null)
             return;
 
+        interactWithRumBoat(boatLocation);
+
         var active = getActiveTrialRoute();
         if (active != null) {
             markNextWaypointVisited(boatLocation, active, VISIT_TOLERANCE);
         }
+    }
+
+    private void interactWithRumBoat(WorldPoint boatLocation) {
+        if (!config.trials() || !config.autoNavigate() || isInTrial == 0 || currentTrial == null) {
+            return;
+        }
+
+        int currentTick = client.getTickCount();
+        if (rumActionPending) {
+            if (currentTrial.HasRum == expectedRumState) {
+                rumActionPending = false;
+                return;
+            }
+            if (currentTick - rumInteractionTick < RUM_RETRY_TICKS) {
+                return;
+            }
+        }
+
+        var rumBoat = trialBoatsById.get(currentTrial.HasRum
+                ? ObjectID.SAILING_BT_TEMPOR_TANTRUM_NORTH_LOC_PARENT
+                : ObjectID.SAILING_BT_TEMPOR_TANTRUM_SOUTH_LOC_PARENT);
+        var rumBoatLocation = getWorldEntityLocation(rumBoat);
+        if (rumBoatLocation == null) {
+            return;
+        }
+
+        var action = getRumAction(currentTrial, boatLocation.distanceTo(rumBoatLocation));
+        if (action != null) {
+            new Rs2TileObjectModel(rumBoat).click(action);
+            rumActionPending = true;
+            expectedRumState = !currentTrial.HasRum;
+            rumInteractionTick = currentTick;
+        }
+    }
+
+    private WorldPoint getWorldEntityLocation(GameObject object) {
+        if (object == null || object.getWorldView() == null || client.getTopLevelWorldView() == null) {
+            return null;
+        }
+
+        var worldEntity = client.getTopLevelWorldView().worldEntities().byIndex(object.getWorldView().getId());
+        return worldEntity == null || worldEntity.getLocalLocation() == null
+                ? null
+                : WorldPoint.fromLocalInstance(client, worldEntity.getLocalLocation());
+    }
+
+    static String getRumAction(TrialInfo trial, int distance) {
+        if (trial == null
+                || trial.Location != TrialLocations.TemporTantrum
+                || trial.TotalPrimaryObjectivesNeeded <= 0
+                || trial.CollectedPrimaryObjectives >= trial.TotalPrimaryObjectivesNeeded
+                || distance > RUM_INTERACTION_DISTANCE) {
+            return null;
+        }
+        return trial.HasRum ? "Deliver-rum" : "Collect-rum";
     }
 
     @Subscribe
@@ -516,6 +583,8 @@ public class TrialsScript {
     private void resetRouteData() {
         lastVisitedIndex = -1;
         toadsThrown = 0;
+        rumActionPending = false;
+        rumInteractionTick = -1;
     }
 
     private void reset() {

--- a/src/main/resources/net/runelite/client/plugins/microbot/sailing/docs/CHANGELOG.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/sailing/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2.2.57]
+
+### Added
+- **Tempor Tantrum rum automation**: Auto Navigate now collects and delivers rum as the boat passes each Barracuda boat.
+
+### Fixed
+- **Tempor Tantrum course recovery**: Auto Navigate limits rum retries until the HUD state changes and follows the remaining forward route after a rum action changes the boat heading.
+
+---
+
 ## [2.2.34]
 
 ### Fixed

--- a/src/main/resources/net/runelite/client/plugins/microbot/sailing/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/sailing/docs/README.md
@@ -1,8 +1,12 @@
 # Sailing Plugin
 
-An automated sailing plugin that supports salvaging shipwrecks while sailing.
+An automated sailing plugin that supports salvaging shipwrecks and Barracuda Trials.
 
 ## Features
+
+### Barracuda Trials
+- **Automatic Navigation**: Follows the selected trial route when Auto Navigate is enabled
+- **Tempor Tantrum Rum**: Collects and delivers rum while the boat passes each Barracuda boat
 
 ### Salvaging
 - **Automatic Shipwreck Detection**: Finds and salvages nearby shipwrecks within a 15-tile radius
@@ -26,6 +30,16 @@ An automated sailing plugin that supports salvaging shipwrecks while sailing.
 - Wreck data for the overlay is updated on each game tick on the client thread so highlights stay in sync with the scene
 
 ## Configuration
+
+### Barracuda Trials
+
+**Enable Trials** (default: disabled)
+- Enable Barracuda Trials route support
+
+**Auto Navigate** (default: disabled)
+- Follow the selected trial route automatically
+- Rejoin the route ahead after the boat passes a waypoint
+- Collect and deliver Tempor Tantrum rum while the boat remains on its route
 
 ### General Settings
 

--- a/src/test/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScriptTest.java
+++ b/src/test/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScriptTest.java
@@ -1,6 +1,8 @@
 package net.runelite.client.plugins.microbot.sailing.features.trials;
 
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.sailing.features.trials.data.TrialInfo;
+import net.runelite.client.plugins.microbot.sailing.features.trials.data.TrialLocations;
 
 import java.util.List;
 
@@ -9,6 +11,7 @@ public class TrialsScriptTest {
     public static void main(String[] args) {
         advancesAcrossPassedSegmentsAfterLateralCourseChange();
         advancesPastMissedWaypointWithoutWrappingTheRoute();
+        selectsRumActionOnlyWhenEligible();
     }
 
     private static void advancesAcrossPassedSegmentsAfterLateralCourseChange() {
@@ -33,9 +36,35 @@ public class TrialsScriptTest {
         assertEquals(0, TrialsScript.getNextWaypointIndex(route, 2, new WorldPoint(10, 0, 0)));
     }
 
+    private static void selectsRumActionOnlyWhenEligible() {
+        var trial = new TrialInfo();
+        trial.Location = TrialLocations.TemporTantrum;
+        trial.TotalPrimaryObjectivesNeeded = 1;
+
+        assertEquals("Collect-rum", TrialsScript.getRumAction(trial, 15));
+
+        trial.HasRum = true;
+        assertEquals("Deliver-rum", TrialsScript.getRumAction(trial, 15));
+
+        assertNull(TrialsScript.getRumAction(trial, 16));
+
+        trial.CollectedPrimaryObjectives = 1;
+        assertNull(TrialsScript.getRumAction(trial, 15));
+
+        trial.CollectedPrimaryObjectives = 0;
+        trial.Location = TrialLocations.JubblyJive;
+        assertNull(TrialsScript.getRumAction(trial, 15));
+    }
+
     private static void assertEquals(Object expected, Object actual) {
         if (!expected.equals(actual)) {
             throw new AssertionError("Expected " + expected + " but got " + actual);
+        }
+    }
+
+    private static void assertNull(Object actual) {
+        if (actual != null) {
+            throw new AssertionError("Expected null but got " + actual);
         }
     }
 

--- a/src/test/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScriptTest.java
+++ b/src/test/java/net/runelite/client/plugins/microbot/sailing/features/trials/TrialsScriptTest.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.sailing.features.trials;
+
+import net.runelite.api.coords.WorldPoint;
+
+import java.util.List;
+
+public class TrialsScriptTest {
+
+    public static void main(String[] args) {
+        advancesAcrossPassedSegmentsAfterLateralCourseChange();
+        advancesPastMissedWaypointWithoutWrappingTheRoute();
+    }
+
+    private static void advancesAcrossPassedSegmentsAfterLateralCourseChange() {
+        var route = List.of(
+                new WorldPoint(0, 0, 0),
+                new WorldPoint(5, 5, 0),
+                new WorldPoint(10, 5, 0),
+                new WorldPoint(15, 5, 0));
+
+        assertEquals(2, TrialsScript.getNextWaypointIndex(route, 0, new WorldPoint(10, -9, 0)));
+    }
+
+    private static void advancesPastMissedWaypointWithoutWrappingTheRoute() {
+        var route = List.of(
+                new WorldPoint(0, 0, 0),
+                new WorldPoint(5, 0, 0),
+                new WorldPoint(10, 0, 0));
+
+        assertEquals(2, TrialsScript.getNextWaypointIndex(route, 0, new WorldPoint(6, 6, 0)));
+        assertEquals(0, TrialsScript.getNextWaypointIndex(route, 0, new WorldPoint(-6, 0, 0)));
+        assertEquals(2, TrialsScript.getNextWaypointIndex(route, 2, new WorldPoint(0, 0, 0)));
+        assertEquals(0, TrialsScript.getNextWaypointIndex(route, 2, new WorldPoint(10, 0, 0)));
+    }
+
+    private static void assertEquals(Object expected, Object actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError("Expected " + expected + " but got " + actual);
+        }
+    }
+
+}


### PR DESCRIPTION
### Problem:

Barracuda Trials Auto Navigate requires manual rum collection and delivery. A successful rum transfer changes the boat course. The route controller can then turn toward route points that the boat already passed.

### Solution:

The controller issues one rum action at each Barracuda boat and waits for the HUD rum state before a retry. It skips a course command in the same tick. It advances only through forward route segments that the boat passed.

### Additional notes:

An end user reported that the final test build worked without route or rum errors. Action breaks remain outside this change.
TrialsScriptTest passed as a direct main-class check.
./gradlew clean build -PpluginList=MSailingPlugin -PmicrobotClientVersion=latest passed with Microbot client 2.6.20.
Bump version from 2.2.56 to 2.2.57