### PR TITLE
fix(mke-wintertodt): preserve warm gear and accept hammer variants

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtPlugin.java
@@ -42,7 +42,7 @@ import java.time.Instant;
 )
 @Slf4j
 public class MKE_WintertodtPlugin extends Plugin {
-    static final String version = "2.2.1";
+    static final String version = "2.2.2";
 
     // Core plugin components
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/MKE_WintertodtScript.java
@@ -1423,7 +1423,7 @@ public class MKE_WintertodtScript extends Script {
             Microbot.log("Fletching enabled but no knife in inventory - this is okay, will get one from bank");
         }
 
-        if (config.fixBrazier() && !Rs2Inventory.hasItem(ItemID.HAMMER)) {
+        if (config.fixBrazier() && !WintertodtInventoryManager.hasHammer()) {
             Microbot.log("Brazier fixing enabled but no hammer in inventory - this is okay, will get one from bank");
         }
 

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/WintertodtStartupManager.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/WintertodtStartupManager.java
@@ -392,7 +392,7 @@ public class WintertodtStartupManager {
         inventoryManager.determineKnifeToUse();
                              
         boolean hasKnife = !config.fletchRoots() || Rs2Inventory.hasItem(WintertodtInventoryManager.knifeToUse);
-        boolean hasHammer = !config.fixBrazier() || Rs2Inventory.hasItem(ItemID.HAMMER);
+        boolean hasHammer = !config.fixBrazier() || WintertodtInventoryManager.hasHammer();
         
         Microbot.log("Tools check - Axe (" + axeDecision.getAxeName() + "): " + hasAxe + 
                     ", Fire tool: " + hasFireTool + ", Knife: " + hasKnife + ", Hammer: " + hasHammer);
@@ -432,12 +432,12 @@ public class WintertodtStartupManager {
                     int itemId = equipped.getId();
                     
                     // Look up the gear item in our comprehensive database
-                    net.runelite.client.plugins.microbot.mke_wintertodt.startup.gear.WintertodtGearItem gearItem = 
+                    net.runelite.client.plugins.microbot.mke_wintertodt.startup.gear.WintertodtGearItem gearItem =
                         gearDatabase.findGearItemById(itemId);
-                    
-                    if (gearItem != null && gearItem.providesWarmth()) {
+
+                    if (gearDatabase.isWarmItem(itemId)) {
                         warmCount++;
-                        Microbot.log("Warm gear: " + gearItem.getItemName() + " (provides warmth)");
+                        Microbot.log("Warm gear: " + equipped.getName() + " (provides warmth)");
                     } else if (gearItem != null) {
                         Microbot.log("Cold gear: " + gearItem.getItemName() + " (no warmth)");
                     } else {
@@ -464,4 +464,4 @@ public class WintertodtStartupManager {
         WorldPoint playerLocation = Rs2Player.getWorldLocation();
         return playerLocation.distanceTo(WINTERTODT_BANK) <= WINTERTODT_AREA_RADIUS;
     }
-} 
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/gear/WintertodtAxeManager.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/gear/WintertodtAxeManager.java
@@ -1,15 +1,18 @@
 package net.runelite.client.plugins.microbot.mke_wintertodt.startup.gear;
 
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static net.runelite.client.plugins.microbot.util.Global.sleepGaussian;
 import static net.runelite.client.plugins.microbot.util.Global.sleepUntilTrue;
@@ -23,6 +26,8 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntilTrue;
  * @version 2.0.0
  */
 public class WintertodtAxeManager {
+
+    private static final WintertodtGearDatabase GEAR_DATABASE = new WintertodtGearDatabase();
     
     // Axe priority list (best to worst) - updated with correct requirements
     private static final List<AxeInfo> AXE_PRIORITY = Arrays.asList(
@@ -149,6 +154,11 @@ public class WintertodtAxeManager {
             Microbot.log("Cannot wield " + bestAxe.name + " (need " + bestAxe.attackLevel + " Attack, have " + attackLevel + ")");
             return false;
         }
+
+        if (!preservesRequiredWarmth(bestAxe.itemId)) {
+            Microbot.log("Keeping axe in inventory to preserve four warm items");
+            return false;
+        }
         
         // Special case: Bronze axe has no attack requirement, always equip if possible
         if (bestAxe.itemId == ItemID.BRONZE_AXE) {
@@ -171,6 +181,18 @@ public class WintertodtAxeManager {
         // Both scenarios use same total slots, but equipped axe allows for more flexible inventory management
         Microbot.log("No bruma torch available - equipping " + bestAxe.name + " for better inventory efficiency");
         return true;
+    }
+
+    private static boolean preservesRequiredWarmth(int axeId) {
+        Rs2ItemModel weapon = Rs2Equipment.get(EquipmentInventorySlot.WEAPON);
+        if (weapon == null) {
+            return true;
+        }
+
+        return GEAR_DATABASE.preservesRequiredWarmthAfterReplacing(
+                Rs2Equipment.all().map(Rs2ItemModel::getId).collect(Collectors.toList()),
+                weapon.getId(),
+                axeId);
     }
     
     /**
@@ -443,4 +465,4 @@ public class WintertodtAxeManager {
                                axeName, shouldEquip, canWield, needsTorchConversion);
         }
     }
-} 
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/gear/WintertodtGearDatabase.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/gear/WintertodtGearDatabase.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.mke_wintertodt.startup.gear;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.questhelper.collections.ItemCollections;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -1489,6 +1490,25 @@ public class WintertodtGearDatabase {
                 .findFirst()
                 .orElse(null);
     }
+
+    public boolean isWarmItem(int itemId) {
+        WintertodtGearItem item = findGearItemById(itemId);
+        return (item != null && item.providesWarmth()) ||
+                ItemCollections.WARM_CLOTHING.getItems().contains(itemId);
+    }
+
+    boolean isAllowedGear(EquipmentInventorySlot slot, int itemId) {
+        return slot == WEAPON || isWarmItem(itemId);
+    }
+
+    boolean preservesRequiredWarmthAfterReplacing(Collection<Integer> equippedItemIds,
+                                                   int replacedItemId,
+                                                   int replacementItemId) {
+        if (!isWarmItem(replacedItemId) || isWarmItem(replacementItemId)) {
+            return true;
+        }
+        return equippedItemIds.stream().filter(this::isWarmItem).count() > 4;
+    }
     
     /**
      * Gets gear items filtered by category.
@@ -1505,4 +1525,4 @@ public class WintertodtGearDatabase {
     public int getTotalGearCount() {
         return allGearItems.size();
     }
-} 
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/gear/WintertodtGearManager.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/gear/WintertodtGearManager.java
@@ -13,9 +13,11 @@ import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.mke_wintertodt.MKE_WintertodtConfig;
 import net.runelite.client.plugins.microbot.mke_wintertodt.startup.inventory.WintertodtInventoryManager;
+import net.runelite.client.game.ItemStats;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 import static net.runelite.client.plugins.microbot.util.Global.sleepUntilTrue;
@@ -52,7 +54,7 @@ public class WintertodtGearManager {
     public boolean setupOptimalGear() {
         try {
             Microbot.log("Setting up optimal Wintertodt gear using database analysis...");
-            
+
             // Ensure bank access
             if (!ensureBankAccess()) {
                 return false;
@@ -97,9 +99,11 @@ public class WintertodtGearManager {
             // Cache player data once for entire analysis
             cachePlayerData();
             
+            List<WintertodtGearItem> accessibleWarmGear = findAccessibleWarmGear();
+
             // Analyze each equipment slot using database
             for (EquipmentInventorySlot slot : EquipmentInventorySlot.values()) {
-                analyzeSlotFromDatabase(slot);
+                analyzeSlotFromDatabase(slot, accessibleWarmGear);
             }
             
             // Log comprehensive analysis
@@ -116,12 +120,15 @@ public class WintertodtGearManager {
     /**
      * Analyzes a specific equipment slot using the database.
      */
-    private void analyzeSlotFromDatabase(EquipmentInventorySlot slot) {
+    private void analyzeSlotFromDatabase(EquipmentInventorySlot slot,
+                                         List<WintertodtGearItem> accessibleWarmGear) {
         gearAnalysisLog.add("=== " + slot.name() + " SLOT ANALYSIS ===");
         
         // Get all gear items for this slot from database
-        List<WintertodtGearItem> availableGear = gearDatabase.getGearForSlot(slot)
-            .stream()
+        List<WintertodtGearItem> availableGear = Stream.concat(
+                gearDatabase.getGearForSlot(slot).stream(),
+                accessibleWarmGear.stream().filter(item -> item.getSlot() == slot))
+            .filter(item -> gearDatabase.isAllowedGear(slot, item.getItemId()))
             .filter(this::canPlayerUseItem)
             .filter(this::hasAccessToItem)
             .sorted((a, b) -> Integer.compare(b.getEffectivePriority(), a.getEffectivePriority()))
@@ -164,6 +171,42 @@ public class WintertodtGearManager {
                 gearAnalysisLog.add("  - " + alt.getItemName() + " (Priority: " + alt.getEffectivePriority() + ")");
             }
         }
+    }
+
+    private List<WintertodtGearItem> findAccessibleWarmGear() {
+        List<Rs2ItemModel> accessible = new ArrayList<>();
+        accessible.addAll(Rs2Inventory.all());
+        accessible.addAll(Rs2Equipment.all().collect(Collectors.toList()));
+        if (Rs2Bank.bankItems() != null) {
+            accessible.addAll(Rs2Bank.bankItems());
+        }
+
+        return accessible.stream()
+                .filter(item -> gearDatabase.isWarmItem(item.getId()))
+                .filter(item -> gearDatabase.findGearItemById(item.getId()) == null)
+                .collect(Collectors.toMap(Rs2ItemModel::getId, item -> item, (first, ignored) -> first))
+                .values().stream()
+                .map(item -> createWarmGearItem(item.getId(), item.getName()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private WintertodtGearItem createWarmGearItem(int itemId, String itemName) {
+        ItemStats stats = Microbot.getClientThread().runOnClientThreadOptional(
+                () -> Microbot.getItemManager().getItemStats(itemId)).orElse(null);
+        if (stats == null || stats.getEquipment() == null) {
+            return null;
+        }
+        EquipmentInventorySlot slot = Arrays.stream(EquipmentInventorySlot.values())
+                .filter(candidate -> candidate.getSlotIdx() == stats.getEquipment().getSlot())
+                .findFirst()
+                .orElse(null);
+        return slot == null ? null : new WintertodtGearItem.Builder(itemId, itemName, slot)
+                .priority(600)
+                .category(WintertodtGearItem.GearCategory.WARM_GEAR)
+                .providesWarmth()
+                .description(itemName + " - provides warmth")
+                .build();
     }
     
     /**
@@ -320,7 +363,9 @@ public class WintertodtGearManager {
             
             // Equip each optimal gear piece
             for (Map.Entry<EquipmentInventorySlot, WintertodtGearItem> entry : optimalGear.entrySet()) {
-                equipGearItem(entry.getValue());
+                if (!equipGearItem(entry.getValue())) {
+                    return false;
+                }
             }
             
             Microbot.log("Optimal gear equipped successfully!");
@@ -335,30 +380,33 @@ public class WintertodtGearManager {
     /**
      * Equips a specific gear item.
      */
-    private void equipGearItem(WintertodtGearItem gearItem) {
+    private boolean equipGearItem(WintertodtGearItem gearItem) {
         int itemId = gearItem.getItemId();
         
         // Skip if already equipped
         if (Rs2Equipment.isWearing(itemId)) {
             Microbot.log("Already wearing: " + gearItem.getItemName());
-            return;
+            return true;
         }
         
         // Withdraw if needed
         if (!Rs2Inventory.hasItem(itemId)) {
             if (Rs2Bank.hasItem(itemId)) {
-                Rs2Bank.withdrawOne(itemId);
-                sleepUntil(() -> Rs2Inventory.hasItem(itemId), 3000);
+                if (!Rs2Bank.withdrawOne(itemId) ||
+                        !sleepUntil(() -> Rs2Inventory.hasItem(itemId), 3000)) {
+                    Microbot.log("Failed to withdraw: " + gearItem.getItemName());
+                    return false;
+                }
             } else {
                 Microbot.log("Warning: Cannot find " + gearItem.getItemName() + " in bank");
-                return;
+                return false;
             }
         }
         
         // Equip the item
         Microbot.log("Equipping: " + gearItem.getItemName());
-        Rs2Inventory.wield(itemId);
-        sleepUntil(() -> Rs2Equipment.isWearing(itemId), 3000);
+        return Rs2Inventory.wield(itemId) &&
+                sleepUntil(() -> Rs2Equipment.isWearing(itemId), 3000);
     }
     
     /**
@@ -396,7 +444,7 @@ public class WintertodtGearManager {
         }
         
         // Preserve hammer in slot 26 (brazier repair)
-        if (itemId == ItemID.HAMMER && slot == 26 && config.fixBrazier()) {
+        if (WintertodtInventoryManager.isHammer(itemId) && slot == 26 && config.fixBrazier()) {
             return true;
         }
         
@@ -511,4 +559,5 @@ public class WintertodtGearManager {
     public Map<EquipmentInventorySlot, WintertodtGearItem> getOptimalGear() {
         return new HashMap<>(optimalGear);
     }
-} 
+
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/inventory/WintertodtInventoryManager.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/mke_wintertodt/startup/inventory/WintertodtInventoryManager.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.mke_wintertodt.startup.inventory;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.ItemID;
 import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.questhelper.collections.ItemCollections;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -44,6 +45,9 @@ public class WintertodtInventoryManager {
     private static final int HAMMER_SLOT = 26;     // Next to knife
     private static final int TINDERBOX_SLOT = 25;  // Above hammer
     private static final int AXE_SLOT = 24;        // Above tinderbox
+    private static final int[] HAMMER_IDS = ItemCollections.HAMMER.getItems().stream()
+            .mapToInt(Integer::intValue)
+            .toArray();
     
     // Axe priority list (best to worst)
     private static final List<Integer> AXE_PRIORITY = Arrays.asList(
@@ -207,7 +211,7 @@ public class WintertodtInventoryManager {
             }
             
         // Handle hammer if fixing enabled
-            if (config.fixBrazier() && !Rs2Inventory.hasItem(ItemID.HAMMER)) {
+            if (config.fixBrazier() && !hasHammer()) {
             if (!Rs2Bank.withdrawX(ItemID.HAMMER, 1)) {
                 inventorySetupLog.add("Failed to get hammer for fixing");
                 return false;
@@ -306,8 +310,9 @@ public class WintertodtInventoryManager {
             }
             
         // Move hammer next to knife if available
-            if (Rs2Inventory.hasItem(ItemID.HAMMER)) {
-                moveItemToSlot(ItemID.HAMMER, HAMMER_SLOT, "hammer next to knife");
+            Rs2ItemModel hammer = Rs2Inventory.get(HAMMER_IDS);
+            if (hammer != null) {
+                moveItemToSlot(hammer.getId(), HAMMER_SLOT, "hammer next to knife");
             }
             
         // Handle axe placement if in inventory
@@ -372,7 +377,7 @@ public class WintertodtInventoryManager {
         }
         
         // Check hammer in slot 26
-        Rs2ItemModel hammerItem = Rs2Inventory.get(ItemID.HAMMER);
+        Rs2ItemModel hammerItem = Rs2Inventory.get(HAMMER_IDS);
         if (hammerItem != null && hammerItem.getSlot() == HAMMER_SLOT) {
             Microbot.log("  Slot 26: Hammer ✓");
         }
@@ -404,6 +409,14 @@ public class WintertodtInventoryManager {
         // Clear any cached state
         Microbot.log("Inventory manager state reset - ready for fresh setup");
     }
+
+    public static boolean isHammer(int itemId) {
+        return ItemCollections.HAMMER.getItems().contains(itemId);
+    }
+
+    public static boolean hasHammer() {
+        return Rs2Inventory.hasItem(HAMMER_IDS) || Rs2Equipment.isWearing(HAMMER_IDS);
+    }
     
     /**
      * Gets the inventory setup log for display.
@@ -428,4 +441,4 @@ public class WintertodtInventoryManager {
             default: return "Unknown axe";
         }
     }
-} 
+}


### PR DESCRIPTION
### Problem

- Automatic gear selection could replace warm clothing with cold armour, including rune equipment, graceful pieces, and dragon defenders.
- Equipping an axe could reduce the player below four warm items.
- Hammer detection rejected Imcando hammer variants.

### Solution

- Select accessible warm clothing through the shared RuneLite warm-item collection.
- Reject cold non-weapon gear and preserve four equipped warm items.
- Keep the axe in inventory when equipping it would reduce warmth.
- Recognize standard, main-hand Imcando, and off-hand Imcando hammers.
- Propagate gear and inventory setup failures.

### Additional notes
Bump version from 2.2.1 to 2.2.2

- Local policy regression passed for the reported and sibling warm outfits, cold fallback gear, and hammer variants.
- Bank-only live acceptance passed in 78.4 seconds with four warm items, one hammer, an inventory axe, no movement, and no duplicate withdrawal.
- Dynamic production-source compilation and git diff --check passed.
- Gradle compilation could not start because the required Adoptium Java 11 toolchain is unavailable; this repository exposes no checkstyle task.