### PR TITLE
fix: correct Spria location in Slayer plugin

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/slayer/SlayerMaster.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/slayer/SlayerMaster.java
@@ -8,7 +8,7 @@ import net.runelite.api.coords.WorldPoint;
 @RequiredArgsConstructor
 public enum SlayerMaster {
     TURAEL("Turael", new WorldPoint(2931, 3536, 0), 1),
-    SPRIA("Spria", new WorldPoint(2907, 3324, 0), 1),
+    SPRIA("Spria", new WorldPoint(3092, 3267, 0), 1),
     MAZCHNA("Mazchna", new WorldPoint(3510, 3507, 0), 20),
     VANNAKA("Vannaka", new WorldPoint(3145, 9914, 0), 40),
     CHAELDAR("Chaeldar", new WorldPoint(2445, 4431, 0), 70),

--- a/src/main/java/net/runelite/client/plugins/microbot/slayer/SlayerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/slayer/SlayerPlugin.java
@@ -42,7 +42,7 @@ import java.awt.*;
 @Slf4j
 public class SlayerPlugin extends Plugin {
 
-    static final String version = "1.1.0";
+    static final String version = "1.1.1";
 
     @Inject
     private SlayerConfig config;


### PR DESCRIPTION
## Summary

Fix Spria task assignment travel by updating her location from (2907, 3324, 0) to (3092, 3267, 0). Bump Slayer from 1.1.0 to 1.1.1.

## Cause

The plugin used an incorrect destination and only searched for the master NPC within five tiles of that destination, preventing it from finding Spria at her actual location.

## Testing

- `./gradlew.bat compileSlayerJava -PpluginList=SlayerPlugin -PmicrobotClientVersion=2.6.22` passed.
- The user installed the corrected JAR and confirmed the fix works in game.
- Full build and the standard JAR task remain blocked by an unrelated FarmingContractScript compilation error: missing `Produce.getContractName()`.