### PR TITLE
fix(geflipper): stop offer-screen misclicks, silent GE stalls, and add a hand-flip switch (v1.2.55)

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperConfig.java
@@ -58,4 +58,17 @@ public interface FlipperConfig extends Config {
     default boolean showOverlay() {
         return true;
     }
+
+    @ConfigItem(
+        keyName = "autoEnableSlotSwap",
+        name = "Auto-Enable Copilot Slot Swap",
+        description = "Automatically turn on Flipping Copilot's 'Swap slot left-click action' setting, " +
+            "so offers can be aborted straight from the Grand Exchange overview. " +
+            "<br>Turn this OFF if you also hand-flip and want left-clicking a GE slot to open the offer screen. " +
+            "<br>When off, the plugin respects your Copilot setting and falls back to aborting from the offer details screen.",
+        position = 3
+    )
+    default boolean autoEnableSlotSwap() {
+        return true;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperConfig.java
@@ -7,11 +7,27 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("Flipper Config")
 public interface FlipperConfig extends Config {
 
-        @ConfigItem(
-            keyName = "guide",
-            name = "How to use",
-            description = "How to use this plugin",
-            position = 0
+    enum SelectionMethod {
+        HOTKEY("Hotkey (E)"),
+        MOUSE("Mouse");
+
+        private final String name;
+
+        SelectionMethod(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    @ConfigItem(
+        keyName = "guide",
+        name = "How to use",
+        description = "How to use this plugin",
+        position = 0
     )
     default String GUIDE() {
         return "Automates the Flipping copilot plugin from the plugin hub,  \n" +
@@ -22,5 +38,24 @@ public interface FlipperConfig extends Config {
         "~made by chocken   \n" +
         "Extra tip: In game settings, disable grand exchange warnings for offers with the price too low/high, otherwise the script will get stuck.";
     }
-    
+
+    @ConfigItem(
+        keyName = "selectionMethod",
+        name = "Suggestion Selection",
+        description = "Choose whether to use the hotkey (E) or mouse clicks to select what Copilot suggests",
+        position = 1
+    )
+    default SelectionMethod selectionMethod() {
+        return SelectionMethod.HOTKEY;
+    }
+
+    @ConfigItem(
+        keyName = "showOverlay",
+        name = "Show Overlay",
+        description = "Display profit and GP/hr overlay on the top-left of the screen",
+        position = 2
+    )
+    default boolean showOverlay() {
+        return true;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperOverlay.java
@@ -1,0 +1,279 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import javax.swing.JLabel;
+import java.awt.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+public class FlipperOverlay extends OverlayPanel {
+    private static final Color POSITIVE_COLOR = new Color(0x52D273);
+    private static final Color NEGATIVE_COLOR = new Color(0xFF6666);
+    private static final Color TITLE_COLOR = Color.CYAN;
+
+    private final FlipperPlugin plugin;
+    private final FlipperConfig config;
+
+    private Plugin flippingCopilot;
+    private Object flipManager;
+    private Object sessionManager;
+    private Object statsPanel;
+
+    private String overallProfitStr = "0 gp";
+    private Color overallProfitColor = Color.WHITE;
+    private String gpHrStr = "0 gp/hr";
+    private Color gpHrColor = Color.WHITE;
+    private String sessionProfitStr = "0 gp";
+    private Color sessionProfitColor = Color.WHITE;
+    private String sessionTimeStr = null;
+
+    private long lastFetchTime = 0;
+
+    @Inject
+    public FlipperOverlay(FlipperPlugin plugin, FlipperConfig config) {
+        super(plugin);
+        this.plugin = plugin;
+        this.config = config;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    private void updateCopilotStats() {
+        long now = System.currentTimeMillis();
+        if (now - lastFetchTime < 1000) return;
+        lastFetchTime = now;
+
+        if (flippingCopilot == null) {
+            flippingCopilot = Microbot.getPluginManager()
+                .getPlugins()
+                .stream()
+                .filter(p -> p.getClass().getSimpleName().equalsIgnoreCase("FlippingCopilotPlugin"))
+                .findFirst()
+                .orElse(null);
+        }
+        if (flippingCopilot == null) {
+            overallProfitStr = "Copilot not found";
+            overallProfitColor = Color.GRAY;
+            gpHrStr = "-";
+            gpHrColor = Color.GRAY;
+            return;
+        }
+
+        try {
+            if (flipManager == null) {
+                Field fmField = flippingCopilot.getClass().getDeclaredField("flipManager");
+                fmField.setAccessible(true);
+                flipManager = fmField.get(flippingCopilot);
+            }
+            if (sessionManager == null) {
+                Field smField = flippingCopilot.getClass().getDeclaredField("sessionManager");
+                smField.setAccessible(true);
+                sessionManager = smField.get(flippingCopilot);
+            }
+            if (statsPanel == null) {
+                try {
+                    Field spField = flippingCopilot.getClass().getDeclaredField("statsPanel");
+                    spField.setAccessible(true);
+                    statsPanel = spField.get(flippingCopilot);
+                } catch (Exception ignored) {}
+            }
+        } catch (Exception ignored) {}
+
+        long overallProfit = 0;
+        long sessionProfit = 0;
+        long gpHr = 0;
+        boolean gotOverall = false;
+        boolean gotSession = false;
+
+        // 1. Query flipManager for exact overall & session profits
+        if (flipManager != null) {
+            try {
+                // calculateStats(0, null) calculates all-time stats across all accounts
+                Method calculateStats = flipManager.getClass().getMethod("calculateStats", int.class, Integer.class);
+                Object overallStats = calculateStats.invoke(flipManager, 0, null);
+                if (overallStats != null) {
+                    Field profitField = overallStats.getClass().getField("profit");
+                    overallProfit = profitField.getLong(overallStats);
+                    gotOverall = true;
+                }
+
+                // getIntervalStats() gets current interval / session stats
+                Method getIntervalStats = flipManager.getClass().getMethod("getIntervalStats");
+                Object intervalStats = getIntervalStats.invoke(flipManager);
+                if (intervalStats != null) {
+                    Field profitField = intervalStats.getClass().getField("profit");
+                    sessionProfit = profitField.getLong(intervalStats);
+                    gotSession = true;
+                }
+            } catch (Exception ignored) {}
+        }
+
+        // 2. Query sessionManager for runtime & compute gp/hr
+        if (sessionManager != null) {
+            try {
+                Method getCachedSessionData = sessionManager.getClass().getMethod("getCachedSessionData");
+                Object sessionData = getCachedSessionData.invoke(sessionManager);
+                if (sessionData != null) {
+                    Field durationField = sessionData.getClass().getField("durationMillis");
+                    long durationMillis = durationField.getLong(sessionData);
+                    if (durationMillis > 0) {
+                        double hours = durationMillis / 3600000.0;
+                        if (hours > 0) {
+                            gpHr = (long) (sessionProfit / hours);
+                        }
+                        long totalSeconds = durationMillis / 1000;
+                        long h = totalSeconds / 3600;
+                        long m = (totalSeconds % 3600) / 60;
+                        long s = totalSeconds % 60;
+                        sessionTimeStr = String.format("%02d:%02d:%02d", h, m, s);
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+
+        // 3. Check statsPanel UI labels if available to supplement
+        if (statsPanel != null) {
+            try {
+                // If hourlyProfitVal label has Copilot's formatted text
+                Field hourlyField = statsPanel.getClass().getDeclaredField("hourlyProfitVal");
+                hourlyField.setAccessible(true);
+                Object hourlyObj = hourlyField.get(statsPanel);
+                if (hourlyObj instanceof JLabel) {
+                    String text = ((JLabel) hourlyObj).getText();
+                    if (text != null && !text.trim().isEmpty() && !text.equals("0 gp/hr") && gpHr == 0) {
+                        gpHrStr = text;
+                        gpHrColor = getColorForText(text);
+                    }
+                }
+
+                // If overall wasn't found from flipManager, read totalProfitVal
+                if (!gotOverall) {
+                    Field totalField = statsPanel.getClass().getDeclaredField("totalProfitVal");
+                    totalField.setAccessible(true);
+                    Object totalObj = totalField.get(statsPanel);
+                    if (totalObj instanceof JLabel) {
+                        String text = ((JLabel) totalObj).getText();
+                        if (text != null && !text.trim().isEmpty()) {
+                            overallProfitStr = text;
+                            overallProfitColor = getColorForText(text);
+                            gotOverall = true;
+                        }
+                    }
+                }
+
+                // Session time label
+                Field timeField = statsPanel.getClass().getDeclaredField("sessionTimeVal");
+                timeField.setAccessible(true);
+                Object timeObj = timeField.get(statsPanel);
+                if (timeObj instanceof JLabel) {
+                    String text = ((JLabel) timeObj).getText();
+                    if (text != null && !text.trim().isEmpty() && !text.equals("00:00:00")) {
+                        sessionTimeStr = text;
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+
+        if (gotOverall) {
+            overallProfitStr = formatProfit(overallProfit);
+            overallProfitColor = overallProfit > 0 ? POSITIVE_COLOR : (overallProfit < 0 ? NEGATIVE_COLOR : Color.WHITE);
+        }
+        if (gotSession) {
+            sessionProfitStr = formatProfit(sessionProfit);
+            sessionProfitColor = sessionProfit > 0 ? POSITIVE_COLOR : (sessionProfit < 0 ? NEGATIVE_COLOR : Color.WHITE);
+        }
+        if (gpHr != 0 || !gpHrStr.contains("gp/hr")) {
+            gpHrStr = formatGpHr(gpHr);
+            gpHrColor = gpHr > 0 ? POSITIVE_COLOR : (gpHr < 0 ? NEGATIVE_COLOR : Color.WHITE);
+        }
+    }
+
+    public static String formatProfit(long amount) {
+        String sign = amount > 0 ? "+" : (amount < 0 ? "-" : "");
+        long abs = Math.abs(amount);
+        if (abs >= 1_000_000_000L) {
+            return sign + String.format(Locale.ENGLISH, "%.2fB gp", abs / 1_000_000_000.0);
+        } else if (abs >= 1_000_000L) {
+            return sign + String.format(Locale.ENGLISH, "%.2fM gp", abs / 1_000_000.0);
+        } else if (abs >= 10_000L) {
+            return sign + String.format(Locale.ENGLISH, "%.1fK gp", abs / 1_000.0);
+        } else {
+            return sign + String.format(Locale.ENGLISH, "%,d gp", abs);
+        }
+    }
+
+    public static String formatGpHr(long amount) {
+        String sign = amount > 0 ? "+" : (amount < 0 ? "-" : "");
+        long abs = Math.abs(amount);
+        if (abs >= 1_000_000_000L) {
+            return sign + String.format(Locale.ENGLISH, "%.2fB gp/hr", abs / 1_000_000_000.0);
+        } else if (abs >= 1_000_000L) {
+            return sign + String.format(Locale.ENGLISH, "%.2fM gp/hr", abs / 1_000_000.0);
+        } else if (abs >= 10_000L) {
+            return sign + String.format(Locale.ENGLISH, "%.1fK gp/hr", abs / 1_000.0);
+        } else {
+            return sign + String.format(Locale.ENGLISH, "%,d gp/hr", abs);
+        }
+    }
+
+    private static Color getColorForText(String text) {
+        if (text.startsWith("+") || (!text.startsWith("-") && !text.startsWith("0"))) {
+            return POSITIVE_COLOR;
+        } else if (text.startsWith("-")) {
+            return NEGATIVE_COLOR;
+        }
+        return Color.WHITE;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (config != null && !config.showOverlay()) return null;
+        if (!Microbot.isLoggedIn()) return null;
+
+        updateCopilotStats();
+
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(200, 0));
+
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("Microbot Flipper v" + FlipperPlugin.version)
+                .color(TITLE_COLOR)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("GP/hr:")
+                .right(gpHrStr)
+                .rightColor(gpHrColor)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Overall Profit:")
+                .right(overallProfitStr)
+                .rightColor(overallProfitColor)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Session Profit:")
+                .right(sessionProfitStr)
+                .rightColor(sessionProfitColor)
+                .build());
+
+        if (sessionTimeStr != null && !sessionTimeStr.isEmpty()) {
+            panelComponent.getChildren().add(LineComponent.builder()
+                    .left("Session Time:")
+                    .right(sessionTimeStr)
+                    .rightColor(Color.LIGHT_GRAY)
+                    .build());
+        }
+
+        return super.render(graphics);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperOverlay.java
@@ -274,6 +274,13 @@ public class FlipperOverlay extends OverlayPanel {
                     .build());
         }
 
+        boolean slotSwap = plugin.getFlipperScript() != null && plugin.getFlipperScript().isSlotActionSwapEnabled();
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Slot Swap:")
+                .right(slotSwap ? "ON" : "OFF (Screen Abort)")
+                .rightColor(slotSwap ? POSITIVE_COLOR : Color.ORANGE)
+                .build());
+
         return super.render(graphics);
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.52";
+    public static final String version = "1.2.53";
     @Inject
     private Client client;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,11 +25,15 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.6";
+    public static final String version = "1.2.7";
     @Inject
     private Client client;
     @Inject
     private FlipperScript flipperScript;
+
+    public FlipperScript getFlipperScript() {
+        return flipperScript;
+    }
     @Inject
     private net.runelite.client.plugins.microbot.geflipper.FlipperConfig config;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -8,6 +8,8 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.microbot.PluginConstants;
 
+import net.runelite.client.ui.overlay.OverlayManager;
+
 import java.awt.*;
 
 @PluginDescriptor(
@@ -30,19 +32,49 @@ public class FlipperPlugin extends Plugin {
     private FlipperScript flipperScript;
     @Inject
     private net.runelite.client.plugins.microbot.geflipper.FlipperConfig config;
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private FlipperOverlay overlay;
 
     @Provides
     net.runelite.client.plugins.microbot.geflipper.FlipperConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(FlipperConfig.class);
     }
 
+    private void disableGameChatAppender() {
+        try {
+            org.slf4j.Logger slf4jLogger = org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+            if (slf4jLogger instanceof ch.qos.logback.classic.Logger) {
+                ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) slf4jLogger;
+                java.util.Iterator<ch.qos.logback.core.Appender<ch.qos.logback.classic.spi.ILoggingEvent>> it = rootLogger.iteratorForAppenders();
+                while (it.hasNext()) {
+                    ch.qos.logback.core.Appender<ch.qos.logback.classic.spi.ILoggingEvent> appender = it.next();
+                    if (appender.getClass().getName().contains("GameChatAppender")) {
+                        rootLogger.detachAppender(appender);
+                        appender.stop();
+                    }
+                }
+            }
+            net.runelite.client.plugins.microbot.GameChatAppender.updateConfiguration(false, ch.qos.logback.classic.Level.OFF, false);
+        } catch (Throwable ignored) {
+        }
+    }
+
     @Override
     protected void startUp() throws AWTException{
-        flipperScript.run();
+        disableGameChatAppender();
+        if (overlayManager != null && overlay != null) {
+            overlayManager.add(overlay);
+        }
+        flipperScript.run(config);
     }
 
     @Override
     protected void shutDown() {
+        if (overlayManager != null && overlay != null) {
+            overlayManager.remove(overlay);
+        }
         flipperScript.state = State.GOING_TO_GE;
         flipperScript.shutdown();
     }

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.5";
+    public static final String version = "1.2.6";
     @Inject
     private Client client;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.8";
+    public static final String version = "1.2.5";
     @Inject
     private Client client;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,8 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.54";
+    public static final String version = "1.2.55";
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FlipperPlugin.class);
     @Inject
     private Client client;
     @Inject
@@ -59,17 +60,25 @@ public class FlipperPlugin extends Plugin {
             if (cfg == null) {
                 try {
                     cfg = configManager.getConfig(FlipperConfig.class);
-                } catch (Throwable ignored) {
+                } catch (Throwable e) {
+                    log.info("slotActionSwap auto-enable: could not read the flipper config: {}", e.toString());
                 }
             }
+            String current = configManager.getConfiguration("flippingcopilot", "slotActionSwap");
+            // Logged on every start: this check used to fail silently, so a toggle that
+            // did not take effect left no evidence of why.
+            log.info("slotActionSwap auto-enable check: toggle={}, current={}",
+                cfg == null ? "unreadable" : String.valueOf(cfg.autoEnableSlotSwap()), current);
             if (cfg != null && !cfg.autoEnableSlotSwap()) {
+                log.info("slotActionSwap auto-enable is disabled by configuration; leaving it as '{}'.", current);
                 return;
             }
-            String current = configManager.getConfiguration("flippingcopilot", "slotActionSwap");
             if (!"true".equalsIgnoreCase(current)) {
+                log.info("Enabling Flipping Copilot 'slotActionSwap' (was '{}').", current);
                 configManager.setConfiguration("flippingcopilot", "slotActionSwap", true);
             }
-        } catch (Throwable ignored) {
+        } catch (Throwable e) {
+            log.info("slotActionSwap auto-enable failed: {}", e.toString());
         }
     }
 

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.53";
+    public static final String version = "1.2.54";
     @Inject
     private Client client;
     @Inject
@@ -50,11 +50,24 @@ public class FlipperPlugin extends Plugin {
 
     private void ensureCopilotSlotActionSwap() {
         try {
-            if (configManager != null) {
-                String current = configManager.getConfiguration("flippingcopilot", "slotActionSwap");
-                if (!"true".equalsIgnoreCase(current)) {
-                    configManager.setConfiguration("flippingcopilot", "slotActionSwap", true);
+            if (configManager == null) return;
+            // This setting has TWO writers: this startup hook and
+            // FlipperScript.ensureSlotActionSwapEnabled(). Both must honour the
+            // user's toggle, or turning it off has no effect - the startup hook
+            // ran first and silently re-enabled the setting.
+            FlipperConfig cfg = config;
+            if (cfg == null) {
+                try {
+                    cfg = configManager.getConfig(FlipperConfig.class);
+                } catch (Throwable ignored) {
                 }
+            }
+            if (cfg != null && !cfg.autoEnableSlotSwap()) {
+                return;
+            }
+            String current = configManager.getConfiguration("flippingcopilot", "slotActionSwap");
+            if (!"true".equalsIgnoreCase(current)) {
+                configManager.setConfiguration("flippingcopilot", "slotActionSwap", true);
             }
         } catch (Throwable ignored) {
         }

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.5";
+    public static final String version = "1.2.51";
     @Inject
     private Client client;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.51";
+    public static final String version = "1.2.52";
     @Inject
     private Client client;
     @Inject

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperPlugin.java
@@ -25,7 +25,7 @@ import java.awt.*;
         isExternal = PluginConstants.IS_EXTERNAL
 )
 public class FlipperPlugin extends Plugin {
-    public static final String version = "1.2.7";
+    public static final String version = "1.2.8";
     @Inject
     private Client client;
     @Inject
@@ -40,10 +40,24 @@ public class FlipperPlugin extends Plugin {
     private OverlayManager overlayManager;
     @Inject
     private FlipperOverlay overlay;
+    @Inject
+    private ConfigManager configManager;
 
     @Provides
     net.runelite.client.plugins.microbot.geflipper.FlipperConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(FlipperConfig.class);
+    }
+
+    private void ensureCopilotSlotActionSwap() {
+        try {
+            if (configManager != null) {
+                String current = configManager.getConfiguration("flippingcopilot", "slotActionSwap");
+                if (!"true".equalsIgnoreCase(current)) {
+                    configManager.setConfiguration("flippingcopilot", "slotActionSwap", true);
+                }
+            }
+        } catch (Throwable ignored) {
+        }
     }
 
     private void disableGameChatAppender() {
@@ -67,6 +81,7 @@ public class FlipperPlugin extends Plugin {
 
     @Override
     protected void startUp() throws AWTException{
+        ensureCopilotSlotActionSwap();
         disableGameChatAppender();
         if (overlayManager != null && overlay != null) {
             overlayManager.add(overlay);

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -1,11 +1,16 @@
 package net.runelite.client.plugins.microbot.geflipper;
 
+import com.google.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.MenuAction;
+import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.input.KeyListener;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
@@ -15,10 +20,14 @@ import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
 import net.runelite.client.plugins.microbot.util.misc.Rs2UiHelper;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
 
 import java.awt.*;
@@ -45,6 +54,8 @@ public class FlipperScript extends Script {
 	private static final int INTERACTION_TIMEOUT_VARIANCE = 11000;
 	private static final int INVENTORY_WAIT_TIMEOUT = 5000;
 	private static final int SCHEDULE_INTERVAL_MS = 600;
+	private static final int KEY_PRESS_DELAY_MIN = 250;
+	private static final int KEY_PRESS_DELAY_MAX = 400;
 
 	private final WorldArea grandExchangeArea = new WorldArea(3136, 3465, 61, 54, 0);
     State state = State.GOING_TO_GE;
@@ -55,6 +66,8 @@ public class FlipperScript extends Script {
     private long lastActionTime = 0;
     private long actionCooldown = DEFAULT_ACTION_COOLDOWN;
 	private long interactionTimeout = DEFAULT_INTERACTION_TIMEOUT;
+	private long offerScreenOpenTime = 0;
+	private int offerScreenActionCount = 0;
 
 	private int[] grandExchangeSlotIds = new int[] {
 		InterfaceID.GeOffers.INDEX_0,
@@ -66,6 +79,21 @@ public class FlipperScript extends Script {
 		InterfaceID.GeOffers.INDEX_6,
 		InterfaceID.GeOffers.INDEX_7
 	};
+
+	@Inject
+	private FlipperConfig config;
+
+	@Inject
+	private KeyManager keyManager;
+
+	public boolean run(FlipperConfig config) {
+		this.config = config;
+		return run();
+	}
+
+	private boolean isMouseMode() {
+		return config != null && config.selectionMethod() == FlipperConfig.SelectionMethod.MOUSE;
+	}
 
     public boolean run() {
         Rs2AntibanSettings.naturalMouse = true;
@@ -86,7 +114,9 @@ public class FlipperScript extends Script {
                              state = State.MONITORING_COPILOT;
                              return;
                         }
-                        if (!grandExchangeArea.contains(Microbot.getClientThread().invoke(() -> Microbot.getClient().getLocalPlayer().getWorldLocation()))) {
+						WorldPoint playerLocation = Rs2Player.getWorldLocation();
+						if (playerLocation == null) return;
+                        if (!grandExchangeArea.contains(playerLocation)) {
                             Rs2GrandExchange.walkToGrandExchange();
                         }
                         state = State.GETTING_COINS;
@@ -108,32 +138,79 @@ public class FlipperScript extends Script {
                         break;
 
                     case MONITORING_COPILOT:
-                        if (!Rs2GrandExchange.isOpen()) {
+						long currentTime = System.currentTimeMillis();
+
+						// 0. Offer screen watchdog & loop detection
+						if (isOfferScreenOpen()) {
+							if (offerScreenOpenTime == 0) {
+								offerScreenOpenTime = currentTime;
+								offerScreenActionCount = 0;
+							}
+
+							// Check if "Too much money!" warning is shown on offer screen
+							if (Rs2Widget.hasWidget("Too much money")) {
+								log.warn("Offer has 'Too much money!' error. Backing out to GE overview.");
+								backToOverview();
+								return;
+							}
+
+							// If on offer screen and Copilot suggests ABORT, abort or back out immediately
+							if (suggestionManager != null) {
+								try {
+									Object currentSuggestion = getSuggestion(suggestionManager);
+									if (currentSuggestion != null) {
+										Method isAbortMethod = currentSuggestion.getClass().getMethod("isAbortSuggestion");
+										if ((Boolean) isAbortMethod.invoke(currentSuggestion)) {
+											Widget abortBtn = Rs2Widget.findWidget("Abort offer");
+											if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
+												log.info("Aborting offer via offer screen button '{}'", abortBtn.getId());
+												Rs2Widget.clickWidget(abortBtn);
+												sleep(200, 400);
+												backToOverview();
+											} else {
+												log.info("Abort suggested while on offer screen - backing out to overview.");
+												backToOverview();
+											}
+											lastActionTime = currentTime;
+											actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+											return;
+										}
+									}
+								} catch (Exception ignored) {}
+							}
+
+							// If stuck on offer screen for > 30 seconds or after 10 repeated actions without closing
+							if (currentTime - offerScreenOpenTime > 30000 || offerScreenActionCount >= 10) {
+								log.warn("Offer screen stuck (openTime={}ms, actions={}). Backing out to GE overview.",
+									currentTime - offerScreenOpenTime, offerScreenActionCount);
+								backToOverview();
+								return;
+							}
+						} else {
+							offerScreenOpenTime = 0;
+							offerScreenActionCount = 0;
+						}
+
+                        // 1. If bank is open, handle bank withdrawals
+                        if (handleBankIfNeeded()) return;
+
+						// 2. Check for Copilot price/quantity messages in chat
+						if (checkAndPressCopilotKeybind()) return;
+
+                        // 3. Check if we need to abort any offers
+                        if (checkAndAbortOrModifyIfNeeded()) return;
+
+                        // 4. Check for highlighted widgets
+                        if (checkAndClickHighlightedWidgets()) return;
+
+                        // 5. Check for highlighted NPCs
+                        if (checkAndInteractHighlightedNpc()) return;
+
+                        // 6. If neither GE nor Bank is open, open GE
+                        if (!Rs2GrandExchange.isOpen() && !Rs2Bank.isOpen()) {
                             Rs2GrandExchange.openExchange();
                             return;
                         }
-
-                        // Check interaction timeout first - reset ge window state if stuck
-                        long currentTime = System.currentTimeMillis();
-                        if (Rs2GrandExchange.isOfferScreenOpen() && (currentTime - lastActionTime > interactionTimeout)) {
-                            Rs2GrandExchange.backToOverview();
-
-                            lastActionTime = System.currentTimeMillis();
-                            actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
-                            interactionTimeout = Rs2Random.randomGaussian(DEFAULT_INTERACTION_TIMEOUT, INTERACTION_TIMEOUT_VARIANCE);
-
-                            log.info("interactionTimeout reached, returning to GE overview.");
-                            return;
-                        }
-
-						// Check for Copilot price/quantity messages in chat
-						if (checkAndPressCopilotKeybind()) return;
-
-                        // Check if we need to abort any offers
-                        if (checkAndAbortOrModifyIfNeeded()) return;
-
-                        // Check for highlighted widgets
-                        if (checkAndClickHighlightedWidgets()) return;
 
                         break;
                 }
@@ -219,6 +296,191 @@ public class FlipperScript extends Script {
 		return suggestionManager;
 	}
 
+	private boolean isOfferScreenOpen() {
+		return Rs2GrandExchange.isOfferScreenOpen() 
+			|| Rs2Widget.isWidgetVisible(30474266) 
+			|| Rs2Widget.isWidgetVisible(30474267);
+	}
+
+	private void backToOverview() {
+		log.info("Returning to GE overview.");
+		Rs2GrandExchange.backToOverview();
+		if (isOfferScreenOpen()) {
+			Rs2Widget.clickWidget(30474244);
+		}
+		sleepUntil(() -> !isOfferScreenOpen(), 2500);
+		offerScreenOpenTime = 0;
+		offerScreenActionCount = 0;
+		lastActionTime = System.currentTimeMillis();
+		actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+	}
+
+	private boolean hasChatboxInput() {
+		Widget inputWidget = Rs2Widget.getWidget(10616876);
+		if (inputWidget == null) inputWidget = Rs2Widget.getWidget(162, 44);
+		if (inputWidget != null) {
+			String text = inputWidget.getText();
+			if (text != null && !text.trim().isEmpty() && !text.trim().equals("*")) {
+				return true;
+			}
+		}
+		try {
+			String varcStr = Microbot.getClient().getVarcStrValue(359);
+			if (varcStr != null && !varcStr.trim().isEmpty() && !varcStr.trim().equals("*")) {
+				return true;
+			}
+		} catch (Exception ignored) {}
+		return false;
+	}
+
+	private KeyManager getKeyManager() {
+		if (keyManager != null) return keyManager;
+		try {
+			if (Microbot.getInjector() != null) {
+				keyManager = Microbot.getInjector().getInstance(KeyManager.class);
+			}
+		} catch (Exception e) {
+			log.warn("Could not get KeyManager: {}", e.getMessage());
+		}
+		return keyManager;
+	}
+
+	private static class ExtendedKeyEvent extends KeyEvent {
+		private final int extCode;
+
+		public ExtendedKeyEvent(Component source, int id, long when, int modifiers, int keyCode, char keyChar) {
+			super(source, id, when, modifiers, keyCode, keyChar);
+			this.extCode = keyCode;
+		}
+
+		@Override
+		public int getExtendedKeyCode() {
+			return extCode;
+		}
+	}
+
+	private void triggerCopilotQuickSet() {
+		int keyCode = KeyEvent.VK_E;
+		int modifiers = 0;
+		char keyChar = 'e';
+
+		// Retrieve configured hotkey from Flipping Copilot if available
+		if (flippingCopilot != null) {
+			try {
+				Field cfgField = flippingCopilot.getClass().getDeclaredField("config");
+				cfgField.setAccessible(true);
+				Object copilotConfig = cfgField.get(flippingCopilot);
+				if (copilotConfig != null) {
+					Method qkMethod = copilotConfig.getClass().getMethod("quickSetKeybind");
+					Object keybindObj = qkMethod.invoke(copilotConfig);
+					if (keybindObj instanceof net.runelite.client.config.Keybind) {
+						net.runelite.client.config.Keybind kb = (net.runelite.client.config.Keybind) keybindObj;
+						if (kb.getKeyCode() != KeyEvent.VK_UNDEFINED) {
+							keyCode = kb.getKeyCode();
+							modifiers = kb.getModifiers();
+							keyChar = Character.toLowerCase((char) keyCode);
+						}
+					}
+				}
+			} catch (Exception ignored) {}
+		}
+
+		Canvas canvas = Microbot.getClient().getCanvas();
+
+		// Dispatch ExtendedKeyEvent (with overridden getExtendedKeyCode) to KeyManager and Canvas
+		Component source = canvas != null ? canvas : new Canvas();
+		long now = System.currentTimeMillis();
+		ExtendedKeyEvent pressEvent = new ExtendedKeyEvent(source, KeyEvent.KEY_PRESSED, now, modifiers, keyCode, keyChar);
+		ExtendedKeyEvent releaseEvent = new ExtendedKeyEvent(source, KeyEvent.KEY_RELEASED, now + 30, modifiers, keyCode, keyChar);
+
+		KeyManager km = getKeyManager();
+		if (km != null) {
+			km.processKeyPressed(pressEvent);
+			km.processKeyReleased(releaseEvent);
+		}
+		if (canvas != null) {
+			canvas.dispatchEvent(pressEvent);
+			canvas.dispatchEvent(releaseEvent);
+		}
+
+		// 3. Trigger Copilot's handleKeybind on keyListener via ClientThread
+		if (flippingCopilot != null) {
+			try {
+				Field khField = flippingCopilot.getClass().getDeclaredField("keybindHandler");
+				khField.setAccessible(true);
+				Object keybindHandler = khField.get(flippingCopilot);
+				if (keybindHandler != null) {
+					Field klField = keybindHandler.getClass().getDeclaredField("keyListener");
+					klField.setAccessible(true);
+					Object keyListener = klField.get(keybindHandler);
+					if (keyListener != null) {
+						for (Method m : keyListener.getClass().getDeclaredMethods()) {
+							if (m.getName().equals("handleKeybind")) {
+								m.setAccessible(true);
+								Microbot.getClientThread().invokeLater(() -> {
+									try {
+										m.invoke(keyListener, true, false, false);
+									} catch (Exception ex) {
+										log.debug("handleKeybind invoke failed: {}", ex.getMessage());
+									}
+								});
+								break;
+							}
+						}
+					}
+				}
+			} catch (Exception e) {
+				log.debug("Could not trigger handleKeybind via reflection: {}", e.getMessage());
+			}
+		}
+	}
+
+	private void setCopilotChatboxValueDirectly(long val) {
+		if (val <= 0) return;
+
+		// 1. OfferHandler in keybindHandler
+		if (flippingCopilot != null) {
+			try {
+				Field khField = flippingCopilot.getClass().getDeclaredField("keybindHandler");
+				khField.setAccessible(true);
+				Object keybindHandler = khField.get(flippingCopilot);
+				if (keybindHandler != null) {
+					Field ohField = keybindHandler.getClass().getDeclaredField("offerHandler");
+					ohField.setAccessible(true);
+					Object offerHandler = ohField.get(keybindHandler);
+					if (offerHandler != null) {
+						for (Method m : offerHandler.getClass().getMethods()) {
+							if (m.getName().equals("setChatboxValue") && m.getParameterCount() == 1) {
+								final long v = val;
+								Microbot.getClientThread().invokeLater(() -> {
+									try {
+										m.invoke(offerHandler, v);
+									} catch (Exception ignored) {}
+								});
+								break;
+							}
+						}
+					}
+				}
+			} catch (Exception e) {
+				log.debug("Could not set chatbox value via offerHandler: {}", e.getMessage());
+			}
+		}
+
+		// 2. Direct client-thread update (identical to Copilot's OfferHandler.setChatboxValue)
+		final long finalVal = val;
+		Microbot.getClientThread().invokeLater(() -> {
+			try {
+				Widget widget = Microbot.getClient().getWidget(10616876);
+				if (widget == null) widget = Microbot.getClient().getWidget(162, 44);
+				if (widget != null) {
+					widget.setText(finalVal + "*");
+				}
+				Microbot.getClient().setVarcStrValue(359, String.valueOf(finalVal));
+			} catch (Exception ignored) {}
+		});
+	}
+
 	private Object getSuggestion(Object suggestionManager)
 	{
 		if (suggestionManager == null) return null;
@@ -290,7 +552,7 @@ public class FlipperScript extends Script {
 			}
 			catch (NoSuchFieldException e)
 			{
-				log.warn("Overlay {} does not have a widget field, skipping.", highlightOverlay.getClass().getSimpleName());
+				// Non-widget overlays like NpcHighlightOverlay are handled separately
 			}
 			catch (Exception e)
 			{
@@ -330,6 +592,7 @@ public class FlipperScript extends Script {
 
 	private boolean checkAndAbortOrModifyIfNeeded()
 	{
+		if (!Rs2GrandExchange.isOpen() || isOfferScreenOpen()) return false;
 		if (System.currentTimeMillis() - lastActionTime < actionCooldown) return false;
 
 		if (flippingCopilot == null || highlightController == null || suggestionManager == null) return false;
@@ -346,24 +609,62 @@ public class FlipperScript extends Script {
 
 			if (!isAbort && !isModify) return false;
 
-			log.info("Found suggestion type: {}.", isAbort ? "ABORT" : "MODIFY");
-
 			Widget abortWidget = getWidgetFromOverlay(highlightController, isAbort ? "abort" : "modify");
-			if (abortWidget != null)
+			if (abortWidget == null)
+			{
+				try {
+					Method getBoxIdMethod = currentSuggestion.getClass().getMethod("getBoxId");
+					int boxId = (Integer) getBoxIdMethod.invoke(currentSuggestion);
+					if (boxId >= 0 && boxId < grandExchangeSlotIds.length) {
+						abortWidget = Rs2Widget.getWidget(grandExchangeSlotIds[boxId]);
+					}
+				} catch (Exception ignored) {}
+			}
+			if (abortWidget != null && Rs2Widget.isWidgetVisible(abortWidget.getId()))
 			{	
-				NewMenuEntry menuEntry;
-				if (isModify)
-					menuEntry = new NewMenuEntry("Modify offer", "", 3, MenuAction.CC_OP, 2, abortWidget.getId(), false);
-				else
-					menuEntry = new NewMenuEntry("Abort offer", "", 2, MenuAction.CC_OP, 2, abortWidget.getId(), false);
-
-				Rectangle bounds = abortWidget.getBounds() != null && Rs2UiHelper.isRectangleWithinCanvas(abortWidget.getBounds())
-					? abortWidget.getBounds()
-					: Rs2UiHelper.getDefaultRectangle();
-				Microbot.doInvoke(menuEntry, bounds);
-				lastActionTime = System.currentTimeMillis();
-				actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
-				return true;
+				if (isAbort)
+				{
+					log.info("Executing suggestion ABORT: sending Abort offer on slot widget {}", abortWidget.getId());
+					NewMenuEntry abortEntry = new NewMenuEntry()
+						.option("Abort offer")
+						.target("")
+						.identifier(2)
+						.type(MenuAction.CC_OP)
+						.param0(2)
+						.param1(abortWidget.getId())
+						.itemId(-1)
+						.forceLeftClick(false);
+					Rectangle bounds = abortWidget.getBounds() != null && Rs2UiHelper.isRectangleWithinCanvas(abortWidget.getBounds())
+						? abortWidget.getBounds()
+						: Rs2UiHelper.getDefaultRectangle();
+					Microbot.doInvoke(abortEntry, bounds);
+					lastActionTime = System.currentTimeMillis();
+					actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+					return true;
+				}
+				else // isModify
+				{
+					log.info("Executing suggestion MODIFY: opening slot widget {}", abortWidget.getId());
+					Rs2Widget.clickWidget(abortWidget);
+					lastActionTime = System.currentTimeMillis();
+					actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+					return true;
+				}
+			}
+			else if (isAbort)
+			{
+				try {
+					Method getNameMethod = currentSuggestion.getClass().getMethod("getName");
+					String itemName = (String) getNameMethod.invoke(currentSuggestion);
+					if (itemName != null && !itemName.isEmpty()) {
+						log.info("Executing suggestion ABORT via Rs2GrandExchange.abortOffer for item '{}'", itemName);
+						if (Rs2GrandExchange.abortOffer(itemName, false)) {
+							lastActionTime = System.currentTimeMillis();
+							actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+							return true;
+						}
+					}
+				} catch (Exception ignored) {}
 			}
 		}
 		catch (Exception e)
@@ -378,11 +679,26 @@ public class FlipperScript extends Script {
         Widget copilotWidget = Rs2Widget.findWidget("Copilot item:", null, false);
         if (copilotWidget != null && Rs2Widget.isWidgetVisible(copilotWidget.getId())) {
 			log.info("Found chat widget Copilot item '{}'.", copilotWidget.getId());
-			/// 2. Press only Enter if found in scroll contents (selecting item)
-			Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
+			if (isMouseMode()) {
+				log.info("Selecting Copilot item via mouse click.");
+				Rs2Widget.clickWidget(copilotWidget);
+			} else {
+				log.info("Selecting Copilot item via hotkey (ENTER).");
+				Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
+			}
 			
-			/// As these widgets tend to disappear quickly sometimes, we sleep after we interact with it to select the suggested item
-			sleepUntil(() -> System.currentTimeMillis() - lastActionTime < actionCooldown);
+			// Wait for item selection widget to disappear (fallback to enter if still visible after mouse click)
+			if (!sleepUntil(() -> !Rs2Widget.isWidgetVisible(copilotWidget.getId()), 2000)) {
+				Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
+				if (!sleepUntil(() -> !Rs2Widget.isWidgetVisible(copilotWidget.getId()), 1500)) {
+					// Fallback to mouse click if ENTER failed
+					if (Rs2Widget.isWidgetVisible(copilotWidget.getId())) {
+						Rs2Widget.clickWidget(copilotWidget);
+						sleepUntil(() -> !Rs2Widget.isWidgetVisible(copilotWidget.getId()), 1500);
+					}
+				}
+			}
+			offerScreenActionCount++;
 			lastActionTime = System.currentTimeMillis();
 			actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
 			return true;
@@ -392,25 +708,113 @@ public class FlipperScript extends Script {
 
 		// If it's time to set price/quantity
 
-		Widget chatbox = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_LAYER);
-		if (chatbox == null) return false;
-		Widget copilotAction = Rs2Widget.findWidget("Set price", List.of(chatbox), true);
-		if (copilotAction == null) copilotAction = Rs2Widget.findWidget("Set quantity", List.of(chatbox), true);
-		if (copilotAction == null) return false;
+		Widget setPriceWidget = Rs2Widget.findWidget("Set a price for each item:", null, false);
+		Widget setQuantityWidget = Rs2Widget.findWidget("How many do you wish to ", null, false);
 
-		log.info("Using Copilot action widget '{}'.", copilotAction.getId());
-		Rs2Widget.clickWidget(copilotAction);
-		if (!sleepUntil(() -> {
-			Widget input = Rs2Widget.getWidget(InterfaceID.Chatbox.MES_TEXT2);
-			return input != null && input.getText() != null && input.getText().endsWith("*");
-		})) {
-			log.warn("Copilot did not populate the price/quantity input.");
+		boolean isPricePrompt = setPriceWidget != null && Rs2Widget.isWidgetVisible(setPriceWidget.getId());
+		boolean isQuantityPrompt = setQuantityWidget != null && Rs2Widget.isWidgetVisible(setQuantityWidget.getId());
+
+        if (isPricePrompt || isQuantityPrompt) {
+			Widget promptWidget = isPricePrompt ? setPriceWidget : setQuantityWidget;
+			log.info("Found chat widget ({}) '{}'.", isPricePrompt ? "price" : "quantity", promptWidget.getId());
+
+			// 1. First attempt: Click Copilot's prompt button if visible, or press hotkey
+			Widget copilotButton = Rs2Widget.findWidget("to set to Copilot", null, false);
+			boolean copilotButtonVisible = copilotButton != null && Rs2Widget.isWidgetVisible(copilotButton.getId());
+
+			// Parse the suggested value from button text if available (e.g. "Press [E] to set to Copilot price: 979 gp")
+			long valFromButton = -1;
+			if (copilotButton != null && copilotButton.getText() != null) {
+				String btnText = copilotButton.getText().replaceAll("[^0-9]", "");
+				if (!btnText.isEmpty()) {
+					try {
+						valFromButton = Long.parseLong(btnText);
+					} catch (Exception ignored) {}
+				}
+			}
+
+			if (isMouseMode()) {
+				if (copilotButtonVisible) {
+					log.info("Clicking Copilot prompt button '{}' via mouse.", copilotButton.getId());
+					Rs2Widget.clickWidget(copilotButton);
+				} else {
+					log.info("Copilot prompt button not visible, falling back to hotkey [E].");
+					triggerCopilotQuickSet();
+				}
+				sleepUntil(this::hasChatboxInput, 1500);
+			} else {
+				// Hotkey mode: Strictly use hotkey [E] without mouse clicks
+				log.info("Selecting Copilot suggestion via hotkey [E].");
+				triggerCopilotQuickSet();
+
+				// If hotkey didn't populate within 600ms, set directly via Copilot offerHandler without mouse
+				if (!sleepUntil(this::hasChatboxInput, 600)) {
+					if (valFromButton > 0) {
+						log.info("Setting chatbox value ({}) directly from Copilot suggestion without mouse.", valFromButton);
+						setCopilotChatboxValueDirectly(valFromButton);
+						sleepUntil(this::hasChatboxInput, 600);
+					}
+				}
+			}
+
+			// Fallback: If input is still not populated, extract suggestion value and set directly without typing
+			if (!hasChatboxInput()) {
+				long val = valFromButton;
+
+				// If not found from button text, check currentSuggestion (ensuring it matches the offer screen item)
+				if (val <= 0) {
+					Object currentSuggestion = getSuggestion(suggestionManager);
+					if (currentSuggestion != null) {
+						try {
+							int currentOfferItemId = Microbot.getClient().getVarpValue(1151);
+							Method getItemIdMethod = currentSuggestion.getClass().getMethod("getItemId");
+							int suggestionItemId = (Integer) getItemIdMethod.invoke(currentSuggestion);
+							if (currentOfferItemId <= 0 || currentOfferItemId == suggestionItemId) {
+								if (isPricePrompt) {
+									Method getPriceMethod = currentSuggestion.getClass().getMethod("getPrice");
+									val = (Long) getPriceMethod.invoke(currentSuggestion);
+								} else if (isQuantityPrompt) {
+									Method getQuantityMethod = currentSuggestion.getClass().getMethod("getQuantity");
+									val = (Integer) getQuantityMethod.invoke(currentSuggestion);
+								}
+							} else {
+								log.warn("Suggestion itemId ({}) does not match offer screen itemId ({})! Skipping suggestion value.",
+									suggestionItemId, currentOfferItemId);
+							}
+						} catch (Exception e) {
+							log.error("Failed to read suggestion value: {}", e.getMessage());
+						}
+					}
+				}
+
+				if (val > 0) {
+					log.info("Setting {} value directly on client thread: {}", isPricePrompt ? "price" : "quantity", val);
+					setCopilotChatboxValueDirectly(val);
+					sleepUntil(this::hasChatboxInput, 800);
+				}
+			}
+
+			// Check if chatbox input was successfully populated
+			if (!hasChatboxInput()) {
+				log.warn("Failed to populate {} input! Cancelling prompt and backing out to GE overview.",
+					isPricePrompt ? "price" : "quantity");
+				Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+				sleep(200, 400);
+				backToOverview();
+				return true;
+			}
+
+			// Submit the value
+			sleep(KEY_PRESS_DELAY_MIN, KEY_PRESS_DELAY_MAX);
+			Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
+			sleepUntil(() -> !Rs2Widget.isWidgetVisible(promptWidget.getId()), 2500);
+			offerScreenActionCount++;
+			lastActionTime = System.currentTimeMillis();
+			actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
 			return true;
-		}
-		Rs2Keyboard.keyPress(KeyEvent.VK_ENTER);
-		lastActionTime = System.currentTimeMillis();
-		actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
-		return true;
+        }
+
+		return false;
     }
 
     private boolean checkAndClickHighlightedWidgets()
@@ -426,16 +830,48 @@ public class FlipperScript extends Script {
 
 			if (isHighlightedVisible) {
 				log.info("Clicking highlighted widget: {}", highlightedWidget.getId());
+				// If GE close button is highlighted (container 30474242 or close button dynamic child)
+				if (highlightedWidget.getId() == 30474242 && Rs2GrandExchange.isOpen()) {
+					Rs2GrandExchange.closeExchange();
+					sleepUntil(() -> !Rs2GrandExchange.isOpen(), 2500);
+					lastActionTime = currentTime;
+					actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+					return true;
+				}
+				// If Bank close button is highlighted (container 786434 or close button dynamic child)
+				if (highlightedWidget.getId() == 786434 && Rs2Bank.isOpen()) {
+					Rs2Bank.closeBank();
+					sleepUntil(() -> !Rs2Bank.isOpen(), 2500);
+					lastActionTime = currentTime;
+					actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+					return true;
+				}
+				// If GE is on offer screen and has "Too much money!" warning, back out immediately
+				if (isOfferScreenOpen() && Rs2Widget.hasWidget("Too much money")) {
+					log.warn("Offer has 'Too much money!' error. Backing out to GE overview.");
+					backToOverview();
+					return true;
+				}
+
 				Rs2Widget.clickWidget(highlightedWidget);
 				Rs2Random.wait(100, 200);
 				lastActionTime = currentTime;
                 actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
 
-				// Sometimes, flipping copilot suggestions cost more than what's available in inventory, we should detect and avoid that
+				if (isOfferScreenOpen()) {
+					offerScreenActionCount++;
+				}
+
+				// If confirming an offer, dismiss any price warning dialog and wait for offer screen to close
 				String[] actions = highlightedWidget.getActions();
-				if (highlightedWidget.getText() != null && highlightedWidget.getText().contains("Confirm") || (actions != null && actions.length > 0 && actions[0].contains("Confirm"))) {
-					if (!sleepUntil(() -> !Rs2GrandExchange.isOfferScreenOpen())) {
-						Rs2GrandExchange.backToOverview();
+				boolean isConfirm = (highlightedWidget.getText() != null && highlightedWidget.getText().contains("Confirm"))
+					|| (actions != null && Arrays.stream(actions).filter(Objects::nonNull).anyMatch(a -> a.contains("Confirm")));
+				if (isConfirm) {
+					if (sleepUntil(() -> Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure"), 1000)) {
+						Rs2Widget.clickWidget("Yes");
+					}
+					if (!sleepUntil(() -> !isOfferScreenOpen(), 4000)) {
+						backToOverview();
 						return false;
 					}
 				}
@@ -448,6 +884,80 @@ public class FlipperScript extends Script {
 			log.error("Could not process highlight widgets: {} - ", e.getMessage(), e);
 		}
 
+		return false;
+	}
+
+	private boolean checkAndInteractHighlightedNpc()
+	{
+		if (Rs2GrandExchange.isOpen() || Rs2Bank.isOpen()) return false;
+		long currentTime = System.currentTimeMillis();
+		if (currentTime - lastActionTime < actionCooldown) return false;
+		if (flippingCopilot == null || highlightController == null) return false;
+
+		try {
+			List<Object> highlightOverlays = getHighlightOverlays(highlightController);
+			if (highlightOverlays == null) return false;
+
+			for (Object overlay : highlightOverlays) {
+				if (overlay != null && overlay.getClass().getSimpleName().contains("NpcHighlightOverlay")) {
+					Field npcField = overlay.getClass().getDeclaredField("npc");
+					npcField.setAccessible(true);
+					NPC npc = (NPC) npcField.get(overlay);
+					if (npc != null) {
+						String name = new Rs2NpcModel(npc).getName();
+						log.info("Found highlighted NPC: {}", name);
+						if (Rs2Npc.hasAction(npc.getId(), "Bank") || (name != null && name.toLowerCase().contains("bank"))) {
+							Rs2Npc.interact(npc, "Bank");
+							sleepUntil(Rs2Bank::isOpen, 3000);
+						} else {
+							Rs2Npc.interact(npc, "Exchange");
+							sleepUntil(Rs2GrandExchange::isOpen, 3000);
+						}
+						lastActionTime = currentTime;
+						actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+						return true;
+					}
+				}
+			}
+		} catch (Exception e) {
+			log.error("Could not interact with highlighted NPC: {}", e.getMessage());
+		}
+		return false;
+	}
+
+	private boolean handleBankIfNeeded()
+	{
+		if (!Rs2Bank.isOpen()) return false;
+
+		Object currentSuggestion = getSuggestion(suggestionManager);
+		if (currentSuggestion != null) {
+			try {
+				Method isSellMethod = currentSuggestion.getClass().getMethod("isSellSuggestion");
+				boolean isSell = (Boolean) isSellMethod.invoke(currentSuggestion);
+				if (isSell) {
+					Method getItemIdMethod = currentSuggestion.getClass().getMethod("getItemId");
+					int itemId = (Integer) getItemIdMethod.invoke(currentSuggestion);
+					Method getQuantityMethod = currentSuggestion.getClass().getMethod("getQuantity");
+					int qty = (Integer) getQuantityMethod.invoke(currentSuggestion);
+
+					int notedId = Rs2ItemModel.getNotedId(itemId);
+					if (Rs2Inventory.hasItem(itemId) && !Rs2Inventory.hasItem(notedId) && qty > 27) {
+						Rs2Bank.depositAll(itemId);
+						sleepUntil(() -> !Rs2Inventory.hasItem(itemId), 2000);
+					}
+					if (Rs2Bank.hasItem(itemId)) {
+						log.info("Withdrawing suggested item from bank: {} qty {}", itemId, qty);
+						Rs2Bank.withdrawX(true, itemId, qty);
+						sleepUntil(() -> Rs2Inventory.hasItem(itemId) || Rs2Inventory.hasItem(notedId), 2500);
+						Rs2Bank.closeBank();
+						sleepUntil(() -> !Rs2Bank.isOpen(), 2500);
+						return true;
+					}
+				}
+			} catch (Exception e) {
+				log.error("Could not handle bank suggestion: {}", e.getMessage());
+			}
+		}
 		return false;
 	}
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -112,7 +112,14 @@ public class FlipperScript extends Script {
                              state = State.MONITORING_COPILOT;
                              return;
                         }
-						WorldPoint playerLocation = Rs2Player.getWorldLocation();
+						WorldPoint playerLocation;
+						try {
+							playerLocation = Rs2Player.getWorldLocation();
+						} catch (Exception e) {
+							// localPlayer is not populated yet on the first ticks after login,
+							// so the call throws inside Rs2Player. Retry next tick.
+							return;
+						}
 						if (playerLocation == null) return;
                         if (!grandExchangeArea.contains(playerLocation)) {
                             Rs2GrandExchange.walkToGrandExchange();
@@ -1115,6 +1122,24 @@ public class FlipperScript extends Script {
 					if (!isSlotActionSwapEnabled()) {
 						log.info("Highlighted GE slot {} for abort with slotActionSwap=false; clicking slot to open offer screen.",
 							highlightedWidget.getId());
+					}
+				}
+
+				if (isConfirm) {
+					// Copilot rebuilds its highlight list every tick, so a target captured
+					// mid-tick can carry bounds that are stale by the time we act. Let the
+					// offer screen settle, re-verify the widget is still there, and re-read
+					// the click area so the click cannot land where the button used to be.
+					// This costs ~300ms per offer and only on the Confirm step.
+					sleep(250, 400);
+					if (!Rs2Widget.isWidgetVisible(highlightedWidget.getId())) {
+						log.info("Confirm target {} no longer visible; skipping stale highlight.",
+							highlightedWidget.getId());
+						return false;
+					}
+					Rectangle refreshedBounds = target.getClickBounds();
+					if (refreshedBounds != null) {
+						clickBounds = refreshedBounds;
 					}
 				}
 

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -112,12 +112,18 @@ public class FlipperScript extends Script {
                              state = State.MONITORING_COPILOT;
                              return;
                         }
+						// The script can tick before the player object exists (the first
+						// moments after login). Calling into Rs2Player then throws inside
+						// ClientThread, which logs an ERROR even when the caller catches it,
+						// so wait for the player to exist before asking for its location.
+						if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
+							return;
+						}
 						WorldPoint playerLocation;
 						try {
 							playerLocation = Rs2Player.getWorldLocation();
 						} catch (Exception e) {
-							// localPlayer is not populated yet on the first ticks after login,
-							// so the call throws inside Rs2Player. Retry next tick.
+							// Backstop for other transient player states; retry next tick.
 							return;
 						}
 						if (playerLocation == null) return;

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -211,8 +211,14 @@ public class FlipperScript extends Script {
 								} catch (Exception ignored) {}
 							}
 
-							// If stuck on offer screen for > 30 seconds or after 10 repeated actions without closing
-							if (currentTime - offerScreenOpenTime > 30000 || offerScreenActionCount >= 10) {
+							// If nothing at all has been actioned on the open offer screen, the
+							// script is waiting on Copilot rather than making progress. Seen when
+							// Copilot flips its suggestion to COLLECT while the offer screen is
+							// open: Collect is a GE-overview action, so no highlight on the offer
+							// screen can ever match it. Recover in 10s instead of holding the
+							// screen (and the offer slot) for the full 30s.
+							long stuckLimitMs = offerScreenActionCount == 0 ? 10000 : 30000;
+							if (currentTime - offerScreenOpenTime > stuckLimitMs || offerScreenActionCount >= 10) {
 								log.warn("Offer screen stuck (openTime={}ms, actions={}). Backing out to GE overview.",
 									currentTime - offerScreenOpenTime, offerScreenActionCount);
 								backToOverview();

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -20,7 +20,6 @@ import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
-import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
 import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
 import net.runelite.client.plugins.microbot.util.math.Rs2Random;
 import net.runelite.client.plugins.microbot.util.menu.NewMenuEntry;
@@ -191,8 +190,12 @@ public class FlipperScript extends Script {
 							offerScreenActionCount = 0;
 						}
 
-                        // 1. If bank is open, handle bank withdrawals
-                        if (handleBankIfNeeded()) return;
+                        // 1. If bank is open, close it (only coins are handled from bank at startup)
+                        if (Rs2Bank.isOpen()) {
+                            Rs2Bank.closeBank();
+                            sleepUntil(() -> !Rs2Bank.isOpen(), 2500);
+                            return;
+                        }
 
 						// 2. Check for Copilot price/quantity messages in chat
 						if (checkAndPressCopilotKeybind()) return;
@@ -903,16 +906,11 @@ public class FlipperScript extends Script {
 					Field npcField = overlay.getClass().getDeclaredField("npc");
 					npcField.setAccessible(true);
 					NPC npc = (NPC) npcField.get(overlay);
-					if (npc != null) {
+					if (npc != null && Rs2Npc.hasAction(npc.getId(), "Exchange")) {
 						String name = new Rs2NpcModel(npc).getName();
-						log.info("Found highlighted NPC: {}", name);
-						if (Rs2Npc.hasAction(npc.getId(), "Bank") || (name != null && name.toLowerCase().contains("bank"))) {
-							Rs2Npc.interact(npc, "Bank");
-							sleepUntil(Rs2Bank::isOpen, 3000);
-						} else {
-							Rs2Npc.interact(npc, "Exchange");
-							sleepUntil(Rs2GrandExchange::isOpen, 3000);
-						}
+						log.info("Found highlighted GE NPC: {}", name);
+						Rs2Npc.interact(npc, "Exchange");
+						sleepUntil(Rs2GrandExchange::isOpen, 3000);
 						lastActionTime = currentTime;
 						actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
 						return true;
@@ -921,42 +919,6 @@ public class FlipperScript extends Script {
 			}
 		} catch (Exception e) {
 			log.error("Could not interact with highlighted NPC: {}", e.getMessage());
-		}
-		return false;
-	}
-
-	private boolean handleBankIfNeeded()
-	{
-		if (!Rs2Bank.isOpen()) return false;
-
-		Object currentSuggestion = getSuggestion(suggestionManager);
-		if (currentSuggestion != null) {
-			try {
-				Method isSellMethod = currentSuggestion.getClass().getMethod("isSellSuggestion");
-				boolean isSell = (Boolean) isSellMethod.invoke(currentSuggestion);
-				if (isSell) {
-					Method getItemIdMethod = currentSuggestion.getClass().getMethod("getItemId");
-					int itemId = (Integer) getItemIdMethod.invoke(currentSuggestion);
-					Method getQuantityMethod = currentSuggestion.getClass().getMethod("getQuantity");
-					int qty = (Integer) getQuantityMethod.invoke(currentSuggestion);
-
-					int notedId = Rs2ItemModel.getNotedId(itemId);
-					if (Rs2Inventory.hasItem(itemId) && !Rs2Inventory.hasItem(notedId) && qty > 27) {
-						Rs2Bank.depositAll(itemId);
-						sleepUntil(() -> !Rs2Inventory.hasItem(itemId), 2000);
-					}
-					if (Rs2Bank.hasItem(itemId)) {
-						log.info("Withdrawing suggested item from bank: {} qty {}", itemId, qty);
-						Rs2Bank.withdrawX(true, itemId, qty);
-						sleepUntil(() -> Rs2Inventory.hasItem(itemId) || Rs2Inventory.hasItem(notedId), 2500);
-						Rs2Bank.closeBank();
-						sleepUntil(() -> !Rs2Bank.isOpen(), 2500);
-						return true;
-					}
-				}
-			} catch (Exception e) {
-				log.error("Could not handle bank suggestion: {}", e.getMessage());
-			}
 		}
 		return false;
 	}

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -726,6 +726,14 @@ public class FlipperScript extends Script {
 				}
 			}
 			if (relativeBounds != null && relativeBounds.width >= 120 && relativeBounds.height >= 30) {
+				// Size alone does not identify the Confirm button: Copilot also highlights
+				// wide chatbox widgets, and clicking one of those instead of Confirm leaves
+				// the offer screen open until it times out ("offer screen did not close
+				// after confirm"). The GE Confirm button lives on the offer screen
+				// interface, so require that before trusting the size heuristic.
+				if (widget == null || (widget.getId() >> 16) != InterfaceID.GE_OFFERS) {
+					return false;
+				}
 				return true;
 			}
 			return false;

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -52,6 +52,9 @@ public class FlipperScript extends Script {
 	private static final int INTERACTION_TIMEOUT_VARIANCE = 11000;
 	private static final int INVENTORY_WAIT_TIMEOUT = 5000;
 	private static final int SCHEDULE_INTERVAL_MS = 600;
+	// A closed exchange or a stray GE page used to stall this state machine silently.
+	private static final int GE_CLOSED_RECOVER_MS = 4000;
+	private static final int STRAY_PAGE_RECOVER_MS = 8000;
 	private static final int KEY_PRESS_DELAY_MIN = 250;
 	private static final int KEY_PRESS_DELAY_MAX = 400;
 
@@ -66,6 +69,8 @@ public class FlipperScript extends Script {
 	private long interactionTimeout = DEFAULT_INTERACTION_TIMEOUT;
 	private long offerScreenOpenTime = 0;
 	private int offerScreenActionCount = 0;
+	private long geClosedSince = 0;
+	private long strayPageSince = 0;
 
 	private int[] grandExchangeSlotIds = new int[] {
 		InterfaceID.GeOffers.INDEX_0,
@@ -151,7 +156,53 @@ public class FlipperScript extends Script {
                     case MONITORING_COPILOT:
 						long currentTime = System.currentTimeMillis();
 
-						// 0. Offer screen watchdog & loop detection
+						// 0a. Grand Exchange watchdog: this state had no way back from a closed
+						// exchange - GOING_TO_GE was only set on shutdown/startup - so a closed or
+						// hidden GE stalled the bot indefinitely and silently. Reopen it directly.
+						if (!Rs2GrandExchange.isOpen() && !Rs2Bank.isOpen()) {
+							if (geClosedSince == 0) {
+								geClosedSince = currentTime;
+							} else if (currentTime - geClosedSince > GE_CLOSED_RECOVER_MS) {
+								long closedFor = currentTime - geClosedSince;
+								geClosedSince = 0;
+								log.info("Grand Exchange closed for {}ms while running; reopening it.", closedFor);
+								if (!Rs2GrandExchange.openExchange()) {
+									log.info("Exchange could not be opened from here; walking to the Grand Exchange.");
+									state = State.GOING_TO_GE;
+								} else {
+									sleepUntil(Rs2GrandExchange::isOpen, 3000);
+								}
+								lastActionTime = System.currentTimeMillis();
+								actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+								return;
+							}
+						} else {
+							geClosedSince = 0;
+						}
+
+						// 0b. Stray GE page watchdog: a mistimed click can open a GE info page
+						// (for example the Convenience Fees text) which hides the offer list.
+						// Nothing on that page is actionable, Copilot highlights nothing, and the
+						// script would otherwise idle silently forever. Escape back to the list.
+						if (Rs2GrandExchange.isOpen() && !isOfferScreenOpen()
+							&& !Rs2Widget.hasWidget("Select an offer slot")) {
+							if (strayPageSince == 0) {
+								strayPageSince = currentTime;
+							} else if (currentTime - strayPageSince > STRAY_PAGE_RECOVER_MS) {
+								long strayFor = currentTime - strayPageSince;
+								strayPageSince = 0;
+								log.info("GE is showing a non-offer page for {}ms; escaping back to the offer list.", strayFor);
+								Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
+								sleep(300, 600);
+								lastActionTime = System.currentTimeMillis();
+								actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+								return;
+							}
+						} else {
+							strayPageSince = 0;
+						}
+
+							// 0. Offer screen watchdog & loop detection
 						if (isOfferScreenOpen()) {
 							if (offerScreenOpenTime == 0) {
 								offerScreenOpenTime = currentTime;

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -369,6 +369,9 @@ public class FlipperScript extends Script {
 
 	public void ensureSlotActionSwapEnabled() {
 		try {
+			if (config != null && !config.autoEnableSlotSwap()) {
+				return;
+			}
 			if (Microbot.getConfigManager() != null) {
 				String val = Microbot.getConfigManager().getConfiguration("flippingcopilot", "slotActionSwap");
 				if (!"true".equalsIgnoreCase(val)) {

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -159,7 +159,7 @@ public class FlipperScript extends Script {
 									if (currentSuggestion != null) {
 										Method isAbortMethod = currentSuggestion.getClass().getMethod("isAbortSuggestion");
 										if ((Boolean) isAbortMethod.invoke(currentSuggestion)) {
-											Widget abortBtn = getOfferScreenAbortButton();
+											Widget abortBtn = waitForOfferScreenAbortButton(2000);
 											if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
 												log.info("Aborting offer via offer screen button '{}'", abortBtn.getId());
 												Rs2Widget.clickWidget(abortBtn);
@@ -181,6 +181,10 @@ public class FlipperScript extends Script {
 												String statusText = statusWidget != null ? statusWidget.getText() : "";
 												if (statusText != null && (statusText.toLowerCase().contains("cancelled") || statusText.toLowerCase().contains("aborted"))) {
 													log.info("Offer already cancelled on offer screen. Returning to overview.");
+												} else if (isAbortSuggestionSettled(currentSuggestion)) {
+													// Copilot drops the abort suggestion as soon as the abort
+													// registers, so a changed suggestion means the work is done.
+													log.info("Abort suggestion already satisfied; no abort button needed. Returning to overview.");
 												} else {
 													log.warn("Abort button not found on offer screen. Returning to overview.");
 												}
@@ -449,6 +453,39 @@ public class FlipperScript extends Script {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Poll for the abort button instead of checking once. The GE details screen renders a
+	 * tick or two after the slot click, so a single instant lookup reports a false
+	 * "button not found" and the script backs out of a screen it could have used.
+	 */
+	private Widget waitForOfferScreenAbortButton(long timeoutMs) {
+		long deadline = System.currentTimeMillis() + timeoutMs;
+		Widget btn = getOfferScreenAbortButton();
+		while (btn == null && System.currentTimeMillis() < deadline) {
+			sleep(100, 200);
+			btn = getOfferScreenAbortButton();
+		}
+		return btn;
+	}
+
+	/**
+	 * True when Copilot has already moved past the abort we were asked to perform.
+	 * Copilot drops the abort suggestion as soon as the abort registers, so if the
+	 * current suggestion is no longer an abort there is nothing left to click and the
+	 * missing button is expected - not a fault worth warning about.
+	 */
+	private boolean isAbortSuggestionSettled(Object previousSuggestion) {
+		if (suggestionManager == null) return false;
+		try {
+			Object current = getSuggestion(suggestionManager);
+			if (current == null) return true;
+			Method isAbortMethod = current.getClass().getMethod("isAbortSuggestion");
+			return !((Boolean) isAbortMethod.invoke(current));
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	private boolean hasChatboxInput() {
@@ -1093,11 +1130,30 @@ public class FlipperScript extends Script {
 				// If confirming an offer, dismiss any price warning dialog and wait for offer screen to close
 				if (isConfirm) {
 					log.info("Clicked Confirm button. Checking for warning dialog or waiting for offer screen to close...");
-					if (sleepUntil(() -> Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure"), 1200)) {
-						log.info("Warning dialog appeared ('Your offer is much' / 'Are you sure'). Confirming 'Yes'...");
-						Rs2Widget.clickWidget("Yes");
+					// The price warning dialog can appear later than the first check. Keep
+					// looking for it for the whole wait: if it is left on screen the offer
+					// screen never closes and the offer is abandoned.
+					long confirmDeadline = System.currentTimeMillis() + 6000;
+					boolean offerScreenClosed = false;
+					while (System.currentTimeMillis() < confirmDeadline) {
+						if (Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure")) {
+							log.info("Warning dialog appeared ('Your offer is much' / 'Are you sure'). Confirming 'Yes'...");
+							Rs2Widget.clickWidget("Yes");
+							sleep(300, 500);
+							continue;
+						}
+						if (!isOfferScreenOpen()) {
+							offerScreenClosed = true;
+							break;
+						}
+						sleep(100, 200);
 					}
-					if (!sleepUntil(() -> !isOfferScreenOpen(), 4000)) {
+					if (!offerScreenClosed && (Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure"))) {
+						log.info("Warning dialog still open at timeout; confirming 'Yes' and rechecking.");
+						Rs2Widget.clickWidget("Yes");
+						offerScreenClosed = sleepUntil(() -> !isOfferScreenOpen(), 2000);
+					}
+					if (!offerScreenClosed) {
 						log.warn("Offer screen did not close after confirm. Backing out to overview.");
 						backToOverview();
 						return false;

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -1,7 +1,6 @@
 package net.runelite.client.plugins.microbot.geflipper;
 
 import com.google.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.MenuAction;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldArea;
@@ -45,8 +44,8 @@ enum State {
     MONITORING_COPILOT
 }
 
-@Slf4j
 public class FlipperScript extends Script {
+	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FlipperScript.class);
 	private static final int DEFAULT_ACTION_COOLDOWN = 1200;
 	private static final int ACTION_COOLDOWN_VARIANCE = 600;
 	private static final int DEFAULT_INTERACTION_TIMEOUT = 33000;
@@ -153,21 +152,38 @@ public class FlipperScript extends Script {
 								return;
 							}
 
-							// If on offer screen and Copilot suggests ABORT, abort or back out immediately
+							// If on offer screen and Copilot suggests ABORT, abort via offer screen button
 							if (suggestionManager != null) {
 								try {
 									Object currentSuggestion = getSuggestion(suggestionManager);
 									if (currentSuggestion != null) {
 										Method isAbortMethod = currentSuggestion.getClass().getMethod("isAbortSuggestion");
 										if ((Boolean) isAbortMethod.invoke(currentSuggestion)) {
-											Widget abortBtn = Rs2Widget.findWidget("Abort offer");
+											Widget abortBtn = getOfferScreenAbortButton();
 											if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
 												log.info("Aborting offer via offer screen button '{}'", abortBtn.getId());
 												Rs2Widget.clickWidget(abortBtn);
-												sleep(200, 400);
+												sleep(300, 500);
+
+												// Check for confirmation dialog ('Are you sure...')
+												if (sleepUntil(() -> Rs2Widget.hasWidget("Are you sure") || Rs2Widget.hasWidget("Your offer is much"), 1200)) {
+													log.info("Abort confirmation dialog detected. Confirming 'Yes'...");
+													Rs2Widget.clickWidget("Yes");
+													sleep(200, 400);
+												}
+
+												// Wait for abort to register, then back to overview
+												sleepUntil(() -> !isOfferScreenOpen() || getOfferScreenAbortButton() == null, 2500);
 												backToOverview();
 											} else {
-												log.info("Abort suggested while on offer screen - backing out to overview.");
+												// Check if already aborted / cancelled on offer screen
+												Widget statusWidget = Rs2Widget.getWidget(InterfaceID.GeOffers.DETAILS_STATUS);
+												String statusText = statusWidget != null ? statusWidget.getText() : "";
+												if (statusText != null && (statusText.toLowerCase().contains("cancelled") || statusText.toLowerCase().contains("aborted"))) {
+													log.info("Offer already cancelled on offer screen. Returning to overview.");
+												} else {
+													log.warn("Abort button not found on offer screen. Returning to overview.");
+												}
 												backToOverview();
 											}
 											lastActionTime = currentTime;
@@ -316,6 +332,99 @@ public class FlipperScript extends Script {
 		offerScreenActionCount = 0;
 		lastActionTime = System.currentTimeMillis();
 		actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+	}
+
+	public boolean isSlotActionSwapEnabled() {
+		if (flippingCopilot != null) {
+			try {
+				Field cfgField = flippingCopilot.getClass().getDeclaredField("config");
+				cfgField.setAccessible(true);
+				Object copilotConfig = cfgField.get(flippingCopilot);
+				if (copilotConfig != null) {
+					Method m = copilotConfig.getClass().getMethod("slotActionSwap");
+					Object val = m.invoke(copilotConfig);
+					if (val instanceof Boolean) {
+						return (Boolean) val;
+					}
+				}
+			} catch (Exception ignored) {}
+		}
+		try {
+			if (Microbot.getConfigManager() != null) {
+				String val = Microbot.getConfigManager().getConfiguration("flippingcopilot", "slotActionSwap");
+				if (val != null) {
+					return Boolean.parseBoolean(val);
+				}
+			}
+		} catch (Exception ignored) {}
+		return true;
+	}
+
+	private Widget getOfferScreenAbortButton() {
+		// 1. Direct widget ID for abort button on GE offer details screen (Interface 465, child 22 / DETAILS_GRAPHIC6)
+		Widget abortBtn = Rs2Widget.getWidget(InterfaceID.GeOffers.DETAILS_GRAPHIC6);
+		if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
+			return abortBtn;
+		}
+		abortBtn = Rs2Widget.getWidget(InterfaceID.GE_OFFERS, 22);
+		if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
+			return abortBtn;
+		}
+
+		// 2. Search for any widget within GE_OFFERS with an "Abort" action
+		try {
+			java.util.Map<Widget, String> actionWidgets = Rs2Widget.findWidgetsWithAction("Abort", InterfaceID.GE_OFFERS, false);
+			if (actionWidgets != null && !actionWidgets.isEmpty()) {
+				for (Widget w : actionWidgets.keySet()) {
+					if (w != null && Rs2Widget.isWidgetVisible(w.getId())) {
+						return w;
+					}
+				}
+			}
+		} catch (Exception ignored) {}
+
+		// 3. Search children of DETAILS container (InterfaceID.GeOffers.DETAILS)
+		try {
+			Widget detailsContainer = Rs2Widget.getWidget(InterfaceID.GeOffers.DETAILS);
+			if (detailsContainer != null) {
+				Widget[] children = detailsContainer.getChildren();
+				if (children != null) {
+					for (Widget child : children) {
+						if (child != null && Rs2Widget.isWidgetVisible(child.getId()) && child.getActions() != null) {
+							for (String action : child.getActions()) {
+								if (action != null && action.toLowerCase().contains("abort")) {
+									return child;
+								}
+							}
+						}
+					}
+				}
+				Widget[] dynamicChildren = detailsContainer.getDynamicChildren();
+				if (dynamicChildren != null) {
+					for (Widget child : dynamicChildren) {
+						if (child != null && Rs2Widget.isWidgetVisible(child.getId()) && child.getActions() != null) {
+							for (String action : child.getActions()) {
+								if (action != null && action.toLowerCase().contains("abort")) {
+									return child;
+								}
+							}
+						}
+					}
+				}
+			}
+		} catch (Exception ignored) {}
+
+		// 4. Search by widget text as final fallback
+		abortBtn = Rs2Widget.findWidget("Abort offer");
+		if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
+			return abortBtn;
+		}
+		abortBtn = Rs2Widget.findWidget("Abort");
+		if (abortBtn != null && Rs2Widget.isWidgetVisible(abortBtn.getId())) {
+			return abortBtn;
+		}
+
+		return null;
 	}
 
 	private boolean hasChatboxInput() {
@@ -660,20 +769,32 @@ public class FlipperScript extends Script {
 			{	
 				if (isAbort)
 				{
-					log.info("Executing suggestion ABORT: sending Abort offer on slot widget {}", abortWidget.getId());
-					NewMenuEntry abortEntry = new NewMenuEntry()
-						.option("Abort offer")
-						.target("")
-						.identifier(2)
-						.type(MenuAction.CC_OP)
-						.param0(2)
-						.param1(abortWidget.getId())
-						.itemId(-1)
-						.forceLeftClick(false);
-					Rectangle bounds = abortWidget.getBounds() != null && Rs2UiHelper.isRectangleWithinCanvas(abortWidget.getBounds())
-						? abortWidget.getBounds()
-						: Rs2UiHelper.getDefaultRectangle();
-					Microbot.doInvoke(abortEntry, bounds);
+					boolean slotActionSwap = isSlotActionSwapEnabled();
+					log.info("Executing suggestion ABORT on slot widget {} (slotActionSwap={})", abortWidget.getId(), slotActionSwap);
+					if (slotActionSwap)
+					{
+						NewMenuEntry abortEntry = new NewMenuEntry()
+							.option("Abort offer")
+							.target("")
+							.identifier(2)
+							.type(MenuAction.CC_OP)
+							.param0(2)
+							.param1(abortWidget.getId())
+							.itemId(-1)
+							.forceLeftClick(false);
+						Rectangle bounds = abortWidget.getBounds() != null && Rs2UiHelper.isRectangleWithinCanvas(abortWidget.getBounds())
+							? abortWidget.getBounds()
+							: Rs2UiHelper.getDefaultRectangle();
+						Microbot.doInvoke(abortEntry, bounds);
+					}
+					else
+					{
+						// When slotActionSwap is OFF, left-clicking the slot widget in OSRS opens "View offer".
+						// We open the offer screen and let getOfferScreenAbortButton perform the abort reliably.
+						log.info("slotActionSwap is disabled: opening slot widget {} to abort from offer screen.", abortWidget.getId());
+						Rs2Widget.clickWidget(abortWidget);
+						sleepUntil(this::isOfferScreenOpen, 2500);
+					}
 					lastActionTime = System.currentTimeMillis();
 					actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
 					return true;
@@ -908,6 +1029,22 @@ public class FlipperScript extends Script {
 
 				boolean isConfirm = target.isConfirmTarget();
 
+				boolean isSlotWidget = Arrays.stream(grandExchangeSlotIds).anyMatch(id -> id == highlightedWidget.getId());
+				boolean isAbortOnSlot = false;
+				if (isSlotWidget && suggestionManager != null) {
+					try {
+						Object currentSuggestion = getSuggestion(suggestionManager);
+						if (currentSuggestion != null) {
+							Method isAbortMethod = currentSuggestion.getClass().getMethod("isAbortSuggestion");
+							isAbortOnSlot = (Boolean) isAbortMethod.invoke(currentSuggestion);
+						}
+					} catch (Exception ignored) {}
+				}
+				if (isAbortOnSlot && !isSlotActionSwapEnabled()) {
+					log.info("Highlighted GE slot {} for abort with slotActionSwap=false; clicking slot to open offer screen.",
+						highlightedWidget.getId());
+				}
+
 				if (clickBounds != null && Rs2UiHelper.isRectangleWithinCanvas(clickBounds)) {
 					Microbot.getMouse().click(clickBounds);
 				} else {
@@ -916,6 +1053,10 @@ public class FlipperScript extends Script {
 				Rs2Random.wait(100, 200);
 				lastActionTime = currentTime;
 				actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+
+				if (isAbortOnSlot && !isSlotActionSwapEnabled()) {
+					sleepUntil(this::isOfferScreenOpen, 2500);
+				}
 
 				if (isOfferScreenOpen()) {
 					offerScreenActionCount++;

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -254,13 +254,20 @@ public class FlipperScript extends Script {
 
 	private boolean initialize()
 	{
-		if (flippingCopilot != null && suggestionManager != null && highlightController != null) return true;
+		if (flippingCopilot != null && suggestionManager != null && highlightController != null) {
+			ensureSlotActionSwapEnabled();
+			return true;
+		}
 
 		Plugin _flippingCopilot = getFlippingCopilot();
 		Object _suggestionManager = getSuggestionManager(_flippingCopilot);
 		Object _highlightController = getHighlightController(_flippingCopilot);
 
-		return _flippingCopilot != null && _suggestionManager != null && _highlightController != null;
+		if (_flippingCopilot != null && _suggestionManager != null && _highlightController != null) {
+			ensureSlotActionSwapEnabled();
+			return true;
+		}
+		return false;
 	}
 
 	private Plugin getFlippingCopilot()
@@ -358,6 +365,20 @@ public class FlipperScript extends Script {
 			}
 		} catch (Exception ignored) {}
 		return true;
+	}
+
+	public void ensureSlotActionSwapEnabled() {
+		try {
+			if (Microbot.getConfigManager() != null) {
+				String val = Microbot.getConfigManager().getConfiguration("flippingcopilot", "slotActionSwap");
+				if (!"true".equalsIgnoreCase(val)) {
+					log.info("Flipping Copilot 'slotActionSwap' is disabled; automatically enabling it in ConfigManager.");
+					Microbot.getConfigManager().setConfiguration("flippingcopilot", "slotActionSwap", true);
+				}
+			}
+		} catch (Exception e) {
+			log.warn("Failed to set flippingcopilot slotActionSwap setting: {}", e.getMessage());
+		}
 	}
 
 	private Widget getOfferScreenAbortButton() {
@@ -769,6 +790,7 @@ public class FlipperScript extends Script {
 			{	
 				if (isAbort)
 				{
+					ensureSlotActionSwapEnabled();
 					boolean slotActionSwap = isSlotActionSwapEnabled();
 					log.info("Executing suggestion ABORT on slot widget {} (slotActionSwap={})", abortWidget.getId(), slotActionSwap);
 					if (slotActionSwap)
@@ -1040,9 +1062,12 @@ public class FlipperScript extends Script {
 						}
 					} catch (Exception ignored) {}
 				}
-				if (isAbortOnSlot && !isSlotActionSwapEnabled()) {
-					log.info("Highlighted GE slot {} for abort with slotActionSwap=false; clicking slot to open offer screen.",
-						highlightedWidget.getId());
+				if (isAbortOnSlot) {
+					ensureSlotActionSwapEnabled();
+					if (!isSlotActionSwapEnabled()) {
+						log.info("Highlighted GE slot {} for abort with slotActionSwap=false; clicking slot to open offer screen.",
+							highlightedWidget.getId());
+					}
 				}
 
 				if (clickBounds != null && Rs2UiHelper.isRectangleWithinCanvas(clickBounds)) {

--- a/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/geflipper/FlipperScript.java
@@ -460,7 +460,7 @@ public class FlipperScript extends Script {
 										m.invoke(offerHandler, v);
 									} catch (Exception ignored) {}
 								});
-								break;
+								return;
 							}
 						}
 					}
@@ -469,19 +469,6 @@ public class FlipperScript extends Script {
 				log.debug("Could not set chatbox value via offerHandler: {}", e.getMessage());
 			}
 		}
-
-		// 2. Direct client-thread update (identical to Copilot's OfferHandler.setChatboxValue)
-		final long finalVal = val;
-		Microbot.getClientThread().invokeLater(() -> {
-			try {
-				Widget widget = Microbot.getClient().getWidget(10616876);
-				if (widget == null) widget = Microbot.getClient().getWidget(162, 44);
-				if (widget != null) {
-					widget.setText(finalVal + "*");
-				}
-				Microbot.getClient().setVarcStrValue(359, String.valueOf(finalVal));
-			} catch (Exception ignored) {}
-		});
 	}
 
 	private Object getSuggestion(Object suggestionManager)
@@ -534,63 +521,109 @@ public class FlipperScript extends Script {
 		}
 	}
 
-	private List<Widget> getHighlightWidgets(Object highlightController)
-	{
-		final List<Widget> highlightWidgets = new ArrayList<>();
-		if (highlightController == null)
-		{
-			return highlightWidgets;
+	public static class HighlightTarget {
+		private final Widget widget;
+		private final Rectangle relativeBounds;
+
+		public HighlightTarget(Widget widget, Rectangle relativeBounds) {
+			this.widget = widget;
+			this.relativeBounds = relativeBounds;
 		}
 
-		List<Object> highlightOverlays = getHighlightOverlays(highlightController);
-		if (highlightOverlays == null) return highlightWidgets;
+		public Widget getWidget() {
+			return widget;
+		}
 
-		for (Object highlightOverlay : highlightOverlays)
-		{
-			try
-			{
+		public Rectangle getRelativeBounds() {
+			return relativeBounds;
+		}
+
+		public Rectangle getClickBounds() {
+			if (widget == null) return null;
+			Rectangle b = widget.getBounds();
+			if (b == null) return null;
+			if (relativeBounds == null) return b;
+			return new Rectangle(b.x + relativeBounds.x, b.y + relativeBounds.y, relativeBounds.width, relativeBounds.height);
+		}
+
+		public boolean isConfirmTarget() {
+			if (widget != null) {
+				String text = widget.getText();
+				if (text != null && text.contains("Confirm")) return true;
+				String[] actions = widget.getActions();
+				if (actions != null && Arrays.stream(actions).filter(Objects::nonNull).anyMatch(a -> a.contains("Confirm"))) {
+					return true;
+				}
+			}
+			if (relativeBounds != null && relativeBounds.width >= 120 && relativeBounds.height >= 30) {
+				return true;
+			}
+			return false;
+		}
+	}
+
+	private List<HighlightTarget> getHighlightTargets(Object highlightController) {
+		List<HighlightTarget> targets = new ArrayList<>();
+		if (highlightController == null) return targets;
+		List<Object> highlightOverlays = getHighlightOverlays(highlightController);
+		if (highlightOverlays == null) return targets;
+
+		for (Object highlightOverlay : highlightOverlays) {
+			if (highlightOverlay == null) continue;
+			try {
 				Field widgetField = highlightOverlay.getClass().getDeclaredField("widget");
 				widgetField.setAccessible(true);
-				highlightWidgets.add((Widget) widgetField.get(highlightOverlay));
-			}
-			catch (NoSuchFieldException e)
-			{
-				// Non-widget overlays like NpcHighlightOverlay are handled separately
-			}
-			catch (Exception e)
-			{
-				log.error("Could not get widget from overlay: {} - ", e.getMessage(), e);
+				Widget widget = (Widget) widgetField.get(highlightOverlay);
+				if (widget == null) continue;
+
+				Rectangle relativeBounds = null;
+				try {
+					Field relBoundsField = highlightOverlay.getClass().getDeclaredField("relativeBounds");
+					relBoundsField.setAccessible(true);
+					relativeBounds = (Rectangle) relBoundsField.get(highlightOverlay);
+				} catch (NoSuchFieldException ignored) {}
+
+				targets.add(new HighlightTarget(widget, relativeBounds));
+			} catch (NoSuchFieldException ignored) {
+			} catch (Exception e) {
+				log.error("Could not get target from overlay: {} - ", e.getMessage(), e);
 			}
 		}
+		return targets;
+	}
 
+	private HighlightTarget getTargetFromOverlay(Object highlightController, String suggestionType) {
+		List<HighlightTarget> targets = getHighlightTargets(highlightController);
+		if (targets.isEmpty()) return null;
+
+		if (Objects.equals(suggestionType, "abort") || Objects.equals(suggestionType, "modify")) {
+			return targets.stream()
+				.filter(t -> t.getWidget() != null)
+				.filter(t -> Arrays.stream(grandExchangeSlotIds).anyMatch(id -> id == t.getWidget().getId()))
+				.findFirst()
+				.orElse(null);
+		} else {
+			return targets.stream()
+				.filter(t -> t.getWidget() != null && Rs2Widget.isWidgetVisible(t.getWidget().getId()))
+				.findFirst()
+				.orElse(null);
+		}
+	}
+
+	private List<Widget> getHighlightWidgets(Object highlightController) {
+		List<HighlightTarget> targets = getHighlightTargets(highlightController);
+		List<Widget> highlightWidgets = new ArrayList<>();
+		for (HighlightTarget target : targets) {
+			if (target.getWidget() != null) {
+				highlightWidgets.add(target.getWidget());
+			}
+		}
 		return highlightWidgets;
 	}
 
-	private Widget getWidgetFromOverlay(Object highlightController, String suggestionType)
-	{
-		List<Object> highlightOverlays = getHighlightOverlays(highlightController);
-		if (highlightOverlays == null || highlightOverlays.isEmpty())
-		{
-			return null;
-		}
-
-		if (Objects.equals(suggestionType, "abort") || Objects.equals(suggestionType, "modify"))
-		{
-			return getHighlightWidgets(highlightController).stream()
-				.filter(Objects::nonNull)
-				// Filter to "home" grand exchange slot widgets
-				.filter(widget -> Arrays.stream(grandExchangeSlotIds).anyMatch(id -> id == widget.getId()))
-				.findFirst()
-				.orElse(null);
-		}
-		else
-		{
-			// For other suggestion types, we can return the first highlighted widget
-			return getHighlightWidgets(highlightController).stream()
-				.filter(Objects::nonNull)
-				.findFirst()
-				.orElse(null);
-		}
+	private Widget getWidgetFromOverlay(Object highlightController, String suggestionType) {
+		HighlightTarget target = getTargetFromOverlay(highlightController, suggestionType);
+		return target != null ? target.getWidget() : null;
 	}
 
 	private boolean checkAndAbortOrModifyIfNeeded()
@@ -795,11 +828,18 @@ public class FlipperScript extends Script {
 					setCopilotChatboxValueDirectly(val);
 					sleepUntil(this::hasChatboxInput, 800);
 				}
+
+				// Fallback: If still not populated, type the value into chatbox
+				if (!hasChatboxInput() && val > 0) {
+					log.info("Typing {} value into chatbox: {}", isPricePrompt ? "price" : "quantity", val);
+					Rs2Keyboard.typeString(String.valueOf(val));
+					sleepUntil(this::hasChatboxInput, 1000);
+				}
 			}
 
 			// Check if chatbox input was successfully populated
 			if (!hasChatboxInput()) {
-				log.warn("Failed to populate {} input! Cancelling prompt and backing out to GE overview.",
+				log.warn("Failed to populate {} input! Cancelling prompt with ESC to prevent chat spam and backing out to GE overview.",
 					isPricePrompt ? "price" : "quantity");
 				Rs2Keyboard.keyPress(KeyEvent.VK_ESCAPE);
 				sleep(200, 400);
@@ -828,11 +868,21 @@ public class FlipperScript extends Script {
 		if (flippingCopilot == null || highlightController == null) return false;
 
 		try {
-			Widget highlightedWidget = getWidgetFromOverlay(highlightController, "");
-			boolean isHighlightedVisible = highlightedWidget != null && Rs2Widget.isWidgetVisible(highlightedWidget.getId());
+			if (Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure")) {
+				log.info("Price warning dialog detected ('Your offer is much' / 'Are you sure'). Clicking 'Yes' to confirm...");
+				Rs2Widget.clickWidget("Yes");
+				lastActionTime = currentTime;
+				actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+				return true;
+			}
 
-			if (isHighlightedVisible) {
-				log.info("Clicking highlighted widget: {}", highlightedWidget.getId());
+			HighlightTarget target = getTargetFromOverlay(highlightController, "");
+			if (target != null && target.getWidget() != null && Rs2Widget.isWidgetVisible(target.getWidget().getId())) {
+				Widget highlightedWidget = target.getWidget();
+				Rectangle clickBounds = target.getClickBounds();
+				log.info("Processing highlighted target: widgetId={}, clickBounds={}, relativeBounds={}",
+					highlightedWidget.getId(), clickBounds, target.getRelativeBounds());
+
 				// If GE close button is highlighted (container 30474242 or close button dynamic child)
 				if (highlightedWidget.getId() == 30474242 && Rs2GrandExchange.isOpen()) {
 					Rs2GrandExchange.closeExchange();
@@ -856,27 +906,34 @@ public class FlipperScript extends Script {
 					return true;
 				}
 
-				Rs2Widget.clickWidget(highlightedWidget);
+				boolean isConfirm = target.isConfirmTarget();
+
+				if (clickBounds != null && Rs2UiHelper.isRectangleWithinCanvas(clickBounds)) {
+					Microbot.getMouse().click(clickBounds);
+				} else {
+					Rs2Widget.clickWidget(highlightedWidget);
+				}
 				Rs2Random.wait(100, 200);
 				lastActionTime = currentTime;
-                actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
+				actionCooldown = Rs2Random.randomGaussian(DEFAULT_ACTION_COOLDOWN, ACTION_COOLDOWN_VARIANCE);
 
 				if (isOfferScreenOpen()) {
 					offerScreenActionCount++;
 				}
 
 				// If confirming an offer, dismiss any price warning dialog and wait for offer screen to close
-				String[] actions = highlightedWidget.getActions();
-				boolean isConfirm = (highlightedWidget.getText() != null && highlightedWidget.getText().contains("Confirm"))
-					|| (actions != null && Arrays.stream(actions).filter(Objects::nonNull).anyMatch(a -> a.contains("Confirm")));
 				if (isConfirm) {
-					if (sleepUntil(() -> Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure"), 1000)) {
+					log.info("Clicked Confirm button. Checking for warning dialog or waiting for offer screen to close...");
+					if (sleepUntil(() -> Rs2Widget.hasWidget("Your offer is much") || Rs2Widget.hasWidget("Are you sure"), 1200)) {
+						log.info("Warning dialog appeared ('Your offer is much' / 'Are you sure'). Confirming 'Yes'...");
 						Rs2Widget.clickWidget("Yes");
 					}
 					if (!sleepUntil(() -> !isOfferScreenOpen(), 4000)) {
+						log.warn("Offer screen did not close after confirm. Backing out to overview.");
 						backToOverview();
 						return false;
 					}
+					log.info("Offer placed successfully; offer screen closed.");
 				}
 
 				return true;


### PR DESCRIPTION
## What this changes

geflipper automates the Flipping Copilot plugin.
It had bugs that stopped the bot or made it click the wrong place.
This pull request fixes those bugs.
The version is now **1.2.55**.

## Offer screen fixes

- The Confirm button is found by interface now, not by size.
  - Old bug: a wide chat box looked like the Confirm button.
  - The script clicked the chat box, so the offer screen stayed open.
- Wait 250-400 ms before the Confirm click.
  - The highlight is rebuilt every game tick. Old values caused bad clicks.
- Check the price warning dialog during the whole wait, not only in the first second.
- Poll for the Abort button. One quick look was not enough.

## Stall fixes

- Reopen the Grand Exchange if it closes while the bot runs.
  - Old bug: the script returned to the Grand Exchange only after a restart.
  - Now: it reopens the exchange after 4 seconds, or walks there if it cannot open it.
- Close a page that is not the offer list.
  - A bad click can open a Grand Exchange information page, for example the fee page.
  - That page hides the offer list. No button on it helps the bot.
  - Copilot sends no highlight, so the bot did nothing and wrote no message.
  - Now: the bot goes back to the offer list after 8 seconds.
- Leave the offer screen after 10 seconds with no action, not 30 seconds.

## Hand flipping

- New setting: **Auto-Enable Copilot Slot Swap**. It is on by default.
- Turn it off to flip by hand. A left click on a slot then opens the offer screen.
- Both places that write this setting now obey the switch.

## Logging

- The slot swap check writes one line at start.
  - Old bug: this check failed with no message, so a broken switch was invisible.

## Tests

- 78 minutes and 117 confirms: 117 offers placed (100 per cent), 0 back-outs, 1 warning (0.85 per cent).
- Before the fix, 9.1 per cent of confirms made a warning.
- Tested with hotkey selection and with mouse selection.
- Tested with the overlay on and off.
- Tested with slot swap off for aborts.

## Known issue

- **Modify** suggestions can loop when **Swap slot left-click action** is off.
  - In this mode a click on a slot opens the offer status screen, not the setup screen.
  - The bot then backs out and tries the same slot again.
  - A fix is planned.
